### PR TITLE
utilty to convert legacy outputs to seraphis lib compatible enotes

### DIFF
--- a/src/seraphis_core/jamtis_payment_proposal.cpp
+++ b/src/seraphis_core/jamtis_payment_proposal.cpp
@@ -99,6 +99,19 @@ static void get_output_proposal_address_parts_v1(const rct::key &q,
 }
 //-------------------------------------------------------------------------------------------------------------------    
 //-------------------------------------------------------------------------------------------------------------------
+/// equality operators
+bool operator==(const JamtisPaymentProposalV1 a, const JamtisPaymentProposalV1 b)
+{
+    return a.destination == b.destination && a.amount == b.amount &&
+        a.enote_ephemeral_privkey == b.enote_ephemeral_privkey && a.partial_memo == b.partial_memo;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool operator==(const JamtisPaymentProposalSelfSendV1 a, const JamtisPaymentProposalSelfSendV1 b)
+{
+    return a.destination == b.destination && a.amount == b.amount && a.type == b.type &&
+        a.enote_ephemeral_privkey == b.enote_ephemeral_privkey && a.partial_memo == b.partial_memo;
+}
+//-------------------------------------------------------------------------------------------------------------------
 void get_enote_ephemeral_pubkey(const JamtisPaymentProposalV1 &proposal,
     crypto::x25519_pubkey &enote_ephemeral_pubkey_out)
 {

--- a/src/seraphis_core/jamtis_payment_proposal.h
+++ b/src/seraphis_core/jamtis_payment_proposal.h
@@ -91,6 +91,10 @@ struct JamtisPaymentProposalSelfSendV1 final
     TxExtra partial_memo;
 };
 
+/// equality operators
+bool operator==(const JamtisPaymentProposalV1 a, const JamtisPaymentProposalV1 b);
+bool operator==(const JamtisPaymentProposalSelfSendV1 a, const JamtisPaymentProposalSelfSendV1 b);
+
 /**
 * brief: get_enote_ephemeral_pubkey - get the proposal's enote ephemeral pubkey xK_e
 * param: proposal -

--- a/src/seraphis_main/enote_record_utils_legacy.cpp
+++ b/src/seraphis_main/enote_record_utils_legacy.cpp
@@ -36,6 +36,7 @@ extern "C"
 {
 #include "crypto/crypto-ops.h"
 }
+#include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_basic/subaddress_index.h"
 #include "device/device.hpp"
 #include "enote_record_types.h"
@@ -552,6 +553,188 @@ void get_legacy_enote_record(const LegacyIntermediateEnoteRecord &intermediate_r
 
     // 2. assemble data
     get_legacy_enote_record(intermediate_record, key_image, record_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_encoded_amount_v1(const cryptonote::transaction &tx)
+{
+    return tx.rct_signatures.type == rct::RCTTypeFull || tx.rct_signatures.type == rct::RCTTypeSimple || tx.rct_signatures.type == rct::RCTTypeBulletproof;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_encoded_amount_v2(const cryptonote::transaction &tx)
+{
+    return tx.rct_signatures.type == rct::RCTTypeBulletproof2 || tx.rct_signatures.type == rct::RCTTypeCLSAG || tx.rct_signatures.type == rct::RCTTypeBulletproofPlus;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_legacy_enote_v1(const cryptonote::transaction &tx, const cryptonote::tx_out &out)
+{
+    // Plaintext amount, no view tag
+    return (tx.version == 1 || (tx.version == 2 && cryptonote::is_coinbase(tx))) && out.target.type() == typeid(cryptonote::txout_to_key);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_legacy_enote_v2(const cryptonote::transaction &tx, const cryptonote::tx_out &out)
+{
+    // Encrypted amount v1, no view tag
+    return tx.version == 2 && !cryptonote::is_coinbase(tx) && out.target.type() == typeid(cryptonote::txout_to_key) &&
+        is_encoded_amount_v1(tx);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_legacy_enote_v3(const cryptonote::transaction &tx, const cryptonote::tx_out &out)
+{
+    // Encrypted amount v2, no view tag
+    return tx.version == 2 && !cryptonote::is_coinbase(tx) && out.target.type() == typeid(cryptonote::txout_to_key) &&
+        is_encoded_amount_v2(tx);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_legacy_enote_v4(const cryptonote::transaction &tx, const cryptonote::tx_out &out)
+{
+    // Plaintext amount, view tag
+    return (tx.version == 1 || (tx.version == 2 && cryptonote::is_coinbase(tx))) && out.target.type() == typeid(cryptonote::txout_to_tagged_key);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_legacy_enote_v5(const cryptonote::transaction &tx, const cryptonote::tx_out &out)
+{
+    // Encrypted amount v2, view tag
+    return tx.version == 2 && !cryptonote::is_coinbase(tx) && out.target.type() == typeid(cryptonote::txout_to_tagged_key) &&
+        is_encoded_amount_v2(tx);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool try_out_to_legacy_enote_v1(const cryptonote::transaction &tx, const size_t output_index, sp::LegacyEnoteVariant &enote)
+{
+    if (output_index >= tx.vout.size())
+        return false;
+    if (!is_legacy_enote_v1(tx, tx.vout[output_index]))
+        return false;
+
+    sp::LegacyEnoteV1 enote_v1;
+
+    /// Ko
+    crypto::public_key out_pub_key;
+    cryptonote::get_output_public_key(tx.vout[output_index], out_pub_key);
+    enote_v1.onetime_address = rct::pk2rct(out_pub_key);
+    /// a
+    enote_v1.amount = tx.vout[output_index].amount;
+
+    enote = std::move(enote_v1);
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool try_out_to_legacy_enote_v2(const cryptonote::transaction &tx, const size_t output_index, sp::LegacyEnoteVariant &enote)
+{
+    if (output_index >= tx.vout.size())
+        return false;
+     if (!is_legacy_enote_v2(tx, tx.vout[output_index]))
+        return false;
+    if (output_index >= tx.rct_signatures.outPk.size() || output_index >= tx.rct_signatures.ecdhInfo.size())
+        return false;
+
+    sp::LegacyEnoteV2 enote_v2;
+
+    /// Ko
+    crypto::public_key out_pub_key;
+    cryptonote::get_output_public_key(tx.vout[output_index], out_pub_key);
+    enote_v2.onetime_address = rct::pk2rct(out_pub_key);
+    /// C
+    enote_v2.amount_commitment = tx.rct_signatures.outPk[output_index].mask;
+    /// enc(x)
+    enote_v2.encoded_amount_blinding_factor = tx.rct_signatures.ecdhInfo[output_index].mask;
+    /// enc(a)
+    enote_v2.encoded_amount = tx.rct_signatures.ecdhInfo[output_index].amount;
+
+    enote = std::move(enote_v2);
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool try_out_to_legacy_enote_v3(const cryptonote::transaction &tx, const size_t output_index, sp::LegacyEnoteVariant &enote)
+{
+    if (output_index >= tx.vout.size())
+        return false;
+    if (!is_legacy_enote_v3(tx, tx.vout[output_index]))
+        return false;
+    if (output_index >= tx.rct_signatures.outPk.size() || output_index >= tx.rct_signatures.ecdhInfo.size())
+        return false;
+
+    sp::LegacyEnoteV3 enote_v3;
+
+    /// Ko
+    crypto::public_key out_pub_key;
+    cryptonote::get_output_public_key(tx.vout[output_index], out_pub_key);
+    enote_v3.onetime_address = rct::pk2rct(out_pub_key);
+    /// C
+    enote_v3.amount_commitment = tx.rct_signatures.outPk[output_index].mask;
+    /// enc(a)
+    static_assert(sizeof(enote_v3.encoded_amount) <= sizeof(tx.rct_signatures.ecdhInfo[output_index].amount.bytes));
+    memcpy(&enote_v3.encoded_amount, &tx.rct_signatures.ecdhInfo[output_index].amount.bytes, sizeof(enote_v3.encoded_amount));
+
+    enote = std::move(enote_v3);
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool try_out_to_legacy_enote_v4(const cryptonote::transaction &tx, const size_t output_index, sp::LegacyEnoteVariant &enote)
+{
+    if (output_index >= tx.vout.size())
+        return false;
+    if (!is_legacy_enote_v4(tx, tx.vout[output_index]))
+        return false;
+
+    sp::LegacyEnoteV4 enote_v4;
+
+    /// Ko
+    crypto::public_key out_pub_key;
+    cryptonote::get_output_public_key(tx.vout[output_index], out_pub_key);
+    enote_v4.onetime_address = rct::pk2rct(out_pub_key);
+    /// a
+    enote_v4.amount = tx.vout[output_index].amount;
+    /// view_tag
+    enote_v4.view_tag = *cryptonote::get_output_view_tag(tx.vout[output_index]);
+
+    enote = std::move(enote_v4);
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool try_out_to_legacy_enote_v5(const cryptonote::transaction &tx, const size_t output_index, LegacyEnoteVariant &enote)
+{
+    if (output_index >= tx.vout.size())
+        return false;
+    if (!is_legacy_enote_v5(tx, tx.vout[output_index]))
+        return false;
+    if (output_index >= tx.rct_signatures.outPk.size() || output_index >= tx.rct_signatures.ecdhInfo.size())
+        return false;
+
+    sp::LegacyEnoteV5 enote_v5;
+
+    /// Ko
+    crypto::public_key out_pub_key;
+    cryptonote::get_output_public_key(tx.vout[output_index], out_pub_key);
+    enote_v5.onetime_address = rct::pk2rct(out_pub_key);
+    /// C
+    enote_v5.amount_commitment = tx.rct_signatures.outPk[output_index].mask;
+    /// enc(a)
+    static_assert(sizeof(enote_v5.encoded_amount) <= sizeof(tx.rct_signatures.ecdhInfo[output_index].amount.bytes));
+    memcpy(&enote_v5.encoded_amount, &tx.rct_signatures.ecdhInfo[output_index].amount.bytes, sizeof(enote_v5.encoded_amount));
+    /// view_tag
+    enote_v5.view_tag = *cryptonote::get_output_view_tag(tx.vout[output_index]);
+
+    enote = std::move(enote_v5);
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void legacy_outputs_to_enotes(const cryptonote::transaction &tx, std::vector<LegacyEnoteVariant> &enotes)
+{
+    enotes.clear();
+    enotes.reserve(tx.vout.size());
+
+    for (size_t i = 0; i < tx.vout.size(); ++i)
+    {
+        enotes.emplace_back();
+        if (!try_out_to_legacy_enote_v1(tx, i, enotes.back())
+            && !try_out_to_legacy_enote_v2(tx, i, enotes.back())
+            && !try_out_to_legacy_enote_v3(tx, i, enotes.back())
+            && !try_out_to_legacy_enote_v4(tx, i, enotes.back())
+            && !try_out_to_legacy_enote_v5(tx, i, enotes.back()))
+        {
+            CHECK_AND_ASSERT_THROW_MES(false, "converting legacy output type to enote type: unknown output type.");
+        }
+    }
 }
 //-------------------------------------------------------------------------------------------------------------------
 } //namespace sp

--- a/src/seraphis_main/enote_record_utils_legacy.h
+++ b/src/seraphis_main/enote_record_utils_legacy.h
@@ -37,6 +37,7 @@
 #include "enote_record_types.h"
 #include "ringct/rctTypes.h"
 #include "seraphis_core/legacy_enote_types.h"
+#include "cryptonote_basic/cryptonote_basic.h"
 
 //third party headers
 
@@ -142,5 +143,11 @@ void get_legacy_enote_record(const LegacyIntermediateEnoteRecord &intermediate_r
     const crypto::secret_key &legacy_spend_privkey,
     hw::device &hwdev,
     LegacyEnoteRecord &record_out);
+/**
+* brief: legacy_outputs_to_enotes - convert legacy tx's "outputs" to Seraphis lib compatible "enotes"
+* param: tx -
+* outparam: enotes -
+*/
+void legacy_outputs_to_enotes(const cryptonote::transaction &tx, std::vector<LegacyEnoteVariant> &enotes);
 
 } //namespace sp


### PR DESCRIPTION
This type conversion is useful to scan legacy txs (returned via the `/getblocks.bin` RPC endpoint) using the Seraphis wallet lib scanner. Can see it in action in [this commit](https://github.com/j-berman/monero/commit/bc869e230130842b897b3c156f2197823342d0de#diff-b44d1e74cbf7fbfe9405856d1e19ce6389b32f6c2ea7bab6fdd1ac1b8fe85c0b).