### PR TITLE
fix base32 unit_test with single quote

### DIFF
--- a/tests/unit_tests/base32.cpp
+++ b/tests/unit_tests/base32.cpp
@@ -29,6 +29,7 @@
 #include "gtest/gtest.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <fstream>
 #include <string>
@@ -370,5 +371,5 @@ TEST(base32, bad_chars)
     for (const char c : BASE32_UNALLOWED)
         EXPECT_EQ(base32::BADC, base32::JAMTIS_INVERTED_ALPHABET[(unsigned) c]);
     
-    EXPECT_EQ(base32::IGNC, base32::JAMTIS_INVERTED_ALPHABET[(unsigned) "-"]);
+    EXPECT_EQ(base32::IGNC, base32::JAMTIS_INVERTED_ALPHABET[(unsigned) '-']);
 }


### PR DESCRIPTION
My compiler was bugging with the double quotes. Since it is a single char, I believe it should be single quotes.