### PR TITLE
add LegacyEnoteOriginContext

### DIFF
--- a/src/seraphis_core/legacy_enote_types.cpp
+++ b/src/seraphis_core/legacy_enote_types.cpp
@@ -76,11 +76,12 @@ rct::key amount_commitment_ref(const LegacyEnoteVariant &variant)
     return variant.visit(visitor());
 }
 //-------------------------------------------------------------------------------------------------------------------
-LegacyEnoteV1 gen_legacy_enote_v1()
+LegacyEnoteV1 gen_legacy_enote_v1(bool is_pre_rct)
 {
     LegacyEnoteV1 temp;
     temp.onetime_address = rct::pkGen();
     temp.amount          = crypto::rand_idx<rct::xmr_amount>(0);
+    temp.is_pre_rct      = is_pre_rct;
     return temp;
 }
 //-------------------------------------------------------------------------------------------------------------------

--- a/src/seraphis_core/legacy_enote_types.h
+++ b/src/seraphis_core/legacy_enote_types.h
@@ -47,9 +47,10 @@ namespace sp
 {
 
 ////
-// LegacyEnoteV1
+// LegacyEnoteV1 (regular & coinbase pre-RingCT, then coinbase-only post-RingCT)
 // - onetime address
 // - cleartext amount
+// - differentitiate pre/post-RingCT
 ///
 struct LegacyEnoteV1 final
 {
@@ -57,6 +58,8 @@ struct LegacyEnoteV1 final
     rct::key onetime_address;
     /// a
     rct::xmr_amount amount;
+
+    bool is_pre_rct;
 };
 
 /// get size in bytes
@@ -104,7 +107,7 @@ struct LegacyEnoteV3 final
 inline std::size_t legacy_enote_v3_size_bytes() { return 2*32 + 8; }
 
 ////
-// LegacyEnoteV4
+// LegacyEnoteV4 (coinbase post-view_tag)
 // - onetime address
 // - cleartext amount
 // - view tag
@@ -159,7 +162,7 @@ rct::key amount_commitment_ref(const LegacyEnoteVariant &variant);
 /**
 * brief: gen_legacy_enote_v1() - generate a legacy v1 enote (all random)
 */
-LegacyEnoteV1 gen_legacy_enote_v1();
+LegacyEnoteV1 gen_legacy_enote_v1(bool is_pre_rct);
 /**
 * brief: gen_legacy_enote_v2() - generate a legacy v2 enote (all random)
 */

--- a/src/seraphis_core/legacy_enote_utils.cpp
+++ b/src/seraphis_core/legacy_enote_utils.cpp
@@ -58,6 +58,27 @@ void get_legacy_enote_identifier(const rct::key &onetime_address, const rct::xmr
     sp_hash_to_32(transcript.data(), transcript.size(), identifier_out.bytes);
 }
 //-------------------------------------------------------------------------------------------------------------------
+void make_legacy_pre_rct_enote(const rct::key &destination_spendkey,
+    const rct::key &destination_viewkey,
+    const rct::xmr_amount amount,
+    const std::uint64_t output_index,
+    const crypto::secret_key &enote_ephemeral_privkey,
+    LegacyEnoteV1 &enote_out)
+{
+    // onetime address: K^o = Hn(r K^v, t) G + K^s
+    make_legacy_onetime_address(destination_spendkey,
+        destination_viewkey,
+        output_index,
+        enote_ephemeral_privkey,
+        hw::get_device("default"),
+        enote_out.onetime_address);
+
+    // amount: a
+    enote_out.amount = amount;
+
+    enote_out.is_pre_rct = true;
+}
+//-------------------------------------------------------------------------------------------------------------------
 void make_legacy_enote_v1(const rct::key &destination_spendkey,
     const rct::key &destination_viewkey,
     const rct::xmr_amount amount,
@@ -75,6 +96,8 @@ void make_legacy_enote_v1(const rct::key &destination_spendkey,
 
     // amount: a
     enote_out.amount = amount;
+
+    enote_out.is_pre_rct = false;
 }
 //-------------------------------------------------------------------------------------------------------------------
 void make_legacy_enote_v2(const rct::key &destination_spendkey,

--- a/src/seraphis_core/legacy_enote_utils.h
+++ b/src/seraphis_core/legacy_enote_utils.h
@@ -60,6 +60,21 @@ namespace sp
 */
 void get_legacy_enote_identifier(const rct::key &onetime_address, const rct::xmr_amount amount, rct::key &identifier_out);
 /**
+* brief: make_legacy_pre_rct_enote - make a v1 legacy pre-ringct enote sending to an address or subaddress
+* param: destination_spendkey - [address: K^s = k^s G] [subaddress: K^{s,i} = (Hn(k^v, i) + k^s) G]
+* param: destination_viewkey - [address: K^v = k^v G] [subaddress: K^{v,i} = k^v*(Hn(k^v, i) + k^s) G]
+* param: amount - a
+* param: output_index - t
+* param: enote_ephemeral_privkey - [address: r] [subaddres: r_t]
+* outparam: enote_out - [K^o, a]
+*/
+void make_legacy_pre_rct_enote(const rct::key &destination_spendkey,
+    const rct::key &destination_viewkey,
+    const rct::xmr_amount amount,
+    const std::uint64_t output_index,
+    const crypto::secret_key &enote_ephemeral_privkey,
+    LegacyEnoteV1 &enote_out);
+/**
 * brief: make_legacy_enote_v1 - make a v1 legacy enote sending to an address or subaddress
 * param: destination_spendkey - [address: K^s = k^s G] [subaddress: K^{s,i} = (Hn(k^v, i) + k^s) G]
 * param: destination_viewkey - [address: K^v = k^v G] [subaddress: K^{v,i} = k^v*(Hn(k^v, i) + k^s) G]

--- a/src/seraphis_impl/enote_store.cpp
+++ b/src/seraphis_impl/enote_store.cpp
@@ -851,7 +851,7 @@ void SpEnoteStore::clean_maps_for_legacy_ledger_update(const std::uint64_t first
                 return false;
 
             // b. ignore onchain enotes outside of range [first_new_block, end of chain]
-            if (mapped_contextual_enote_record.second.origin_context.block_index < first_new_block)
+            if (block_index_ref(mapped_contextual_enote_record.second.origin_context) < first_new_block)
                 return false;
 
             // c. record the identifier of the enote being removed

--- a/src/seraphis_impl/enote_store_utils.cpp
+++ b/src/seraphis_impl/enote_store_utils.cpp
@@ -75,16 +75,18 @@ static boost::multiprecision::uint128_t get_balance_intermediate_legacy(
     for (const auto &mapped_contextual_record : legacy_intermediate_records)
     {
         const LegacyContextualIntermediateEnoteRecordV1 &current_contextual_record{mapped_contextual_record.second};
+        SpEnoteOriginStatus current_record_origin_status;
+        origin_status_ref(current_contextual_record.origin_context, current_record_origin_status);
 
         // a. ignore this enote if its origin status is not requested
-        if (origin_statuses.find(current_contextual_record.origin_context.origin_status) == origin_statuses.end())
+        if (origin_statuses.find(current_record_origin_status) == origin_statuses.end())
             continue;
 
         // b. ignore locked onchain enotes if they should be excluded
         if (exclusions.find(BalanceExclusions::ORIGIN_LEDGER_LOCKED) != exclusions.end() &&
-            current_contextual_record.origin_context.origin_status == SpEnoteOriginStatus::ONCHAIN &&
+            current_record_origin_status == SpEnoteOriginStatus::ONCHAIN &&
             onchain_legacy_enote_is_locked(
-                    current_contextual_record.origin_context.block_index,
+                    block_index_ref(current_contextual_record.origin_context),
                     current_contextual_record.record.unlock_time,
                     top_block_index,
                     default_spendable_age,
@@ -111,10 +113,9 @@ static boost::multiprecision::uint128_t get_balance_intermediate_legacy(
                         "get balance intermediate legacy: tracked legacy duplicates has an entry that "
                         "doesn't line up 1:1 with the legacy intermediate map even though it should (bug).");
 
-                    return legacy_intermediate_records
+                    return origin_status_ref(legacy_intermediate_records
                         .at(identifier)
-                        .origin_context
-                        .origin_status;
+                        .origin_context);
                 },
                 [&legacy_intermediate_records](const rct::key &identifier) -> rct::xmr_amount
                 {
@@ -156,9 +157,11 @@ static boost::multiprecision::uint128_t get_balance_full_legacy(
     for (const auto &mapped_contextual_record : legacy_records)
     {
         const LegacyContextualEnoteRecordV1 &current_contextual_record{mapped_contextual_record.second};
+        SpEnoteOriginStatus current_record_origin_status;
+        origin_status_ref(current_contextual_record.origin_context, current_record_origin_status);
 
         // a. ignore this enote if its origin status is not requested
-        if (origin_statuses.find(current_contextual_record.origin_context.origin_status) == origin_statuses.end())
+        if (origin_statuses.find(current_record_origin_status) == origin_statuses.end())
             continue;
 
         // b. ignore this enote if its spent status is requested
@@ -167,9 +170,9 @@ static boost::multiprecision::uint128_t get_balance_full_legacy(
 
         // c. ignore locked onchain enotes if they should be excluded
         if (exclusions.find(BalanceExclusions::ORIGIN_LEDGER_LOCKED) != exclusions.end() &&
-            current_contextual_record.origin_context.origin_status == SpEnoteOriginStatus::ONCHAIN &&
+            current_record_origin_status == SpEnoteOriginStatus::ONCHAIN &&
             onchain_legacy_enote_is_locked(
-                    current_contextual_record.origin_context.block_index,
+                    block_index_ref(current_contextual_record.origin_context),
                     current_contextual_record.record.unlock_time,
                     top_block_index,
                     default_spendable_age,
@@ -195,10 +198,9 @@ static boost::multiprecision::uint128_t get_balance_full_legacy(
                         "get balance full legacy: tracked legacy duplicates has an entry that doesn't line up "
                         "1:1 with the legacy map even though it should (bug).");
 
-                    return legacy_records
+                    return origin_status_ref(legacy_records
                         .at(identifier)
-                        .origin_context
-                        .origin_status;
+                        .origin_context);
                 },
                 [&legacy_records](const rct::key &identifier) -> rct::xmr_amount
                 {

--- a/src/seraphis_impl/legacy_ki_import_tool.cpp
+++ b/src/seraphis_impl/legacy_ki_import_tool.cpp
@@ -144,7 +144,7 @@ void finish_legacy_ki_import_cycle(const LegacyKIImportCheckpoint &checkpoint, S
         highest_aligned_index_post_import_cycle =
             std::min(
                     highest_aligned_index_post_import_cycle + 1,
-                    intermediate_record.second.origin_context.block_index
+                    block_index_ref(intermediate_record.second.origin_context)
                 ) - 1;
     }
 

--- a/src/seraphis_main/contextual_enote_record_types.cpp
+++ b/src/seraphis_main/contextual_enote_record_types.cpp
@@ -45,6 +45,138 @@
 
 namespace sp
 {
+
+//-------------------------------------------------------------------------------------------------------------------
+LegacyContextualIntermediateEnoteRecordV1::LegacyContextualIntermediateEnoteRecordV1()
+{
+    // just assume post-rct enote as default, if no EnoteRecord gets provided
+    // Note : don't forget to manually set LegacyEnoteOriginContextVariant to V1 if enote is pre-rct
+    LegacyEnoteOriginContextV2 new_origin_context;
+    origin_context = new_origin_context;
+}
+//-------------------------------------------------------------------------------------------------------------------
+LegacyContextualIntermediateEnoteRecordV1::LegacyContextualIntermediateEnoteRecordV1(LegacyIntermediateEnoteRecord record_in)
+    : record{ record_in }
+{
+    LegacyEnoteOriginContextV1 new_origin_context_v1;
+    LegacyEnoteOriginContextV2 new_origin_context_v2;
+    if (record.enote.is_type<LegacyEnoteV1>() && record.enote.unwrap<LegacyEnoteV1>().is_pre_rct)
+        origin_context = new_origin_context_v1;
+    else
+        origin_context = new_origin_context_v2;
+}
+//-------------------------------------------------------------------------------------------------------------------
+LegacyContextualEnoteRecordV1::LegacyContextualEnoteRecordV1()
+{
+    // just assume post-rct enote as default, if no EnoteRecord gets provided
+    // Note : don't forget to manually set LegacyEnoteOriginContextVariant to V1 if enote is pre-rct
+    LegacyEnoteOriginContextV2 new_origin_context;
+    origin_context = new_origin_context;
+}
+//-------------------------------------------------------------------------------------------------------------------
+LegacyContextualEnoteRecordV1::LegacyContextualEnoteRecordV1(LegacyEnoteRecord record_in) : record{ record_in }
+{
+    LegacyEnoteOriginContextV1 new_origin_context_v1;
+    LegacyEnoteOriginContextV2 new_origin_context_v2;
+    if (record.enote.is_type<LegacyEnoteV1>() && record.enote.unwrap<LegacyEnoteV1>().is_pre_rct)
+        origin_context = new_origin_context_v1;
+    else
+        origin_context = new_origin_context_v2;
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::uint64_t& block_index_ref(const LegacyEnoteOriginContextVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const std::uint64_t&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV1 &record) const
+        { return record.block_index; }
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV2 &record) const
+        { return record.block_index; }
+    };
+
+    return variant.visit(visitor{});
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::uint64_t& block_timestamp_ref(const LegacyEnoteOriginContextVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const std::uint64_t&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV1 &record) const
+        { return record.block_timestamp; }
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV2 &record) const
+        { return record.block_timestamp; }
+    };
+
+    return variant.visit(visitor{});
+}
+//-------------------------------------------------------------------------------------------------------------------
+const rct::key& transaction_id_ref(const LegacyEnoteOriginContextVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const rct::key&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const rct::key& operator()(const LegacyEnoteOriginContextV1 &record) const
+        { return record.transaction_id; }
+        const rct::key& operator()(const LegacyEnoteOriginContextV2 &record) const
+        { return record.transaction_id; }
+    };
+
+    return variant.visit(visitor{});
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::uint64_t& enote_ledger_index_ref(const LegacyEnoteOriginContextVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const std::uint64_t&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV1 &record) const
+        { return record.enote_ledger_index; }
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV2 &record) const
+        { return record.enote_ledger_index; }
+    };
+
+    return variant.visit(visitor{});
+}
+//-------------------------------------------------------------------------------------------------------------------
+const SpEnoteOriginStatus& origin_status_ref(const LegacyEnoteOriginContextVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const SpEnoteOriginStatus&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const SpEnoteOriginStatus& operator()(const LegacyEnoteOriginContextV1 &record) const
+        { return record.origin_status; }
+        const SpEnoteOriginStatus& operator()(const LegacyEnoteOriginContextV2 &record) const
+        { return record.origin_status; }
+    };
+
+    return variant.visit(visitor{});
+}
+//-------------------------------------------------------------------------------------------------------------------
+void origin_status_ref(const LegacyEnoteOriginContextVariant &variant, SpEnoteOriginStatus &origin_status_out)
+{
+    if (variant.is_type<LegacyEnoteOriginContextV1>())
+        origin_status_out = variant.unwrap<LegacyEnoteOriginContextV1>().origin_status;
+    else if (variant.is_type<LegacyEnoteOriginContextV2>())
+        origin_status_out = variant.unwrap<LegacyEnoteOriginContextV2>().origin_status;
+    else
+        ASSERT_MES_AND_THROW("unknown LegacyEnoteOriginContextVariant");
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::uint64_t& enote_version_dependent_index_ref(const LegacyEnoteOriginContextVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const std::uint64_t&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV1 &record) const
+        { return record.enote_same_amount_ledger_index; }
+        const std::uint64_t& operator()(const LegacyEnoteOriginContextV2 &record) const
+        { return record.rct_enote_ledger_index; }
+    };
+
+    return variant.visit(visitor{});
+}
 //-------------------------------------------------------------------------------------------------------------------
 const rct::key& onetime_address_ref(const LegacyContextualIntermediateEnoteRecordV1 &record)
 {
@@ -86,18 +218,46 @@ rct::xmr_amount amount_ref(const SpContextualEnoteRecordV1 &record)
     return record.record.amount;
 }
 //-------------------------------------------------------------------------------------------------------------------
-const SpEnoteOriginContextV1& origin_context_ref(const ContextualBasicRecordVariant &variant)
+const SpEnoteOriginStatus& origin_status_ref(const ContextualBasicRecordVariant &variant)
 {
-    struct visitor final : public tools::variant_static_visitor<const SpEnoteOriginContextV1&>
+    struct visitor final : public tools::variant_static_visitor<const SpEnoteOriginStatus&>
     {
         using variant_static_visitor::operator();  //for blank overload
-        const SpEnoteOriginContextV1& operator()(const LegacyContextualBasicEnoteRecordV1 &record) const
-        { return record.origin_context; }
-        const SpEnoteOriginContextV1& operator()(const SpContextualBasicEnoteRecordV1 &record) const
-        { return record.origin_context; }
+        const SpEnoteOriginStatus& operator()(const LegacyContextualBasicEnoteRecordV1 &record) const
+        { return origin_status_ref(record.origin_context); }
+        const SpEnoteOriginStatus& operator()(const SpContextualBasicEnoteRecordV1 &record) const
+        { return record.origin_context.origin_status; }
     };
 
-    return variant.visit(visitor());
+    return variant.visit(visitor{});
+}
+//-------------------------------------------------------------------------------------------------------------------
+const rct::key& transaction_id_ref(const ContextualBasicRecordVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const rct::key&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const rct::key& operator()(const LegacyContextualBasicEnoteRecordV1 &record) const
+        { return transaction_id_ref(record.origin_context); }
+        const rct::key& operator()(const SpContextualBasicEnoteRecordV1 &record) const
+        { return record.origin_context.transaction_id; }
+    };
+
+    return variant.visit(visitor{});
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::uint64_t& block_index_ref(const ContextualBasicRecordVariant &variant)
+{
+    struct visitor final : public tools::variant_static_visitor<const std::uint64_t&>
+    {
+        using variant_static_visitor::operator();  //for blank overload
+        const std::uint64_t& operator()(const LegacyContextualBasicEnoteRecordV1 &record) const
+        { return block_index_ref(record.origin_context); }
+        const std::uint64_t& operator()(const SpContextualBasicEnoteRecordV1 &record) const
+        { return record.origin_context.block_index; }
+    };
+
+    return variant.visit(visitor{});
 }
 //-------------------------------------------------------------------------------------------------------------------
 rct::xmr_amount amount_ref(const ContextualRecordVariant &variant)
@@ -107,20 +267,6 @@ rct::xmr_amount amount_ref(const ContextualRecordVariant &variant)
         using variant_static_visitor::operator();  //for blank overload
         rct::xmr_amount operator()(const LegacyContextualEnoteRecordV1 &record) const { return amount_ref(record); }
         rct::xmr_amount operator()(const SpContextualEnoteRecordV1 &record)     const { return amount_ref(record); }
-    };
-
-    return variant.visit(visitor());
-}
-//-------------------------------------------------------------------------------------------------------------------
-const SpEnoteOriginContextV1& origin_context_ref(const ContextualRecordVariant &variant)
-{
-    struct visitor final : public tools::variant_static_visitor<const SpEnoteOriginContextV1&>
-    {
-        using variant_static_visitor::operator();  //for blank overload
-        const SpEnoteOriginContextV1& operator()(const LegacyContextualEnoteRecordV1 &record) const
-        { return record.origin_context; }
-        const SpEnoteOriginContextV1& operator()(const SpContextualEnoteRecordV1 &record) const
-        { return record.origin_context; }
     };
 
     return variant.visit(visitor());
@@ -138,6 +284,45 @@ const SpEnoteSpentContextV1& spent_context_ref(const ContextualRecordVariant &va
     };
 
     return variant.visit(visitor());
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool is_older_than(const LegacyEnoteOriginContextVariant &context, const LegacyEnoteOriginContextVariant &other_context)
+{
+    CHECK_AND_ASSERT_THROW_MES(LegacyEnoteOriginContextVariant::same_type(context, other_context), "compared LegacyEnoteOriginContextVariants are of different types");
+
+    // 1. origin status (higher statuses are assumed to be 'older')
+    if (origin_status_ref(context) > origin_status_ref(other_context))
+        return true;
+    if (origin_status_ref(context) < origin_status_ref(other_context))
+        return false;
+
+    // 2. block index
+    if (block_index_ref(context) < block_index_ref(other_context))
+        return true;
+    if (block_index_ref(context) > block_index_ref(other_context))
+        return false;
+
+    // note: don't assess the tx output index
+
+    // 3. enote same amount ledger index / rct enote ledger index
+    if (enote_version_dependent_index_ref(context) < enote_version_dependent_index_ref(other_context))
+        return true;
+    if (enote_version_dependent_index_ref(context) > enote_version_dependent_index_ref(other_context))
+        return false;
+
+    // 4. enote ledger index
+    if (enote_ledger_index_ref(context) < enote_ledger_index_ref(other_context))
+        return true;
+    if (enote_ledger_index_ref(context) > enote_ledger_index_ref(other_context))
+        return false;
+
+    // 5. block timestamp
+    if (block_timestamp_ref(context) < block_timestamp_ref(other_context))
+        return true;
+    if (block_timestamp_ref(context) > block_timestamp_ref(other_context))
+        return false;
+
+    return false;
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool is_older_than(const SpEnoteOriginContextV1 &context, const SpEnoteOriginContextV1 &other_context)
@@ -227,12 +412,12 @@ bool have_same_destination(const SpContextualEnoteRecordV1 &a, const SpContextua
 //-------------------------------------------------------------------------------------------------------------------
 bool has_origin_status(const LegacyContextualIntermediateEnoteRecordV1 &record, const SpEnoteOriginStatus test_status)
 {
-    return record.origin_context.origin_status == test_status;
+    return origin_status_ref(record.origin_context) == test_status;
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool has_origin_status(const LegacyContextualEnoteRecordV1 &record, const SpEnoteOriginStatus test_status)
 {
-    return record.origin_context.origin_status == test_status;
+    return origin_status_ref(record.origin_context) == test_status;
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool has_origin_status(const SpContextualIntermediateEnoteRecordV1 &record, const SpEnoteOriginStatus test_status)

--- a/src/seraphis_main/contextual_enote_record_utils.cpp
+++ b/src/seraphis_main/contextual_enote_record_utils.cpp
@@ -204,7 +204,7 @@ bool try_get_membership_proof_real_reference_mappings(const std::vector<LegacyCo
 
         // 2. save the [ KI : enote ledger index ] entry
         enote_ledger_mappings_out[key_image_ref(contextual_record)] =
-            contextual_record.origin_context.enote_ledger_index;
+            enote_ledger_index_ref(contextual_record.origin_context);
     }
 
     return true;
@@ -226,6 +226,19 @@ bool try_get_membership_proof_real_reference_mappings(const std::vector<SpContex
         enote_ledger_mappings_out[key_image_ref(contextual_record)] =
             contextual_record.origin_context.enote_ledger_index;
     }
+
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool try_update_enote_origin_context_v1(const LegacyEnoteOriginContextVariant &fresh_origin_context,
+    LegacyEnoteOriginContextVariant &current_origin_context_inout)
+{
+    // 1. fail if the current context is older than the fresh one
+    if (is_older_than(current_origin_context_inout, fresh_origin_context))
+        return false;
+
+    // 2. overwrite with the fresh context (do this even if the fresh one seems to have the same age)
+    current_origin_context_inout = fresh_origin_context;
 
     return true;
 }
@@ -304,6 +317,23 @@ bool try_bump_enote_record_origin_status_v1(const SpEnoteSpentStatus spent_statu
     origin_status_inout = implied_origin_status;
 
     return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void update_contextual_enote_record_contexts_v1(const LegacyEnoteOriginContextVariant &new_origin_context,
+    const SpEnoteSpentContextV1 &new_spent_context,
+    LegacyEnoteOriginContextVariant &origin_context_inout,
+    SpEnoteSpentContextV1 &spent_context_inout)
+{
+    // 1. update the origin context
+    try_update_enote_origin_context_v1(new_origin_context, origin_context_inout);
+
+    // 2. update the spent context
+    try_update_enote_spent_context_v1(new_spent_context, spent_context_inout);
+
+    // 3. bump the origin status based on the new spent status
+    SpEnoteOriginStatus origin_status_out;
+    origin_status_ref(origin_context_inout, origin_status_out);
+    try_bump_enote_record_origin_status_v1(spent_context_inout.spent_status, origin_status_out);
 }
 //-------------------------------------------------------------------------------------------------------------------
 void update_contextual_enote_record_contexts_v1(const SpEnoteOriginContextV1 &new_origin_context,

--- a/src/seraphis_main/contextual_enote_record_utils.h
+++ b/src/seraphis_main/contextual_enote_record_utils.h
@@ -123,6 +123,8 @@ bool try_get_membership_proof_real_reference_mappings(const std::vector<SpContex
 * param: fresh_origin_context -
 * inoutparam: current_origin_context_inout -
 */
+bool try_update_enote_origin_context_v1(const LegacyEnoteOriginContextVariant &fresh_origin_context,
+    LegacyEnoteOriginContextVariant &current_origin_context_inout);
 bool try_update_enote_origin_context_v1(const SpEnoteOriginContextV1 &fresh_origin_context,
     SpEnoteOriginContextV1 &current_origin_context_inout);
 /**
@@ -163,6 +165,10 @@ bool try_bump_enote_record_origin_status_v1(const SpEnoteSpentStatus spent_statu
 * inoutparam: origin_context_inout -
 * inoutparam: spent_context_inout -
 */
+void update_contextual_enote_record_contexts_v1(const LegacyEnoteOriginContextVariant &new_origin_context,
+    const SpEnoteSpentContextV1 &new_spent_context,
+    LegacyEnoteOriginContextVariant &origin_context_inout,
+    SpEnoteSpentContextV1 &spent_context_inout);
 void update_contextual_enote_record_contexts_v1(const SpEnoteOriginContextV1 &new_origin_context,
     const SpEnoteSpentContextV1 &new_spent_context,
     SpEnoteOriginContextV1 &origin_context_inout,

--- a/src/seraphis_main/scan_balance_recovery_utils.h
+++ b/src/seraphis_main/scan_balance_recovery_utils.h
@@ -85,6 +85,7 @@ bool try_find_legacy_enotes_in_tx(const rct::key &legacy_base_spend_pubkey,
     const std::uint64_t unlock_time,
     const TxExtra &tx_memo,
     const std::vector<LegacyEnoteVariant> &enotes_in_tx,
+    const std::vector<uint64_t> enote_version_dependent_indices,
     const SpEnoteOriginStatus origin_status,
     hw::device &hwdev,
     std::list<ContextualBasicRecordVariant> &basic_records_in_tx_out);

--- a/src/seraphis_main/scan_misc_utils.cpp
+++ b/src/seraphis_main/scan_misc_utils.cpp
@@ -75,19 +75,19 @@ void check_chunk_data_semantics(const ChunkData &chunk_data,
     {
         for (const ContextualBasicRecordVariant &contextual_basic_record : tx_basic_records.second)
         {
-            CHECK_AND_ASSERT_THROW_MES(origin_context_ref(contextual_basic_record).origin_status ==
+            CHECK_AND_ASSERT_THROW_MES(origin_status_ref(contextual_basic_record) ==
                     expected_origin_status,
                 "scan chunk data semantics check: contextual basic record doesn't have expected origin status.");
-            CHECK_AND_ASSERT_THROW_MES(origin_context_ref(contextual_basic_record).transaction_id ==
+            CHECK_AND_ASSERT_THROW_MES(transaction_id_ref(contextual_basic_record) ==
                     tx_basic_records.first,
                 "scan chunk data semantics check: contextual basic record doesn't have origin tx id matching mapped id.");
-            CHECK_AND_ASSERT_THROW_MES(origin_context_ref(contextual_basic_record).block_index ==
-                    origin_context_ref(*tx_basic_records.second.begin()).block_index,
+            CHECK_AND_ASSERT_THROW_MES(block_index_ref(contextual_basic_record) ==
+                    block_index_ref(*tx_basic_records.second.begin()),
                 "scan chunk data semantics check: contextual record tx index doesn't match other records in tx.");
 
             CHECK_AND_ASSERT_THROW_MES(
-                    origin_context_ref(contextual_basic_record).block_index >= allowed_lowest_index &&
-                    origin_context_ref(contextual_basic_record).block_index <= allowed_highest_index,
+                    block_index_ref(contextual_basic_record) >= allowed_lowest_index &&
+                    block_index_ref(contextual_basic_record) <= allowed_highest_index,
                 "scan chunk data semantics check: contextual record block index is out of the expected range.");
         }
     }

--- a/src/seraphis_mocks/mock_ledger_context.h
+++ b/src/seraphis_mocks/mock_ledger_context.h
@@ -255,6 +255,17 @@ public:
         const crypto::x25519_secret_key &xk_find_received,
         scanning::ChunkContext &chunk_context_out,
         scanning::ChunkData &chunk_data_out) const;
+    /**
+    * brief: get_legacy_amount_counts - getter for m_legacy_amount_counts
+    * param: amount -
+    * return: number of enotes with same amount -
+    */
+    std::uint64_t get_legacy_amount_counts(rct::xmr_amount amount);
+    /**
+    * brief: is_empty_legacy_amount_counts
+    * return: true if map is empty -
+    */
+    bool is_empty_legacy_amount_counts();
 
 private:
     /// first block where a seraphis tx is allowed (this block and all following must have a seraphis coinbase tx)
@@ -327,7 +338,8 @@ private:
             std::tuple<       // tx output contents
                 std::uint64_t,                    // unlock time
                 TxExtra,                          // tx memo
-                std::vector<LegacyEnoteVariant>   // output enotes
+                std::vector<LegacyEnoteVariant>,  // output enotes
+                std::vector<std::uint64_t>        // enote same amount ledger indices
             >
         >
     > m_blocks_of_legacy_tx_output_contents;
@@ -351,6 +363,11 @@ private:
             std::uint64_t   // block timestamp
         >
     > m_block_infos;
+    /// map of legacy amount counts
+    std::map<
+        rct::xmr_amount,    // amount
+        std::uint64_t       // count
+    > m_legacy_amount_counts;
 };
 
 bool try_add_tx_to_ledger(const SpTxCoinbaseV1 &tx_to_add, MockLedgerContext &ledger_context_inout);

--- a/src/seraphis_mocks/tx_input_selector_mocks.cpp
+++ b/src/seraphis_mocks/tx_input_selector_mocks.cpp
@@ -198,7 +198,7 @@ bool InputSelectorMockV1::try_select_input_candidate_v1(const boost::multiprecis
                         "input selector (mock): tracked legacy duplicates has an entry that doesn't line up "
                         "1:1 with the legacy map even though it should (bug).");
 
-                    return mapped_legacy_contextual_enote_records.at(identifier).origin_context.origin_status;
+                    return origin_status_ref(mapped_legacy_contextual_enote_records.at(identifier).origin_context);
                 },
                 [&mapped_legacy_contextual_enote_records](const rct::key &identifier) -> rct::xmr_amount
                 {

--- a/tests/unit_tests/seraphis_input_selection.cpp
+++ b/tests/unit_tests/seraphis_input_selection.cpp
@@ -61,9 +61,7 @@ static void prepare_enote_store(const std::vector<rct::xmr_amount> &legacy_amoun
         temp_record.key_image = rct::rct2ki(rct::pkGen());
 
         enote_store_inout.add_record(
-                LegacyContextualEnoteRecordV1{
-                    .record = temp_record
-                }
+                LegacyContextualEnoteRecordV1(temp_record)
             );
     }
 

--- a/tests/unit_tests/seraphis_multisig.cpp
+++ b/tests/unit_tests/seraphis_multisig.cpp
@@ -183,7 +183,7 @@ static bool legacy_multisig_input_is_ready_to_spend(const LegacyMultisigInputPro
         return false;
 
     // 4. expect the enote is spendable within the index specified
-    if (onchain_legacy_enote_is_locked(contextual_record.origin_context.block_index,
+    if (onchain_legacy_enote_is_locked(block_index_ref(contextual_record.origin_context),
             contextual_record.record.unlock_time,
             top_block_index,
             0,  //default spendable age: configurable


### PR DESCRIPTION
The changes quickly added up to get around compiler errors. Now it builds fine, but fails at unit_tests `seraphis_enote_scanning.trivial_ledger`. Before I go too deep in the complete wrong direction, some feedback would be appreciated.
I added comments with `QUESTION` and `TODO` (without a well defined distinction), for things I currently focus on.

_____________________________________
Edit after squash:
this PR adds:
- `LegacyEnoteOriginContextV1` for pre-RingCT enotes which get indexed by `enote_same_amount_ledger_index`
- `LegacyEnoteOriginContextV2` for post-RingCT enotes which get indexed by `rct_enote_ledger_index`
- `LegacyEnoteOriginContextVariant` which contains either V1 or V2 contexts
-  a bool `is_pre_rct` to `LegacyEnoteV1` to help differentiate between V1 and V2 contexts
-  function to create pre-RingCT `LegacyEnoteV1`
- some *_ref functions
- constructors for LegacyContextual(Intermediate)EnoteRecords to set the `LegacyEnoteOriginContextVariant` to the correct type or to default type post-RingCT
- functionality for the new indexes in the scanner and mock ledger
- tests in `seraphis_enote_scanning`: `legacy_pre_rct_1` & `legacy_coinbase_1`

Feel free to review.