### PR TITLE
Include tree root in PoW block hash

### DIFF
--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1820,7 +1820,7 @@ public:
   virtual bool audit_tree(const uint64_t expected_n_leaf_tuples) const = 0;
   virtual uint64_t get_n_leaf_tuples() const = 0;
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const = 0;
-  virtual std::size_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const = 0;
+  virtual uint8_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const = 0;
 
   /**
    * @brief return custom timelocked outputs after the provided block idx

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1820,6 +1820,33 @@ public:
   virtual bool audit_tree(const uint64_t expected_n_leaf_tuples) const = 0;
   virtual uint64_t get_n_leaf_tuples() const = 0;
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const = 0;
+
+  /**
+   * @brief return tree's root and n_tree_layers at a specific block idx
+   *
+   * Gets the tree root and n_tree_layers composed of all valid spendable
+   * outputs when blk_idx is the tip of the chain.
+   *
+   * If the chain tip is block index n, and `blk_idx == n`, then this will
+   * return the tree root and n layers in a tree composed of all valid
+   * spendable outputs in the chain at that time.
+   *
+   * If the chain tip is block index n, and `blk_idx == n-1`, then this will
+   * return the tree root and n layers in a tree composed of all valid
+   * spendable outputs in the chain *when the chain tip was block index n - 1*.
+   *
+   * Note that the tree stored in the database may not match up with the tree
+   * root returned here, since the tree stored in the db may have grown past
+   * the chain tip's tree, with outputs that will unlock in future blocks.
+   *
+   * This function throws if the db does not have a tree root stored for the
+   * given blk_idx.
+   *
+   * @param blk_idx the state of the tree as of this block index
+   * @param tree_root_out return-by-reference tree root
+   *
+   * @return n tree layers when blk_idx was chain tip
+   */
   virtual uint8_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const = 0;
 
   /**

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1807,6 +1807,8 @@ public:
    */
   virtual bool for_all_alt_blocks(std::function<bool(const crypto::hash &blkid, const alt_block_data_t &data, const cryptonote::blobdata_ref *blob)> f, bool include_blob = false) const = 0;
 
+  virtual void advance_tree_one_block(const uint64_t block_idx) = 0;
+
   // TODO: description and make private
   virtual void grow_tree(const uint64_t block_id, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs) = 0;
 

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1807,7 +1807,7 @@ public:
    */
   virtual bool for_all_alt_blocks(std::function<bool(const crypto::hash &blkid, const alt_block_data_t &data, const cryptonote::blobdata_ref *blob)> f, bool include_blob = false) const = 0;
 
-  virtual void advance_tree_one_block(const uint64_t block_idx) = 0;
+  virtual void advance_tree(const uint64_t block_idx) = 0;
 
   // TODO: description and make private
   virtual void grow_tree(const uint64_t block_id, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs) = 0;

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -819,13 +819,6 @@ void BlockchainLMDB::add_block(const block& blk, size_t block_weight, uint64_t l
       throw0(BLOCK_PARENT_DNE("Top block is not new block's parent"));
   }
 
-  // Grow the tree with outputs that are no longer locked once this block is in the chain
-  auto unlocked_outputs = this->get_outs_at_last_locked_block_id(m_height);
-  this->grow_tree(m_height, std::move(unlocked_outputs));
-
-  // Now that we've used the unlocked leaves to grow the tree, we can delete them from the locked outputs table
-  this->del_locked_outs_at_block_id(m_height);
-
   int result = 0;
 
   MDB_val_set(key, m_height);
@@ -1405,6 +1398,31 @@ void BlockchainLMDB::remove_spent_key(const crypto::key_image& k_image)
   }
 }
 
+void BlockchainLMDB::advance_tree_one_block(const uint64_t blk_idx)
+{
+  LOG_PRINT_L3("BlockchainLMDB::" << __func__);
+  check_open();
+
+  if (blk_idx == 0)
+    throw0(DB_ERROR("Expected to advance to blk_idx > 0"));
+
+  if (blk_idx == 1)
+  {
+    // If we're advancing 1 block past genesis, make sure to initialize the tree for the genesis block.
+    // We grow the genesis block with empty outputs, since no outputs should be spendable once it's in the chain.
+    this->grow_tree(0, {});
+  }
+
+  // Now we can advance the tree 1 block
+  auto unlocked_outputs = this->get_outs_at_last_locked_block_id(blk_idx);
+
+  // Grow the tree with outputs that are spendable once blk_idx is in the chain (i.e. they can be included starting in blk_idx+1)
+  this->grow_tree(blk_idx, std::move(unlocked_outputs));
+
+  // Now that we've used the unlocked leaves to grow the tree, we delete them from the locked outputs table
+  this->del_locked_outs_at_block_id(blk_idx);
+}
+
 void BlockchainLMDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs)
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
@@ -1426,13 +1444,15 @@ void BlockchainLMDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curv
     // Get the block idx corresponding to the current tree in the db
     const uint64_t tree_block_idx = this->get_tree_block_idx();
     if (blk_idx > (tree_block_idx + 1))
-      throw0(DB_ERROR("The chain has extended too far past the tree"));
+      throw0(DB_ERROR(("The chain has extended too far past the tree (blk_idx=" + std::to_string(blk_idx) + ", tree_block_idx=" + std::to_string(tree_block_idx) + ")").c_str()));
     if (tree_block_idx >= blk_idx)
     {
       LOG_PRINT_L1("Skip re-growing the tree at block " << blk_idx << ", waiting for the chain to catch up to the tree's block " << tree_block_idx);
       return;
     }
-    // blk_idx == (tree_block_idx + 1), we're growing the tree 1 block
+    // We're supposed to be growing the tree to the given blk_idx
+    if (blk_idx != (tree_block_idx + 1))
+      throw0(DB_ERROR(("Mismatch block idx to tree tip (blk_idx=" + std::to_string(blk_idx) + ", tree_block_idx=" + std::to_string(tree_block_idx) + ")").c_str()));
 
     // Get the prev block's tree edge (i.e. the current tree edge before growing)
     prev_blk_idx = blk_idx - 1;
@@ -7589,12 +7609,7 @@ void BlockchainLMDB::migrate_5_6()
           }
         }
 
-        // Get leaf tuples of outputs that unlock once i is in the chain, since i is their last locked block
-        auto unlocked_outputs = this->get_outs_at_last_locked_block_id(i);
-        this->grow_tree(i, std::move(unlocked_outputs));
-
-        // Now that we've used the unlocked leaves to grow the tree, we delete them from the locked outputs table
-        this->del_locked_outs_at_block_id(i);
+        this->advance_tree_one_block(i);
 
         LOGIF(el::Level::Info)
         {

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1403,24 +1403,27 @@ void BlockchainLMDB::advance_tree_one_block(const uint64_t blk_idx)
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
 
-  if (blk_idx == 0)
-    throw0(DB_ERROR("Expected to advance to blk_idx > 0"));
+  // Get the earliest possible last locked block of outputs created in blk_idx
+  const uint64_t earliest_last_locked_block = cryptonote::get_default_last_locked_block_index(blk_idx);
 
-  if (blk_idx == 1)
+  // If we're advancing the genesis block, make sure to initialize the tree
+  if (blk_idx == 0)
   {
-    // If we're advancing 1 block past genesis, make sure to initialize the tree for the genesis block.
-    // We grow the genesis block with empty outputs, since no outputs should be spendable once it's in the chain.
-    this->grow_tree(0, {});
+    // We grow the first blocks with empty outputs, since no outputs in this range should be spendable yet
+    for (uint64_t new_blk_idx = blk_idx; new_blk_idx < earliest_last_locked_block; ++new_blk_idx)
+    {
+      this->grow_tree(new_blk_idx, {});
+    }
   }
 
   // Now we can advance the tree 1 block
-  auto unlocked_outputs = this->get_outs_at_last_locked_block_id(blk_idx);
+  auto unlocked_outputs = this->get_outs_at_last_locked_block_id(earliest_last_locked_block);
 
-  // Grow the tree with outputs that are spendable once blk_idx is in the chain (i.e. they can be included starting in blk_idx+1)
-  this->grow_tree(blk_idx, std::move(unlocked_outputs));
+  // Grow the tree with outputs that are spendable once the earliest_last_locked_block is in the chain
+  this->grow_tree(earliest_last_locked_block, std::move(unlocked_outputs));
 
   // Now that we've used the unlocked leaves to grow the tree, we delete them from the locked outputs table
-  this->del_locked_outs_at_block_id(blk_idx);
+  this->del_locked_outs_at_block_id(earliest_last_locked_block);
 }
 
 void BlockchainLMDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs)
@@ -1434,28 +1437,23 @@ void BlockchainLMDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curv
 
   CURSOR(leaves)
 
-  // We may want to skip re-growing the tree if the tree is ahead of the chain.
-  // This can happen if we prior removed the block but have yet to trim the tree
-  // for that block. See trim_block for why we would do that.
+  MDEBUG("Growing tree usable once block " << blk_idx << " is in the chain");
+
+  // Get the prev block's tree edge (i.e. the current tree edge before growing)
   std::vector<crypto::ec_point> prev_tree_edge;
   uint64_t prev_blk_idx = 0;
   if (blk_idx > 0)
   {
-    // Get the block idx corresponding to the current tree in the db
-    const uint64_t tree_block_idx = this->get_tree_block_idx();
-    if (blk_idx > (tree_block_idx + 1))
-      throw0(DB_ERROR(("The chain has extended too far past the tree (blk_idx=" + std::to_string(blk_idx) + ", tree_block_idx=" + std::to_string(tree_block_idx) + ")").c_str()));
-    if (tree_block_idx >= blk_idx)
-    {
-      LOG_PRINT_L1("Skip re-growing the tree at block " << blk_idx << ", waiting for the chain to catch up to the tree's block " << tree_block_idx);
-      return;
-    }
-    // We're supposed to be growing the tree to the given blk_idx
-    if (blk_idx != (tree_block_idx + 1))
-      throw0(DB_ERROR(("Mismatch block idx to tree tip (blk_idx=" + std::to_string(blk_idx) + ", tree_block_idx=" + std::to_string(tree_block_idx) + ")").c_str()));
-
-    // Get the prev block's tree edge (i.e. the current tree edge before growing)
     prev_blk_idx = blk_idx - 1;
+
+    // Make sure tree tip lines up to expected block
+    const uint64_t tree_block_idx = this->get_tree_block_idx();
+    if (tree_block_idx != prev_blk_idx)
+    {
+      throw0(DB_ERROR(("Unexpected tree block idx mismatch to prev block ("
+          + std::to_string(tree_block_idx) + " vs " + std::to_string(prev_blk_idx) + ")").c_str()));
+    }
+
     prev_tree_edge = this->get_tree_edge(prev_blk_idx);
   }
 
@@ -1837,34 +1835,13 @@ void BlockchainLMDB::trim_block()
 
   // Get the earliest possible last locked block of outputs created in removing_block_idx
   const uint64_t default_last_locked_block = cryptonote::get_default_last_locked_block_index(removing_block_idx);
-
-  // Since the tree grows with outputs that must have entered the chain at least
-  // CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE blocks prior to chain tip, we do not
-  // need to trim blocks that will just be re-grown with the same outputs again.
-  // Instead, we wait to trim until the tree tip is
-  // CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE blocks ahead of the chain tip, at which
-  // point we can trim outputs created in the block we're removing from the tree
   const uint64_t tree_block_idx = this->get_tree_block_idx();
-
-  // The tree tip should remain bounded to [removing_block_idx, default_last_locked_block]
-  if (tree_block_idx < removing_block_idx || tree_block_idx > default_last_locked_block)
-  {
-    throw0(DB_ERROR(("Chain tip (" + std::to_string(removing_block_idx) + ") and tree tip (" +
-        std::to_string(tree_block_idx) + ") have diverged too far apart").c_str()));
-  }
-
   if (tree_block_idx != default_last_locked_block)
   {
-    LOG_PRINT_L1("Skipping trim when removing block " << removing_block_idx << " (tree block=" << tree_block_idx << ")");
-    return;
+    throw0(DB_ERROR(("Unexpected tree block idx mismatch ("
+        + std::to_string(tree_block_idx) + " vs " + std::to_string(default_last_locked_block) + ")").c_str()));
   }
 
-  // Block removing_block_idx must be the the youngest block where outputs were
-  // created that were used to grow the tree at tree_block_idx. So we trim 1
-  // block from the tree. Upon trimming tree_block_idx from the tree,
-  // no outputs in the tree will exist that were created in removing_block_idx.
-  // After trimming, we can safely remove all outputs from the chain created in
-  // removing_block_idx.
   if (tree_block_idx == 0)
     throw0(DB_ERROR("Unexpected 0 tree block idx"));
   const uint64_t prev_tree_block_idx = tree_block_idx - 1;

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -2119,7 +2119,7 @@ uint64_t BlockchainLMDB::get_block_n_leaf_tuples(const uint64_t block_idx) const
   return n_leaf_tuples;
 }
 
-std::size_t BlockchainLMDB::get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const
+uint8_t BlockchainLMDB::get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const
 {
   const std::vector<crypto::ec_point> tree_edge = this->get_tree_edge(blk_idx);
   if (tree_edge.empty())
@@ -2128,7 +2128,8 @@ std::size_t BlockchainLMDB::get_tree_root_at_blk_idx(const uint64_t blk_idx, cry
     return 0;
   }
   tree_root_out = tree_edge.back();
-  return tree_edge.size();
+  static_assert(sizeof(std::size_t) >= sizeof(uint8_t), "unexpected size of size_t");
+  return (uint8_t) tree_edge.size();
 }
 
 bool BlockchainLMDB::audit_tree(const uint64_t expected_n_leaf_tuples) const

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1398,7 +1398,7 @@ void BlockchainLMDB::remove_spent_key(const crypto::key_image& k_image)
   }
 }
 
-void BlockchainLMDB::advance_tree_one_block(const uint64_t blk_idx)
+void BlockchainLMDB::advance_tree(const uint64_t blk_idx)
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
@@ -1409,21 +1409,24 @@ void BlockchainLMDB::advance_tree_one_block(const uint64_t blk_idx)
   // If we're advancing the genesis block, make sure to initialize the tree
   if (blk_idx == 0)
   {
+    // TODO: include a pre-check that tree meta is empty
+
     // We grow the first blocks with empty outputs, since no outputs in this range should be spendable yet
     for (uint64_t new_blk_idx = blk_idx; new_blk_idx < earliest_last_locked_block; ++new_blk_idx)
     {
       this->grow_tree(new_blk_idx, {});
     }
   }
+  // TODO: include a pre-check that earliest_last_locked_block == last block idx + 1 in tree meta (when blk_idx != 0)
 
   // Now we can advance the tree 1 block
-  auto unlocked_outputs = this->get_outs_at_last_locked_block_id(earliest_last_locked_block);
+  auto unlocked_outputs = this->get_outs_at_last_locked_block_idx(earliest_last_locked_block);
 
   // Grow the tree with outputs that are spendable once the earliest_last_locked_block is in the chain
   this->grow_tree(earliest_last_locked_block, std::move(unlocked_outputs));
 
   // Now that we've used the unlocked leaves to grow the tree, we delete them from the locked outputs table
-  this->del_locked_outs_at_block_id(earliest_last_locked_block);
+  this->del_locked_outs_at_block_idx(earliest_last_locked_block);
 }
 
 void BlockchainLMDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs)
@@ -2391,8 +2394,8 @@ bool BlockchainLMDB::audit_layer(const std::unique_ptr<C_CHILD> &c_child,
   return audit_complete;
 }
 
-std::vector<fcmp_pp::curve_trees::OutputContext> BlockchainLMDB::get_outs_at_last_locked_block_id(
-  uint64_t block_id)
+std::vector<fcmp_pp::curve_trees::OutputContext> BlockchainLMDB::get_outs_at_last_locked_block_idx(
+  uint64_t block_idx)
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
@@ -2400,7 +2403,7 @@ std::vector<fcmp_pp::curve_trees::OutputContext> BlockchainLMDB::get_outs_at_las
   TXN_PREFIX_RDONLY();
   RCURSOR(locked_outputs)
 
-  MDB_val_set(k_block_id, block_id);
+  MDB_val_set(k_block_idx, block_idx);
   MDB_val v_output;
 
   // Get all the locked outputs at the provided block id
@@ -2409,16 +2412,16 @@ std::vector<fcmp_pp::curve_trees::OutputContext> BlockchainLMDB::get_outs_at_las
   MDB_cursor_op op = MDB_SET;
   while (1)
   {
-    int result = mdb_cursor_get(m_cur_locked_outputs, &k_block_id, &v_output, op);
+    int result = mdb_cursor_get(m_cur_locked_outputs, &k_block_idx, &v_output, op);
     if (result == MDB_NOTFOUND)
       break;
     if (result != MDB_SUCCESS)
       throw0(DB_ERROR(lmdb_error("Failed to get next locked outputs: ", result).c_str()));
     op = MDB_NEXT_MULTIPLE;
 
-    const uint64_t blk_id = *(const uint64_t*)k_block_id.mv_data;
-    if (blk_id != block_id)
-      throw0(DB_ERROR(("Blk id " + std::to_string(blk_id) + " not the expected" + std::to_string(block_id)).c_str()));
+    const uint64_t blk_id = *(const uint64_t*)k_block_idx.mv_data;
+    if (blk_id != block_idx)
+      throw0(DB_ERROR(("Blk id " + std::to_string(blk_id) + " not the expected" + std::to_string(block_idx)).c_str()));
 
     const auto range_begin = ((const fcmp_pp::curve_trees::OutputContext*)v_output.mv_data);
     const auto range_end = range_begin + v_output.mv_size / sizeof(fcmp_pp::curve_trees::OutputContext);
@@ -2441,7 +2444,7 @@ std::vector<fcmp_pp::curve_trees::OutputContext> BlockchainLMDB::get_outs_at_las
   return outs;
 }
 
-void BlockchainLMDB::del_locked_outs_at_block_id(uint64_t block_id)
+void BlockchainLMDB::del_locked_outs_at_block_idx(uint64_t block_idx)
 {
   LOG_PRINT_L3("BlockchainLMDB::" << __func__);
   check_open();
@@ -2449,9 +2452,9 @@ void BlockchainLMDB::del_locked_outs_at_block_id(uint64_t block_id)
 
   CURSOR(locked_outputs)
 
-  MDB_val_set(k_block_id, block_id);
+  MDB_val_set(k_block_idx, block_idx);
 
-  int result = mdb_cursor_get(m_cur_locked_outputs, &k_block_id, NULL, MDB_SET);
+  int result = mdb_cursor_get(m_cur_locked_outputs, &k_block_idx, NULL, MDB_SET);
   if (result == MDB_NOTFOUND)
     return;
   if (result != MDB_SUCCESS)
@@ -7587,7 +7590,7 @@ void BlockchainLMDB::migrate_5_6()
           }
         }
 
-        this->advance_tree_one_block(i);
+        this->advance_tree(i);
 
         LOGIF(el::Level::Info)
         {

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -457,7 +457,7 @@ private:
 
   uint64_t get_block_n_leaf_tuples(uint64_t block_idx) const;
 
-  virtual std::size_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const;
+  virtual uint8_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const;
 
   std::vector<crypto::ec_point> get_tree_edge(uint64_t block_id) const;
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -342,7 +342,7 @@ public:
                             , const std::vector<std::pair<transaction, blobdata>>& txs
                             );
 
-  virtual void advance_tree_one_block(const uint64_t blk_idx);
+  virtual void advance_tree(const uint64_t blk_idx);
 
   virtual void set_batch_transactions(bool batch_transactions);
   virtual bool batch_start(uint64_t batch_num_blocks=0, uint64_t batch_bytes=0);
@@ -457,6 +457,11 @@ private:
 
   uint64_t get_block_n_leaf_tuples(uint64_t block_idx) const;
 
+  // Gets the tree root and n_tree_layers composed of all valid spendable outputs when blk_idx is the tip of the chain.
+  // If the chain tip is block index n, and `blk_idx == n`, then this will return the tree root and n layers for the
+  // tree composed of all valid spendable outputs in the chain at that time. Note that the tree stored in the database
+  // may not match up with the tree root returned here, since the tree stored in the database may have grown past the
+  // current tip, with outputs that will unlock in future blocks.
   virtual uint8_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const;
 
   std::vector<crypto::ec_point> get_tree_edge(uint64_t block_id) const;
@@ -467,9 +472,9 @@ private:
     const uint64_t child_layer_idx,
     const uint64_t chunk_width) const;
 
-  std::vector<fcmp_pp::curve_trees::OutputContext> get_outs_at_last_locked_block_id(uint64_t block_id);
+  std::vector<fcmp_pp::curve_trees::OutputContext> get_outs_at_last_locked_block_idx(uint64_t block_id);
 
-  void del_locked_outs_at_block_id(uint64_t block_id);
+  void del_locked_outs_at_block_idx(uint64_t block_idx);
 
   uint64_t get_tree_block_idx() const;
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -342,6 +342,8 @@ public:
                             , const std::vector<std::pair<transaction, blobdata>>& txs
                             );
 
+  virtual void advance_tree_one_block(const uint64_t blk_idx);
+
   virtual void set_batch_transactions(bool batch_transactions);
   virtual bool batch_start(uint64_t batch_num_blocks=0, uint64_t batch_bytes=0);
   virtual void batch_commit();

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -457,11 +457,6 @@ private:
 
   uint64_t get_block_n_leaf_tuples(uint64_t block_idx) const;
 
-  // Gets the tree root and n_tree_layers composed of all valid spendable outputs when blk_idx is the tip of the chain.
-  // If the chain tip is block index n, and `blk_idx == n`, then this will return the tree root and n layers for the
-  // tree composed of all valid spendable outputs in the chain at that time. Note that the tree stored in the database
-  // may not match up with the tree root returned here, since the tree stored in the database may have grown past the
-  // current tip, with outputs that will unlock in future blocks.
   virtual uint8_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const;
 
   std::vector<crypto::ec_point> get_tree_edge(uint64_t block_id) const;

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -117,7 +117,7 @@ public:
   virtual void add_tx_amount_output_indices(const uint64_t tx_index, const std::vector<uint64_t>& amount_output_indices) override {}
   virtual void add_spent_key(const crypto::key_image& k_image) override {}
   virtual void remove_spent_key(const crypto::key_image& k_image) override {}
-  virtual void advance_tree_one_block(const uint64_t block_idx) override {}
+  virtual void advance_tree(const uint64_t block_idx) override {}
   virtual void grow_tree(const uint64_t block_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs) override {};
   virtual std::pair<uint64_t, fcmp_pp::curve_trees::PathBytes> get_last_path(const uint64_t block_idx) const override { return {0, fcmp_pp::curve_trees::PathBytes{}}; };
   virtual void trim_tree(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_id) override {};

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -122,7 +122,7 @@ public:
   virtual std::pair<uint64_t, fcmp_pp::curve_trees::PathBytes> get_last_path(const uint64_t block_idx) const override { return {0, fcmp_pp::curve_trees::PathBytes{}}; };
   virtual void trim_tree(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_id) override {};
   virtual bool audit_tree(const uint64_t expected_n_leaf_tuples) const override { return false; };
-  virtual std::size_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const override { return {}; };
+  virtual uint8_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const override { return {}; };
   virtual uint64_t get_n_leaf_tuples() const override { return 0; };
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const override { return 0; };
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const override { return {{}}; };

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -117,6 +117,7 @@ public:
   virtual void add_tx_amount_output_indices(const uint64_t tx_index, const std::vector<uint64_t>& amount_output_indices) override {}
   virtual void add_spent_key(const crypto::key_image& k_image) override {}
   virtual void remove_spent_key(const crypto::key_image& k_image) override {}
+  virtual void advance_tree_one_block(const uint64_t block_idx) override {}
   virtual void grow_tree(const uint64_t block_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs) override {};
   virtual std::pair<uint64_t, fcmp_pp::curve_trees::PathBytes> get_last_path(const uint64_t block_idx) const override { return {0, fcmp_pp::curve_trees::PathBytes{}}; };
   virtual void trim_tree(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_id) override {};

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -478,8 +478,8 @@ namespace cryptonote
 
   public:
     block(): block_header(), hash_valid(false) {}
-    block(const block &b): block_header(b), hash_valid(false), miner_tx(b.miner_tx), tx_hashes(b.tx_hashes) { if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } }
-    block &operator=(const block &b) { block_header::operator=(b); hash_valid = false; miner_tx = b.miner_tx; tx_hashes = b.tx_hashes; if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } return *this; }
+    block(const block &b): block_header(b), hash_valid(false), miner_tx(b.miner_tx), tx_hashes(b.tx_hashes), fcmp_pp_tree_root(b.fcmp_pp_tree_root) { if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } }
+    block &operator=(const block &b) { block_header::operator=(b); hash_valid = false; miner_tx = b.miner_tx; tx_hashes = b.tx_hashes; fcmp_pp_tree_root = b.fcmp_pp_tree_root; if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } return *this; }
     void invalidate_hashes() { set_hash_valid(false); }
     bool is_hash_valid() const { return hash_valid.load(std::memory_order_acquire); }
     void set_hash_valid(bool v) const { hash_valid.store(v,std::memory_order_release); }
@@ -487,6 +487,8 @@ namespace cryptonote
 
     transaction miner_tx;
     std::vector<crypto::hash> tx_hashes;
+
+    crypto::ec_point fcmp_pp_tree_root;
 
     // hash cash
     mutable crypto::hash hash;
@@ -500,6 +502,8 @@ namespace cryptonote
       FIELD(tx_hashes)
       if (tx_hashes.size() > CRYPTONOTE_MAX_TX_PER_BLOCK)
         return false;
+      if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+        FIELD(fcmp_pp_tree_root)
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -478,8 +478,8 @@ namespace cryptonote
 
   public:
     block(): block_header(), hash_valid(false) {}
-    block(const block &b): block_header(b), hash_valid(false), miner_tx(b.miner_tx), tx_hashes(b.tx_hashes), fcmp_pp_tree_root(b.fcmp_pp_tree_root) { if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } }
-    block &operator=(const block &b) { block_header::operator=(b); hash_valid = false; miner_tx = b.miner_tx; tx_hashes = b.tx_hashes; fcmp_pp_tree_root = b.fcmp_pp_tree_root; if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } return *this; }
+    block(const block &b): block_header(b), hash_valid(false), miner_tx(b.miner_tx), tx_hashes(b.tx_hashes), fcmp_pp_n_tree_layers(b.fcmp_pp_n_tree_layers), fcmp_pp_tree_root(b.fcmp_pp_tree_root) { if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } }
+    block &operator=(const block &b) { block_header::operator=(b); hash_valid = false; miner_tx = b.miner_tx; tx_hashes = b.tx_hashes; fcmp_pp_n_tree_layers = b.fcmp_pp_n_tree_layers; fcmp_pp_tree_root = b.fcmp_pp_tree_root; if (b.is_hash_valid()) { hash = b.hash; set_hash_valid(true); } return *this; }
     void invalidate_hashes() { set_hash_valid(false); }
     bool is_hash_valid() const { return hash_valid.load(std::memory_order_acquire); }
     void set_hash_valid(bool v) const { hash_valid.store(v,std::memory_order_release); }
@@ -488,6 +488,8 @@ namespace cryptonote
     transaction miner_tx;
     std::vector<crypto::hash> tx_hashes;
 
+    // We include both n tree layers and the root so SPV nodes can verify FCMP++ proofs
+    uint8_t fcmp_pp_n_tree_layers;
     crypto::ec_point fcmp_pp_tree_root;
 
     // hash cash
@@ -503,7 +505,12 @@ namespace cryptonote
       if (tx_hashes.size() > CRYPTONOTE_MAX_TX_PER_BLOCK)
         return false;
       if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+      {
+        FIELD(fcmp_pp_n_tree_layers)
+        if (fcmp_pp_n_tree_layers > FCMP_PLUS_PLUS_MAX_LAYERS)
+          return false;
         FIELD(fcmp_pp_tree_root)
+      }
     END_SERIALIZE()
   };
 

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -203,7 +203,10 @@ namespace boost
     a & b.miner_tx;
     a & b.tx_hashes;
     if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    {
+      a & b.fcmp_pp_n_tree_layers;
       a & b.fcmp_pp_tree_root;
+    }
   }
 
   template <class Archive>

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -202,6 +202,8 @@ namespace boost
     //------------------
     a & b.miner_tx;
     a & b.tx_hashes;
+    if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+      a & b.fcmp_pp_tree_root;
   }
 
   template <class Archive>

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -99,6 +99,18 @@ namespace cryptonote
     const uint64_t bp_clawback = (bp_base * n_padded_outputs - bp_size) * 4 / 5;
     return bp_clawback;
   }
+
+  static void get_tree_hash(const std::vector<crypto::hash>& tx_hashes, crypto::hash& h)
+  {
+    tree_hash(tx_hashes.data(), tx_hashes.size(), h);
+  }
+
+  static crypto::hash get_tree_hash(const std::vector<crypto::hash>& tx_hashes)
+  {
+    crypto::hash h = null_hash;
+    get_tree_hash(tx_hashes, h);
+    return h;
+  }
   //---------------------------------------------------------------
 }
 
@@ -1515,7 +1527,7 @@ namespace cryptonote
   blobdata get_block_hashing_blob(const block& b)
   {
     blobdata blob = t_serializable_object_to_blob(static_cast<block_header>(b));
-    crypto::hash tree_root_hash = get_tx_tree_hash(b);
+    crypto::hash tree_root_hash = get_tree_hash(b);
     blob.append(reinterpret_cast<const char*>(&tree_root_hash), sizeof(tree_root_hash));
     blob.append(tools::get_varint_data(b.tx_hashes.size()+1));
     return blob;
@@ -1658,29 +1670,23 @@ namespace cryptonote
     return t_serializable_object_to_blob(tx, b_blob);
   }
   //---------------------------------------------------------------
-  void get_tx_tree_hash(const std::vector<crypto::hash>& tx_hashes, crypto::hash& h)
+  crypto::hash get_tree_hash(const block& b)
   {
-    tree_hash(tx_hashes.data(), tx_hashes.size(), h);
-  }
-  //---------------------------------------------------------------
-  crypto::hash get_tx_tree_hash(const std::vector<crypto::hash>& tx_hashes)
-  {
-    crypto::hash h = null_hash;
-    get_tx_tree_hash(tx_hashes, h);
-    return h;
-  }
-  //---------------------------------------------------------------
-  crypto::hash get_tx_tree_hash(const block& b)
-  {
-    std::vector<crypto::hash> txs_ids;
-    txs_ids.reserve(1 + b.tx_hashes.size());
+    std::vector<crypto::hash> hashes;
+    hashes.reserve(1 + 1 + b.tx_hashes.size());
+    // 1. FCMP++ root
+    static_assert(sizeof(crypto::hash) == sizeof(crypto::ec_point), "expected sizeof hash == sizeof ec_point");
+    if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+      hashes.push_back((crypto::hash&)b.fcmp_pp_tree_root);
+    // 2. Miner tx
     crypto::hash h = null_hash;
     size_t bl_sz = 0;
     CHECK_AND_ASSERT_THROW_MES(get_transaction_hash(b.miner_tx, h, bl_sz), "Failed to calculate transaction hash");
-    txs_ids.push_back(h);
+    hashes.push_back(h);
+    // 3. All other txs
     for(auto& th: b.tx_hashes)
-      txs_ids.push_back(th);
-    return get_tx_tree_hash(txs_ids);
+      hashes.push_back(th);
+    return get_tree_hash(hashes);
   }
   //---------------------------------------------------------------
   bool is_valid_decomposed_amount(uint64_t amount)

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1527,8 +1527,8 @@ namespace cryptonote
   blobdata get_block_hashing_blob(const block& b)
   {
     blobdata blob = t_serializable_object_to_blob(static_cast<block_header>(b));
-    crypto::hash tree_root_hash = get_tree_hash(b);
-    blob.append(reinterpret_cast<const char*>(&tree_root_hash), sizeof(tree_root_hash));
+    crypto::hash block_content_hash = get_block_content_hash(b);
+    blob.append(reinterpret_cast<const char*>(&block_content_hash), sizeof(block_content_hash));
     blob.append(tools::get_varint_data(b.tx_hashes.size()+1));
     return blob;
   }
@@ -1670,20 +1670,24 @@ namespace cryptonote
     return t_serializable_object_to_blob(tx, b_blob);
   }
   //---------------------------------------------------------------
-  crypto::hash get_tree_hash(const block& b)
+  crypto::hash get_block_content_hash(const block& b)
   {
     std::vector<crypto::hash> hashes;
-    hashes.reserve(1 + 1 + b.tx_hashes.size());
-    // 1. FCMP++ root
+    hashes.reserve(1 + 1 + 1 + b.tx_hashes.size());
+    // 1. n tree layers in FCMP++ tree
+    static_assert(sizeof(crypto::hash) >= sizeof(uint8_t), "crypto::hash is too small");
+    if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+      hashes.push_back(crypto::hash{static_cast<char>(b.fcmp_pp_n_tree_layers)});
+    // 2. FCMP++ tree root
     static_assert(sizeof(crypto::hash) == sizeof(crypto::ec_point), "expected sizeof hash == sizeof ec_point");
     if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
       hashes.push_back((crypto::hash&)b.fcmp_pp_tree_root);
-    // 2. Miner tx
+    // 3. Miner tx
     crypto::hash h = null_hash;
     size_t bl_sz = 0;
     CHECK_AND_ASSERT_THROW_MES(get_transaction_hash(b.miner_tx, h, bl_sz), "Failed to calculate transaction hash");
     hashes.push_back(h);
-    // 3. All other txs
+    // 4. All other txs
     for(auto& th: b.tx_hashes)
       hashes.push_back(th);
     return get_tree_hash(hashes);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -263,9 +263,7 @@ namespace cryptonote
   bool block_to_blob(const block& b, blobdata& b_blob);
   blobdata tx_to_blob(const transaction& b);
   bool tx_to_blob(const transaction& b, blobdata& b_blob);
-  void get_tx_tree_hash(const std::vector<crypto::hash>& tx_hashes, crypto::hash& h);
-  crypto::hash get_tx_tree_hash(const std::vector<crypto::hash>& tx_hashes);
-  crypto::hash get_tx_tree_hash(const block& b);
+  crypto::hash get_tree_hash(const block& b);
   bool is_valid_decomposed_amount(uint64_t amount);
   void get_hash_stats(uint64_t &tx_hashes_calculated, uint64_t &tx_hashes_cached, uint64_t &block_hashes_calculated, uint64_t & block_hashes_cached);
 

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -263,7 +263,7 @@ namespace cryptonote
   bool block_to_blob(const block& b, blobdata& b_blob);
   blobdata tx_to_blob(const transaction& b);
   bool tx_to_blob(const transaction& b, blobdata& b_blob);
-  crypto::hash get_tree_hash(const block& b);
+  crypto::hash get_block_content_hash(const block& b);
   bool is_valid_decomposed_amount(uint64_t amount);
   void get_hash_stats(uint64_t &tx_hashes_calculated, uint64_t &tx_hashes_cached, uint64_t &block_hashes_calculated, uint64_t & block_hashes_cached);
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4699,7 +4699,7 @@ leave:
   TIME_MEASURE_START(advance_tree);
 
   static_assert(CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE > 0, "Expect a non-0 spendable age");
-  try { m_db->advance_tree_one_block(new_height-1); }
+  try { m_db->advance_tree(new_height-1); }
   catch (const std::exception& e)
   {
     LOG_ERROR("Failed to advance tree at block with hash: " << id << ", what = " << e.what());

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1552,6 +1552,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
     invalidate_block_template_cache();
   }
 
+  const uint64_t cur_n_blocks = m_db->height();
   if (from_block)
   {
     //build alternative subchain, front -> mainchain, back -> alternative head
@@ -1612,6 +1613,32 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
     b.minor_version = m_hardfork->get_ideal_version();
     b.prev_id = *from_block;
 
+    if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    {
+      if (alt_chain.size() > CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE)
+      {
+        // Since the daemon is not wasting cycles calculating alt-trees, it does
+        // not know the correct root to use for an alt chain longer than 10
+        // blocks. The daemon could theoretically build the altchain's tree in
+        // handle_alternative_block, but that seems like a pre-mature
+        // optimization. Who wants to mine altchains longer than 10 blocks
+        // anyway?
+        MERROR("altchain is too long, the daemon is not structured to calculate its FCMP++ tree root");
+        return false;
+      }
+
+      if (height > cur_n_blocks)
+      {
+        MERROR("altchain is longer than the mainchain, so we don't have the FCMP++ tree root saved for its block");
+        // Theoretically the daemon could calculate the tree 10 blocks ahead
+        // of the mainchain, which would allow us to mine on top of an altchain
+        // while growing the mainchain tree (which we need to do anyway), but it
+        // seems like pre-mature optimization to support mining on top
+        // of altchains longer than the mainchain anyway.
+        return false;
+      }
+    }
+
     // cheat and use the weight of the block we start from, virtually certain to be acceptable
     // and use 1.9 times rather than 2 times so we're even more sure
     if (parent_in_main)
@@ -1634,7 +1661,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
   }
   else
   {
-    height = m_db->height();
+    height = cur_n_blocks;
     b.major_version = m_hardfork->get_current_version();
     b.minor_version = m_hardfork->get_ideal_version();
     b.prev_id = get_tail_id();
@@ -1657,6 +1684,11 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
   }
 
   CHECK_AND_ASSERT_MES(diffic, false, "difficulty overhead.");
+
+  if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+  {
+    m_db->get_tree_root_at_blk_idx(height, b.fcmp_pp_tree_root);
+  }
 
   size_t txs_weight;
   uint64_t fee;
@@ -1791,15 +1823,21 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
   return create_block_template(b, NULL, miner_address, diffic, height, expected_reward, cumulative_weight, ex_nonce, seed_height, seed_hash);
 }
 //------------------------------------------------------------------
-bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
+bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
 {
   prev_id = m_db->top_block_hash(&height);
   ++height;
 
   major_version = m_hardfork->get_ideal_version(height);
 
+  const uint8_t cur_version = m_hardfork->get_current_version();
+
+  fcmp_pp_tree_root = crypto::ec_point{};
+  if (cur_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
+
   seed_hash = crypto::null_hash;
-  if (m_hardfork->get_current_version() >= RX_BLOCK_VERSION)
+  if (cur_version >= RX_BLOCK_VERSION)
   {
     uint64_t seed_height, next_height;
     crypto::rx_seedheights(height, &seed_height, &next_height);
@@ -4338,6 +4376,19 @@ leave:
 
   TIME_MEASURE_START(t3);
 
+  // Make sure the block uses the correct FCMP++ tree root
+  if (hf_version >= HF_VERSION_FCMP_PLUS_PLUS)
+  {
+    crypto::ec_point fcmp_pp_tree_root;
+    m_db->get_tree_root_at_blk_idx(blockchain_height, fcmp_pp_tree_root);
+    if (bl.fcmp_pp_tree_root != fcmp_pp_tree_root)
+    {
+      MERROR_VER("Block with id: " << id << " used incorrect FCMP++ tree root");
+      bvc.m_verifivation_failed = true;
+      goto leave;
+    }
+  }
+
   // sanity check basic miner tx properties;
   if(!prevalidate_miner_transaction(bl, blockchain_height, hf_version))
   {
@@ -4652,6 +4703,27 @@ leave:
     return false;
   }
 
+  // Assume we're adding block n, now we grow the FCMP++ tree and generate a
+  // new root that will be usable once block n+1 is in the chain. We keep the
+  // tree 1 block ahead of the chain so that miners can use the block's tree
+  // root to calculate the next block's PoW hash. Note that we're still growing
+  // the tree 1 block at a time in the sync process. We just grow the tree ahead
+  // of the "next" block after syncing "this" block. This approach works because
+  // outputs are not immediately spendable upon inclusion in the chain. There is
+  // room for improvement in parallelizing tree building, left for another day.
+  TIME_MEASURE_START(advance_tree);
+
+  static_assert(CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE > 0, "Expect a non-0 spendable age");
+  try { m_db->advance_tree_one_block(new_height); }
+  catch (const std::exception& e)
+  {
+    LOG_ERROR("Failed to advance tree at block with hash: " << id << ", what = " << e.what());
+    bvc.m_verifivation_failed = true;
+    return false;
+  }
+
+  TIME_MEASURE_FINISH(advance_tree);
+
   MINFO("+++++ BLOCK SUCCESSFULLY ADDED" << std::endl << "id:\t" << id << std::endl << "PoW:\t" << proof_of_work << std::endl << "HEIGHT " << new_height-1 << ", difficulty:\t" << current_diffic << std::endl << "block reward: " << print_money(fee_summary + base_reward) << "(" << print_money(base_reward) << " + " << print_money(fee_summary) << "), coinbase_weight: " << coinbase_weight << ", cumulative weight: " << cumulative_block_weight << ", " << block_processing_time << "(" << target_calculating_time << "/" << longhash_calculating_time << ")ms");
   if(m_show_time_stats)
   {
@@ -4659,7 +4731,8 @@ leave:
         << cumulative_block_weight << " p/t: " << block_processing_time << " ("
         << target_calculating_time << "/" << longhash_calculating_time << "/"
         << t1 << "/" << t2 << "/" << t3 << "/" << t_exists << "/" << t_pool
-        << "/" << t_checktx << "/" << t_dblspnd << "/" << vmt << "/" << addblock << ")ms");
+        << "/" << t_checktx << "/" << t_dblspnd << "/" << vmt << "/" << addblock
+        << "/" << advance_tree << ")ms");
   }
 
   bvc.m_added_to_main_chain = true;
@@ -5931,9 +6004,13 @@ void Blockchain::send_miner_notifications(uint64_t height, const crypto::hash &s
   std::vector<tx_block_template_backlog_entry> tx_backlog;
   m_tx_pool.get_block_template_backlog(tx_backlog);
 
+  crypto::ec_point fcmp_pp_tree_root{};
+  if (m_hardfork->get_current_version() >= HF_VERSION_FCMP_PLUS_PLUS)
+    m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
+
   for (const auto& notifier : m_miner_notifiers)
   {
-    notifier(major_version, height, prev_id, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
+    notifier(major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
   }
 }
 

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1613,30 +1613,10 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
     b.minor_version = m_hardfork->get_ideal_version();
     b.prev_id = *from_block;
 
-    if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS && alt_chain.size())
     {
-      if (alt_chain.size() > CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE)
-      {
-        // Since the daemon is not wasting cycles calculating alt-trees, it does
-        // not know the correct root to use for an alt chain longer than 10
-        // blocks. The daemon could theoretically build the altchain's tree in
-        // handle_alternative_block, but that seems like a pre-mature
-        // optimization. Who wants to mine altchains longer than 10 blocks
-        // anyway?
-        MERROR("altchain is too long, the daemon is not structured to calculate its FCMP++ tree root");
-        return false;
-      }
-
-      if (height > cur_n_blocks)
-      {
-        MERROR("altchain is longer than the mainchain, so we don't have the FCMP++ tree root saved for its block");
-        // Theoretically the daemon could calculate the tree 10 blocks ahead
-        // of the mainchain, which would allow us to mine on top of an altchain
-        // while growing the mainchain tree (which we need to do anyway), but it
-        // seems like pre-mature optimization to support mining on top
-        // of altchains longer than the mainchain anyway.
-        return false;
-      }
+      MERROR("The daemon is not structured to build the FCMP++ tree for alt chains and does not know the correct root for the alt block header");
+      return false;
     }
 
     // cheat and use the weight of the block we start from, virtually certain to be acceptable
@@ -1687,7 +1667,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
 
   if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
   {
-    b.fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(height, b.fcmp_pp_tree_root);
+    b.fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(cryptonote::get_default_last_locked_block_index(height - 1), b.fcmp_pp_tree_root);
   }
 
   size_t txs_weight;
@@ -1826,6 +1806,7 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
 bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, uint8_t& fcmp_pp_n_tree_layers, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
 {
   prev_id = m_db->top_block_hash(&height);
+  uint64_t top_block_idx = height;
   ++height;
 
   major_version = m_hardfork->get_ideal_version(height);
@@ -1833,7 +1814,7 @@ bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto
   fcmp_pp_n_tree_layers = 0;
   fcmp_pp_tree_root = crypto::ec_point{};
   if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
-    fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
+    fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(cryptonote::get_default_last_locked_block_index(top_block_idx), fcmp_pp_tree_root);
 
   seed_hash = crypto::null_hash;
   if (major_version >= RX_BLOCK_VERSION)
@@ -1845,7 +1826,7 @@ bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto
 
   difficulty = get_difficulty_for_next_block();
   median_weight = m_current_block_cumul_weight_median;
-  already_generated_coins = m_db->get_block_already_generated_coins(height - 1);
+  already_generated_coins = m_db->get_block_already_generated_coins(top_block_idx);
 
   m_tx_pool.get_block_template_backlog(tx_backlog);
 
@@ -4378,7 +4359,8 @@ leave:
   if (hf_version >= HF_VERSION_FCMP_PLUS_PLUS)
   {
     crypto::ec_point fcmp_pp_tree_root;
-    const uint8_t n_tree_layers = m_db->get_tree_root_at_blk_idx(blockchain_height, fcmp_pp_tree_root);
+    const uint64_t expected_tree_tip_block_idx = cryptonote::get_default_last_locked_block_index(blockchain_height - 1);
+    const uint8_t n_tree_layers = m_db->get_tree_root_at_blk_idx(expected_tree_tip_block_idx, fcmp_pp_tree_root);
     if (bl.fcmp_pp_n_tree_layers != n_tree_layers || bl.fcmp_pp_tree_root != fcmp_pp_tree_root)
     {
       MERROR_VER("Block with id: " << id << " used incorrect FCMP++ n tree layers or tree root");
@@ -4701,18 +4683,23 @@ leave:
     return false;
   }
 
-  // Assume we're adding block n, now we grow the FCMP++ tree and generate a
-  // new root that will be usable once block n+1 is in the chain. We keep the
-  // tree 1 block ahead of the chain so that miners can use the block's tree
-  // root to calculate the next block's PoW hash. Note that we're still growing
-  // the tree 1 block at a time in the sync process. We just grow the tree ahead
-  // of the "next" block after syncing "this" block. This approach works because
-  // outputs are not immediately spendable upon inclusion in the chain. There is
-  // room for improvement in parallelizing tree building, left for another day.
+  // Assume we just added block n. The soonest that outputs from block n can be
+  // included in the chain is in block n + CRYPTNOTE_DEFAULT_SPENDABLE_AGE. So
+  // we grow the tree with these outputs (and any others with last locked block
+  // n + CRYPTNOTE_DEFAULT_SPENDABLE_AGE - 1). We then expect this tree root
+  // be included in block header n+1. This way miners will build on top of the
+  // tree root usable in FCMP++'s in a future block. After block
+  // n + (CRYPTNOTE_DEFAULT_SPENDABLE_AGE - 1) is added to the chain, SPV
+  // clients syncing just block headers will have a solid assurance that the
+  // root usable to construct FCMP++ proofs is the correct root, since it will
+  // have 9 blocks of PoW on top of it.
+  // To be clear, block header n+1 includes the tree root usable to spend
+  // outputs with last locked block n + CRYPTNOTE_DEFAULT_SPENDABLE_AGE - 1.
+
   TIME_MEASURE_START(advance_tree);
 
   static_assert(CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE > 0, "Expect a non-0 spendable age");
-  try { m_db->advance_tree_one_block(new_height); }
+  try { m_db->advance_tree_one_block(new_height-1); }
   catch (const std::exception& e)
   {
     LOG_ERROR("Failed to advance tree at block with hash: " << id << ", what = " << e.what());
@@ -5994,6 +5981,7 @@ void Blockchain::send_miner_notifications(uint64_t height, const crypto::hash &s
 {
   if (m_miner_notifiers.empty())
     return;
+  CHECK_AND_ASSERT_THROW_MES(height > 0, "Unexpected height == 0");
 
   const uint8_t major_version = m_hardfork->get_ideal_version(height);
   const difficulty_type diff = get_difficulty_for_next_block();
@@ -6005,7 +5993,7 @@ void Blockchain::send_miner_notifications(uint64_t height, const crypto::hash &s
   uint8_t fcmp_pp_n_tree_layers = 0;
   crypto::ec_point fcmp_pp_tree_root{};
   if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
-    fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
+    fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(cryptonote::get_default_last_locked_block_index(height - 1), fcmp_pp_tree_root);
 
   for (const auto& notifier : m_miner_notifiers)
   {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1687,7 +1687,7 @@ bool Blockchain::create_block_template(block& b, const crypto::hash *from_block,
 
   if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
   {
-    m_db->get_tree_root_at_blk_idx(height, b.fcmp_pp_tree_root);
+    b.fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(height, b.fcmp_pp_tree_root);
   }
 
   size_t txs_weight;
@@ -1823,21 +1823,20 @@ bool Blockchain::create_block_template(block& b, const account_public_address& m
   return create_block_template(b, NULL, miner_address, diffic, height, expected_reward, cumulative_weight, ex_nonce, seed_height, seed_hash);
 }
 //------------------------------------------------------------------
-bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
+bool Blockchain::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, uint8_t& fcmp_pp_n_tree_layers, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
 {
   prev_id = m_db->top_block_hash(&height);
   ++height;
 
   major_version = m_hardfork->get_ideal_version(height);
 
-  const uint8_t cur_version = m_hardfork->get_current_version();
-
+  fcmp_pp_n_tree_layers = 0;
   fcmp_pp_tree_root = crypto::ec_point{};
-  if (cur_version >= HF_VERSION_FCMP_PLUS_PLUS)
-    m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
+  if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
 
   seed_hash = crypto::null_hash;
-  if (cur_version >= RX_BLOCK_VERSION)
+  if (major_version >= RX_BLOCK_VERSION)
   {
     uint64_t seed_height, next_height;
     crypto::rx_seedheights(height, &seed_height, &next_height);
@@ -2628,12 +2627,11 @@ static bool get_fcmp_tx_tree_root(const BlockchainDB *db, const cryptonote::tran
       "tx included reference block that was too high");
 
   // Get the tree root and n tree layers at provided block
-  const std::size_t n_tree_layers = db->get_tree_root_at_blk_idx(tx.rct_signatures.p.reference_block, tree_root_out);
+  const uint8_t n_tree_layers = db->get_tree_root_at_blk_idx(tx.rct_signatures.p.reference_block, tree_root_out);
 
   // Make sure the provided n tree layers matches expected
   // IMPORTANT!
-  static_assert(sizeof(std::size_t) >= sizeof(uint8_t), "unexpected size of size_t");
-  CHECK_AND_ASSERT_MES((std::size_t)tx.rct_signatures.p.n_tree_layers == n_tree_layers, false,
+  CHECK_AND_ASSERT_MES(tx.rct_signatures.p.n_tree_layers == n_tree_layers, false,
       "tx included incorrect number of tree layers");
 
   return true;
@@ -4376,14 +4374,14 @@ leave:
 
   TIME_MEASURE_START(t3);
 
-  // Make sure the block uses the correct FCMP++ tree root
+  // Make sure the block uses the correct FCMP++ tree root and n tree layers
   if (hf_version >= HF_VERSION_FCMP_PLUS_PLUS)
   {
     crypto::ec_point fcmp_pp_tree_root;
-    m_db->get_tree_root_at_blk_idx(blockchain_height, fcmp_pp_tree_root);
-    if (bl.fcmp_pp_tree_root != fcmp_pp_tree_root)
+    const uint8_t n_tree_layers = m_db->get_tree_root_at_blk_idx(blockchain_height, fcmp_pp_tree_root);
+    if (bl.fcmp_pp_n_tree_layers != n_tree_layers || bl.fcmp_pp_tree_root != fcmp_pp_tree_root)
     {
-      MERROR_VER("Block with id: " << id << " used incorrect FCMP++ tree root");
+      MERROR_VER("Block with id: " << id << " used incorrect FCMP++ n tree layers or tree root");
       bvc.m_verifivation_failed = true;
       goto leave;
     }
@@ -6004,13 +6002,14 @@ void Blockchain::send_miner_notifications(uint64_t height, const crypto::hash &s
   std::vector<tx_block_template_backlog_entry> tx_backlog;
   m_tx_pool.get_block_template_backlog(tx_backlog);
 
+  uint8_t fcmp_pp_n_tree_layers = 0;
   crypto::ec_point fcmp_pp_tree_root{};
-  if (m_hardfork->get_current_version() >= HF_VERSION_FCMP_PLUS_PLUS)
-    m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
+  if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    fcmp_pp_n_tree_layers = m_db->get_tree_root_at_blk_idx(height, fcmp_pp_tree_root);
 
   for (const auto& notifier : m_miner_notifiers)
   {
-    notifier(major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
+    notifier(major_version, height, prev_id, fcmp_pp_n_tree_layers, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
   }
 }
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -94,7 +94,7 @@ namespace cryptonote
 
   typedef boost::function<void(std::vector<txpool_event>)> TxpoolNotifyCallback;
   typedef boost::function<void(uint64_t /* height */, epee::span<const block> /* blocks */)> BlockNotifyCallback;
-  typedef boost::function<void(uint8_t /* major_version */, uint64_t /* height */, const crypto::hash& /* prev_id */, const crypto::hash& /* seed_hash */, difficulty_type /* diff */, uint64_t /* median_weight */, uint64_t /* already_generated_coins */, const std::vector<tx_block_template_backlog_entry>& /* tx_backlog */)> MinerNotifyCallback;
+  typedef boost::function<void(uint8_t /* major_version */, uint64_t /* height */, const crypto::hash& /* prev_id */, const crypto::ec_point& /* fcmp_pp_tree_root */, const crypto::hash& /* seed_hash */, difficulty_type /* diff */, uint64_t /* median_weight */, uint64_t /* already_generated_coins */, const std::vector<tx_block_template_backlog_entry>& /* tx_backlog */)> MinerNotifyCallback;
 
   /************************************************************************/
   /*                                                                      */
@@ -396,6 +396,7 @@ namespace cryptonote
      * @param major_version current hardfork version
      * @param height current blockchain height
      * @param prev_id hash of the top block
+     * @param fcmp_pp_tree_root FCMP++ root as of when this next block enters the chain
      * @param seed_hash seed hash used for RandomX initialization
      * @param difficulty current mining difficulty
      * @param median_weight current median block weight
@@ -404,7 +405,7 @@ namespace cryptonote
      *
      * @return true if block template filled in successfully, else false
      */
-    bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
+    bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
 
     /**
      * @brief checks if a block is known about with a given hash

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -94,7 +94,7 @@ namespace cryptonote
 
   typedef boost::function<void(std::vector<txpool_event>)> TxpoolNotifyCallback;
   typedef boost::function<void(uint64_t /* height */, epee::span<const block> /* blocks */)> BlockNotifyCallback;
-  typedef boost::function<void(uint8_t /* major_version */, uint64_t /* height */, const crypto::hash& /* prev_id */, const crypto::ec_point& /* fcmp_pp_tree_root */, const crypto::hash& /* seed_hash */, difficulty_type /* diff */, uint64_t /* median_weight */, uint64_t /* already_generated_coins */, const std::vector<tx_block_template_backlog_entry>& /* tx_backlog */)> MinerNotifyCallback;
+  typedef boost::function<void(uint8_t /* major_version */, uint64_t /* height */, const crypto::hash& /* prev_id */, const uint8_t& /*fcmp_pp_n_tree_layers*/, const crypto::ec_point& /* fcmp_pp_tree_root */, const crypto::hash& /* seed_hash */, difficulty_type /* diff */, uint64_t /* median_weight */, uint64_t /* already_generated_coins */, const std::vector<tx_block_template_backlog_entry>& /* tx_backlog */)> MinerNotifyCallback;
 
   /************************************************************************/
   /*                                                                      */
@@ -396,6 +396,7 @@ namespace cryptonote
      * @param major_version current hardfork version
      * @param height current blockchain height
      * @param prev_id hash of the top block
+     * @param fcmp_pp_n_tree_layers number of layers in the FCMP++ curve tree
      * @param fcmp_pp_tree_root FCMP++ root as of when this next block enters the chain
      * @param seed_hash seed hash used for RandomX initialization
      * @param difficulty current mining difficulty
@@ -405,7 +406,7 @@ namespace cryptonote
      *
      * @return true if block template filled in successfully, else false
      */
-    bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
+    bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, uint8_t& fcmp_pp_n_tree_layers, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
 
     /**
      * @brief checks if a block is known about with a given hash

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1204,9 +1204,9 @@ namespace cryptonote
     return m_blockchain_storage.create_block_template(b, prev_block, adr, diffic, height, expected_reward, cumulative_weight, ex_nonce, seed_height, seed_hash);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
+  bool core::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, uint8_t& fcmp_pp_n_tree_layers, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
   {
-    return m_blockchain_storage.get_miner_data(major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, difficulty, median_weight, already_generated_coins, tx_backlog);
+    return m_blockchain_storage.get_miner_data(major_version, height, prev_id, fcmp_pp_n_tree_layers, fcmp_pp_tree_root, seed_hash, difficulty, median_weight, already_generated_coins, tx_backlog);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, bool clip_pruned, NOTIFY_RESPONSE_CHAIN_ENTRY::request& resp) const

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1204,9 +1204,9 @@ namespace cryptonote
     return m_blockchain_storage.create_block_template(b, prev_block, adr, diffic, height, expected_reward, cumulative_weight, ex_nonce, seed_height, seed_hash);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
+  bool core::get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog)
   {
-    return m_blockchain_storage.get_miner_data(major_version, height, prev_id, seed_hash, difficulty, median_weight, already_generated_coins, tx_backlog);
+    return m_blockchain_storage.get_miner_data(major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, difficulty, median_weight, already_generated_coins, tx_backlog);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, bool clip_pruned, NOTIFY_RESPONSE_CHAIN_ENTRY::request& resp) const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -242,7 +242,7 @@ namespace cryptonote
       *
       * @note see Blockchain::get_miner_data
       */
-     bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
+     bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, uint8_t& fcmp_pp_n_tree_layers, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
 
      /**
       * @brief called when a transaction is relayed.

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -242,7 +242,7 @@ namespace cryptonote
       *
       * @note see Blockchain::get_miner_data
       */
-     bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
+     bool get_miner_data(uint8_t& major_version, uint64_t& height, crypto::hash& prev_id, crypto::ec_point& fcmp_pp_tree_root, crypto::hash& seed_hash, difficulty_type& difficulty, uint64_t& median_weight, uint64_t& already_generated_coins, std::vector<tx_block_template_backlog_entry>& tx_backlog);
 
      /**
       * @brief called when a transaction is relayed.

--- a/src/fcmp_pp/tree_cache.cpp
+++ b/src/fcmp_pp/tree_cache.cpp
@@ -1309,6 +1309,27 @@ void TreeCache<C1, C2>::clear()
 }
 template void TreeCache<Selene, Helios>::clear();
 //----------------------------------------------------------------------------------------------------------------------
+template<typename C1, typename C2>
+crypto::ec_point TreeCache<C1, C2>::get_tree_root() const
+{
+    const uint64_t n_leaf_tuples = this->get_n_leaf_tuples();
+    if (n_leaf_tuples == 0)
+        return crypto::ec_point{};
+
+    const LeafIdx last_leaf_idx = n_leaf_tuples - 1;
+    const auto child_chunk_idxs = TreeSync<C1, C2>::m_curve_trees->get_child_chunk_indexes(n_leaf_tuples,
+        last_leaf_idx);
+    CHECK_AND_ASSERT_THROW_MES(child_chunk_idxs.size() >= 2, "unexpected empty child chunk indexes");
+    const LayerIdx last_layer_idx = child_chunk_idxs.size() - 2;
+    const auto child_chunk_it = read_child_chunk(last_layer_idx, child_chunk_idxs.back(), m_tree_elem_cache);
+
+    CHECK_AND_ASSERT_THROW_MES(child_chunk_it->second.tree_elems.size() == 1, "unexpected root layer size");
+    return child_chunk_it->second.tree_elems.back();
+}
+
+// Explicit instantiation
+template crypto::ec_point TreeCache<Selene, Helios>::get_tree_root() const;
+//----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 template<typename C1, typename C2>
 typename CurveTrees<C1, C2>::LastHashes TreeCache<C1, C2>::get_last_hashes() const

--- a/src/fcmp_pp/tree_cache.cpp
+++ b/src/fcmp_pp/tree_cache.cpp
@@ -1310,11 +1310,12 @@ void TreeCache<C1, C2>::clear()
 template void TreeCache<Selene, Helios>::clear();
 //----------------------------------------------------------------------------------------------------------------------
 template<typename C1, typename C2>
-crypto::ec_point TreeCache<C1, C2>::get_tree_root() const
+uint8_t TreeCache<C1, C2>::get_tree_root(crypto::ec_point &tree_root_out) const
 {
+    tree_root_out = crypto::ec_point{};
     const uint64_t n_leaf_tuples = this->get_n_leaf_tuples();
     if (n_leaf_tuples == 0)
-        return crypto::ec_point{};
+        return 0;
 
     const LeafIdx last_leaf_idx = n_leaf_tuples - 1;
     const auto child_chunk_idxs = TreeSync<C1, C2>::m_curve_trees->get_child_chunk_indexes(n_leaf_tuples,
@@ -1324,11 +1325,12 @@ crypto::ec_point TreeCache<C1, C2>::get_tree_root() const
     const auto child_chunk_it = read_child_chunk(last_layer_idx, child_chunk_idxs.back(), m_tree_elem_cache);
 
     CHECK_AND_ASSERT_THROW_MES(child_chunk_it->second.tree_elems.size() == 1, "unexpected root layer size");
-    return child_chunk_it->second.tree_elems.back();
+    tree_root_out = child_chunk_it->second.tree_elems.back();
+    return TreeSync<C1, C2>::m_curve_trees->n_layers(n_leaf_tuples);
 }
 
 // Explicit instantiation
-template crypto::ec_point TreeCache<Selene, Helios>::get_tree_root() const;
+template uint8_t TreeCache<Selene, Helios>::get_tree_root(crypto::ec_point &tree_root_out) const;
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 template<typename C1, typename C2>

--- a/src/fcmp_pp/tree_cache.h
+++ b/src/fcmp_pp/tree_cache.h
@@ -226,7 +226,7 @@ public:
 
     uint64_t get_output_count() const { return m_output_count; }
 
-    crypto::ec_point get_tree_root() const;
+    uint8_t get_tree_root(crypto::ec_point &tree_root_out) const;
 
     // Build the tree extension and all other types needed to grow the cache, returning the state change by ref
     void prepare_to_grow_cache(const uint64_t start_block_idx,

--- a/src/fcmp_pp/tree_cache.h
+++ b/src/fcmp_pp/tree_cache.h
@@ -226,6 +226,9 @@ public:
 
     uint64_t get_output_count() const { return m_output_count; }
 
+    // Gets the tree root and n_tree_layers for the tree currently cached in the TreeCache. If the TreeCache's tip is
+    // block index n, then this will return the tree root and n_tree_layers for the tree composed of all valid spendable
+    // outputs in the chain when the chain tip is block index n.
     uint8_t get_tree_root(crypto::ec_point &tree_root_out) const;
 
     // Build the tree extension and all other types needed to grow the cache, returning the state change by ref

--- a/src/fcmp_pp/tree_cache.h
+++ b/src/fcmp_pp/tree_cache.h
@@ -226,6 +226,8 @@ public:
 
     uint64_t get_output_count() const { return m_output_count; }
 
+    crypto::ec_point get_tree_root() const;
+
     // Build the tree extension and all other types needed to grow the cache, returning the state change by ref
     void prepare_to_grow_cache(const uint64_t start_block_idx,
         const crypto::hash &prev_block_hash,

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2166,8 +2166,9 @@ namespace cryptonote
     difficulty_type difficulty;
 
     std::vector<tx_block_template_backlog_entry> tx_backlog;
+    uint8_t fcmp_pp_n_tree_layers;
     crypto::ec_point fcmp_pp_tree_root{};
-    if (!m_core.get_miner_data(res.major_version, res.height, prev_id, fcmp_pp_tree_root, seed_hash, difficulty, res.median_weight, res.already_generated_coins, tx_backlog))
+    if (!m_core.get_miner_data(res.major_version, res.height, prev_id, fcmp_pp_n_tree_layers, fcmp_pp_tree_root, seed_hash, difficulty, res.median_weight, res.already_generated_coins, tx_backlog))
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
       error_resp.message = "Internal error: failed to get miner data";
@@ -2186,6 +2187,7 @@ namespace cryptonote
     res.prev_id = string_tools::pod_to_hex(prev_id);
     res.seed_hash = string_tools::pod_to_hex(seed_hash);
     res.difficulty = cryptonote::hex(difficulty);
+    res.fcmp_pp_n_tree_layers = fcmp_pp_n_tree_layers;
     res.fcmp_pp_tree_root = string_tools::pod_to_hex(fcmp_pp_tree_root);
 
     res.status = CORE_RPC_STATUS_OK;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -2166,7 +2166,8 @@ namespace cryptonote
     difficulty_type difficulty;
 
     std::vector<tx_block_template_backlog_entry> tx_backlog;
-    if (!m_core.get_miner_data(res.major_version, res.height, prev_id, seed_hash, difficulty, res.median_weight, res.already_generated_coins, tx_backlog))
+    crypto::ec_point fcmp_pp_tree_root{};
+    if (!m_core.get_miner_data(res.major_version, res.height, prev_id, fcmp_pp_tree_root, seed_hash, difficulty, res.median_weight, res.already_generated_coins, tx_backlog))
     {
       error_resp.code = CORE_RPC_ERROR_CODE_INTERNAL_ERROR;
       error_resp.message = "Internal error: failed to get miner data";
@@ -2185,6 +2186,7 @@ namespace cryptonote
     res.prev_id = string_tools::pod_to_hex(prev_id);
     res.seed_hash = string_tools::pod_to_hex(seed_hash);
     res.difficulty = cryptonote::hex(difficulty);
+    res.fcmp_pp_tree_root = string_tools::pod_to_hex(fcmp_pp_tree_root);
 
     res.status = CORE_RPC_STATUS_OK;
     return true;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1070,6 +1070,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint8_t major_version;
       uint64_t height;
       std::string prev_id;
+      std::string fcmp_pp_tree_root;
       std::string seed_hash;
       std::string difficulty;
       uint64_t median_weight;
@@ -1095,6 +1096,8 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE(major_version)
         KV_SERIALIZE(height)
         KV_SERIALIZE(prev_id)
+        if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+          KV_SERIALIZE(fcmp_pp_tree_root)
         KV_SERIALIZE(seed_hash)
         KV_SERIALIZE(difficulty)
         KV_SERIALIZE(median_weight)

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -1070,6 +1070,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint8_t major_version;
       uint64_t height;
       std::string prev_id;
+      uint8_t fcmp_pp_n_tree_layers;
       std::string fcmp_pp_tree_root;
       std::string seed_hash;
       std::string difficulty;
@@ -1097,7 +1098,10 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE(height)
         KV_SERIALIZE(prev_id)
         if (major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+        {
+          KV_SERIALIZE(fcmp_pp_n_tree_layers)
           KV_SERIALIZE(fcmp_pp_tree_root)
+        }
         KV_SERIALIZE(seed_hash)
         KV_SERIALIZE(difficulty)
         KV_SERIALIZE(median_weight)

--- a/src/rpc/zmq_pub.cpp
+++ b/src/rpc/zmq_pub.cpp
@@ -60,7 +60,7 @@ namespace
   constexpr const char txpool_signal[] = "tx_signal";
 
   using chain_writer =  void(epee::byte_stream&, std::uint64_t, epee::span<const cryptonote::block>);
-  using miner_writer =  void(epee::byte_stream&, uint8_t, uint64_t, const crypto::hash&, const crypto::ec_point&, const crypto::hash&, cryptonote::difficulty_type, uint64_t, uint64_t, const std::vector<cryptonote::tx_block_template_backlog_entry>&);
+  using miner_writer =  void(epee::byte_stream&, uint8_t, uint64_t, const crypto::hash&, const uint8_t, const crypto::ec_point&, const crypto::hash&, cryptonote::difficulty_type, uint64_t, uint64_t, const std::vector<cryptonote::tx_block_template_backlog_entry>&);
   using txpool_writer = void(epee::byte_stream&, epee::span<const cryptonote::txpool_event>);
 
   template<typename F>
@@ -126,6 +126,7 @@ namespace
     uint8_t major_version;
     uint64_t height;
     const crypto::hash& prev_id;
+    const uint8_t fcmp_pp_n_tree_layers;
     const crypto::ec_point& fcmp_pp_tree_root;
     const crypto::hash& seed_hash;
     cryptonote::difficulty_type diff;
@@ -173,6 +174,7 @@ namespace
     INSERT_INTO_JSON_OBJECT(dest, prev_id, self.prev_id);
     if (self.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
     {
+      INSERT_INTO_JSON_OBJECT(dest, fcmp_pp_n_tree_layers, self.fcmp_pp_n_tree_layers);
       INSERT_INTO_JSON_OBJECT(dest, fcmp_pp_tree_root, self.fcmp_pp_tree_root);
     }
     INSERT_INTO_JSON_OBJECT(dest, seed_hash, self.seed_hash);
@@ -203,9 +205,9 @@ namespace
     json_pub(buf, minimal_chain{height, blocks});
   }
 
-  void json_miner_data(epee::byte_stream& buf, uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, cryptonote::difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<cryptonote::tx_block_template_backlog_entry>& tx_backlog)
+  void json_miner_data(epee::byte_stream& buf, uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const uint8_t fcmp_pp_n_tree_layers, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, cryptonote::difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<cryptonote::tx_block_template_backlog_entry>& tx_backlog)
   {
-    json_pub(buf, miner_data{major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog});
+    json_pub(buf, miner_data{major_version, height, prev_id, fcmp_pp_n_tree_layers, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog});
   }
 
   // boost::adaptors are in place "views" - no copy/move takes place
@@ -485,7 +487,7 @@ std::size_t zmq_pub::send_chain_main(const std::uint64_t height, const epee::spa
   return 0;
 }
 
-std::size_t zmq_pub::send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog)
+std::size_t zmq_pub::send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const uint8_t fcmp_pp_n_tree_layers, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog)
 {
   boost::unique_lock<boost::mutex> guard{sync_};
 
@@ -496,7 +498,7 @@ std::size_t zmq_pub::send_miner_data(uint8_t major_version, uint64_t height, con
   {
     if (sub)
     {
-        auto messages = make_pubs(subs_copy, miner_contexts, major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
+        auto messages = make_pubs(subs_copy, miner_contexts, major_version, height, prev_id, fcmp_pp_n_tree_layers, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
         guard.lock();
         return send_messages(relay_.get(), messages);
     }
@@ -534,11 +536,11 @@ void zmq_pub::chain_main::operator()(const std::uint64_t height, epee::span<cons
     MERROR("Unable to send ZMQ/Pub - ZMQ server destroyed");
 }
 
-void zmq_pub::miner_data::operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const
+void zmq_pub::miner_data::operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const uint8_t fcmp_pp_n_tree_layers, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const
 {
   const std::shared_ptr<zmq_pub> self = self_.lock();
   if (self)
-    self->send_miner_data(major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
+    self->send_miner_data(major_version, height, prev_id, fcmp_pp_n_tree_layers, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
   else
     MERROR("Unable to send ZMQ/Pub - ZMQ server destroyed");
 }

--- a/src/rpc/zmq_pub.cpp
+++ b/src/rpc/zmq_pub.cpp
@@ -60,7 +60,7 @@ namespace
   constexpr const char txpool_signal[] = "tx_signal";
 
   using chain_writer =  void(epee::byte_stream&, std::uint64_t, epee::span<const cryptonote::block>);
-  using miner_writer =  void(epee::byte_stream&, uint8_t, uint64_t, const crypto::hash&, const crypto::hash&, cryptonote::difficulty_type, uint64_t, uint64_t, const std::vector<cryptonote::tx_block_template_backlog_entry>&);
+  using miner_writer =  void(epee::byte_stream&, uint8_t, uint64_t, const crypto::hash&, const crypto::ec_point&, const crypto::hash&, cryptonote::difficulty_type, uint64_t, uint64_t, const std::vector<cryptonote::tx_block_template_backlog_entry>&);
   using txpool_writer = void(epee::byte_stream&, epee::span<const cryptonote::txpool_event>);
 
   template<typename F>
@@ -126,6 +126,7 @@ namespace
     uint8_t major_version;
     uint64_t height;
     const crypto::hash& prev_id;
+    const crypto::ec_point& fcmp_pp_tree_root;
     const crypto::hash& seed_hash;
     cryptonote::difficulty_type diff;
     uint64_t median_weight;
@@ -170,6 +171,10 @@ namespace
     INSERT_INTO_JSON_OBJECT(dest, major_version, self.major_version);
     INSERT_INTO_JSON_OBJECT(dest, height, self.height);
     INSERT_INTO_JSON_OBJECT(dest, prev_id, self.prev_id);
+    if (self.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    {
+      INSERT_INTO_JSON_OBJECT(dest, fcmp_pp_tree_root, self.fcmp_pp_tree_root);
+    }
     INSERT_INTO_JSON_OBJECT(dest, seed_hash, self.seed_hash);
     INSERT_INTO_JSON_OBJECT(dest, difficulty, cryptonote::hex(self.diff));
     INSERT_INTO_JSON_OBJECT(dest, median_weight, self.median_weight);
@@ -198,9 +203,9 @@ namespace
     json_pub(buf, minimal_chain{height, blocks});
   }
 
-  void json_miner_data(epee::byte_stream& buf, uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::hash& seed_hash, cryptonote::difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<cryptonote::tx_block_template_backlog_entry>& tx_backlog)
+  void json_miner_data(epee::byte_stream& buf, uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, cryptonote::difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<cryptonote::tx_block_template_backlog_entry>& tx_backlog)
   {
-    json_pub(buf, miner_data{major_version, height, prev_id, seed_hash, diff, median_weight, already_generated_coins, tx_backlog});
+    json_pub(buf, miner_data{major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog});
   }
 
   // boost::adaptors are in place "views" - no copy/move takes place
@@ -480,7 +485,7 @@ std::size_t zmq_pub::send_chain_main(const std::uint64_t height, const epee::spa
   return 0;
 }
 
-std::size_t zmq_pub::send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog)
+std::size_t zmq_pub::send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog)
 {
   boost::unique_lock<boost::mutex> guard{sync_};
 
@@ -491,7 +496,7 @@ std::size_t zmq_pub::send_miner_data(uint8_t major_version, uint64_t height, con
   {
     if (sub)
     {
-        auto messages = make_pubs(subs_copy, miner_contexts, major_version, height, prev_id, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
+        auto messages = make_pubs(subs_copy, miner_contexts, major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
         guard.lock();
         return send_messages(relay_.get(), messages);
     }
@@ -529,11 +534,11 @@ void zmq_pub::chain_main::operator()(const std::uint64_t height, epee::span<cons
     MERROR("Unable to send ZMQ/Pub - ZMQ server destroyed");
 }
 
-void zmq_pub::miner_data::operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const
+void zmq_pub::miner_data::operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const
 {
   const std::shared_ptr<zmq_pub> self = self_.lock();
   if (self)
-    self->send_miner_data(major_version, height, prev_id, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
+    self->send_miner_data(major_version, height, prev_id, fcmp_pp_tree_root, seed_hash, diff, median_weight, already_generated_coins, tx_backlog);
   else
     MERROR("Unable to send ZMQ/Pub - ZMQ server destroyed");
 }

--- a/src/rpc/zmq_pub.h
+++ b/src/rpc/zmq_pub.h
@@ -95,7 +95,7 @@ class zmq_pub
     /*! Send a `ZMQ_PUB` notification for a new miner data.
         Thread-safe.
         \return Number of ZMQ messages sent to relay. */
-    std::size_t send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog);
+    std::size_t send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const uint8_t fcmp_pp_n_tree_layers, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog);
 
     /*! Send a `ZMQ_PUB` notification for new tx(es) being added to the local
         pool. Thread-safe.
@@ -113,7 +113,7 @@ class zmq_pub
     struct miner_data
     {
       std::weak_ptr<zmq_pub> self_;
-      void operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const;
+      void operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const uint8_t fcmp_pp_n_tree_layers, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const;
     };
 
     //! Callable for `send_txpool_add` with weak ownership to `zmq_pub` object.

--- a/src/rpc/zmq_pub.h
+++ b/src/rpc/zmq_pub.h
@@ -37,6 +37,7 @@
 #include <memory>
 #include <vector>
 
+#include "crypto/crypto.h"
 #include "cryptonote_basic/fwd.h"
 #include "net/zmq.h"
 #include "span.h"
@@ -94,7 +95,7 @@ class zmq_pub
     /*! Send a `ZMQ_PUB` notification for a new miner data.
         Thread-safe.
         \return Number of ZMQ messages sent to relay. */
-    std::size_t send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog);
+    std::size_t send_miner_data(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog);
 
     /*! Send a `ZMQ_PUB` notification for new tx(es) being added to the local
         pool. Thread-safe.
@@ -112,7 +113,7 @@ class zmq_pub
     struct miner_data
     {
       std::weak_ptr<zmq_pub> self_;
-      void operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const;
+      void operator()(uint8_t major_version, uint64_t height, const crypto::hash& prev_id, const crypto::ec_point& fcmp_pp_tree_root, const crypto::hash& seed_hash, difficulty_type diff, uint64_t median_weight, uint64_t already_generated_coins, const std::vector<tx_block_template_backlog_entry>& tx_backlog) const;
     };
 
     //! Callable for `send_txpool_add` with weak ownership to `zmq_pub` object.

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -305,7 +305,7 @@ bool test_generator::construct_block(cryptonote::block& blk, uint64_t height, co
     }
   }
 
-  //blk.tree_root_hash = get_tx_tree_hash(blk);
+  //blk.tree_root_hash = get_tree_hash(blk);
 
   fill_nonce(blk, get_test_difficulty(hf_ver), height);
   const uint64_t block_reward = get_outs_money_amount(blk.miner_tx) - total_fee;
@@ -344,7 +344,7 @@ bool test_generator::construct_block_manually(block& blk, const block& prev_bloc
                                               const transaction& miner_tx/* = transaction()*/,
                                               const std::vector<crypto::hash>& tx_hashes/* = std::vector<crypto::hash>()*/,
                                               size_t txs_weight/* = 0*/, size_t max_outs/* = 0*/, uint8_t hf_version/* = 1*/,
-                                              uint64_t fees/* = 0*/)
+                                              uint64_t fees/* = 0*/, const crypto::ec_point& fcmp_pp_tree_root/* = crypto::ec_point{}*/)
 {
   blk.major_version = actual_params & bf_major_ver ? major_ver : CURRENT_BLOCK_MAJOR_VERSION;
   blk.minor_version = actual_params & bf_minor_ver ? minor_ver : CURRENT_BLOCK_MINOR_VERSION;
@@ -371,7 +371,9 @@ bool test_generator::construct_block_manually(block& blk, const block& prev_bloc
       return false;
   }
 
-  //blk.tree_root_hash = get_tx_tree_hash(blk);
+  //blk.tree_root_hash = get_tree_hash(blk);
+  if (blk.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    blk.fcmp_pp_tree_root = fcmp_pp_tree_root;
 
   difficulty_type a_diffic = actual_params & bf_diffic ? diffic : get_test_difficulty(hf_version);
   fill_nonce(blk, a_diffic, height);

--- a/tests/core_tests/chaingen.cpp
+++ b/tests/core_tests/chaingen.cpp
@@ -305,8 +305,6 @@ bool test_generator::construct_block(cryptonote::block& blk, uint64_t height, co
     }
   }
 
-  //blk.tree_root_hash = get_tree_hash(blk);
-
   fill_nonce(blk, get_test_difficulty(hf_ver), height);
   const uint64_t block_reward = get_outs_money_amount(blk.miner_tx) - total_fee;
   add_block(blk, txs_weight, block_weights, already_generated_coins, block_reward, hf_ver ? hf_ver.get() : 1);
@@ -344,7 +342,8 @@ bool test_generator::construct_block_manually(block& blk, const block& prev_bloc
                                               const transaction& miner_tx/* = transaction()*/,
                                               const std::vector<crypto::hash>& tx_hashes/* = std::vector<crypto::hash>()*/,
                                               size_t txs_weight/* = 0*/, size_t max_outs/* = 0*/, uint8_t hf_version/* = 1*/,
-                                              uint64_t fees/* = 0*/, const crypto::ec_point& fcmp_pp_tree_root/* = crypto::ec_point{}*/)
+                                              uint64_t fees/* = 0*/, const uint8_t fcmp_pp_n_tree_layers/* = 0*/,
+                                              const crypto::ec_point& fcmp_pp_tree_root/* = crypto::ec_point{}*/)
 {
   blk.major_version = actual_params & bf_major_ver ? major_ver : CURRENT_BLOCK_MAJOR_VERSION;
   blk.minor_version = actual_params & bf_minor_ver ? minor_ver : CURRENT_BLOCK_MINOR_VERSION;
@@ -371,9 +370,11 @@ bool test_generator::construct_block_manually(block& blk, const block& prev_bloc
       return false;
   }
 
-  //blk.tree_root_hash = get_tree_hash(blk);
   if (blk.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+  {
+    blk.fcmp_pp_n_tree_layers = fcmp_pp_n_tree_layers;
     blk.fcmp_pp_tree_root = fcmp_pp_tree_root;
+  }
 
   difficulty_type a_diffic = actual_params & bf_diffic ? diffic : get_test_difficulty(hf_version);
   fill_nonce(blk, a_diffic, height);

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -252,7 +252,8 @@ public:
     uint8_t minor_ver = 0, uint64_t timestamp = 0, const crypto::hash& prev_id = crypto::hash(),
     const cryptonote::difficulty_type& diffic = 1, const cryptonote::transaction& miner_tx = cryptonote::transaction(),
     const std::vector<crypto::hash>& tx_hashes = std::vector<crypto::hash>(), size_t txs_sizes = 0, size_t max_outs = 999,
-    uint8_t hf_version = 1, uint64_t fees = 0, const crypto::ec_point& fcmp_pp_tree_root = crypto::ec_point{});
+    uint8_t hf_version = 1, uint64_t fees = 0, const uint8_t fcmp_pp_n_tree_layres = 0,
+    const crypto::ec_point& fcmp_pp_tree_root = crypto::ec_point{});
   bool construct_block_manually_tx(cryptonote::block& blk, const cryptonote::block& prev_block,
     const cryptonote::account_base& miner_acc, const std::vector<crypto::hash>& tx_hashes, size_t txs_size);
   void fill_nonce(cryptonote::block& blk, const cryptonote::difficulty_type& diffic, uint64_t height);

--- a/tests/core_tests/chaingen.h
+++ b/tests/core_tests/chaingen.h
@@ -252,7 +252,7 @@ public:
     uint8_t minor_ver = 0, uint64_t timestamp = 0, const crypto::hash& prev_id = crypto::hash(),
     const cryptonote::difficulty_type& diffic = 1, const cryptonote::transaction& miner_tx = cryptonote::transaction(),
     const std::vector<crypto::hash>& tx_hashes = std::vector<crypto::hash>(), size_t txs_sizes = 0, size_t max_outs = 999,
-    uint8_t hf_version = 1, uint64_t fees = 0);
+    uint8_t hf_version = 1, uint64_t fees = 0, const crypto::ec_point& fcmp_pp_tree_root = crypto::ec_point{});
   bool construct_block_manually_tx(cryptonote::block& blk, const cryptonote::block& prev_block,
     const cryptonote::account_base& miner_acc, const std::vector<crypto::hash>& tx_hashes, size_t txs_size);
   void fill_nonce(cryptonote::block& blk, const cryptonote::difficulty_type& diffic, uint64_t height);

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -231,12 +231,13 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
   // call pop_block after reading the root to reverse this if we need the cache
   // to be in the correct state after this op.
   tree_cache.sync_block(n_synced_blocks, crypto::hash{}, blocks[n_manual_blocks - 1].hash, {});
-  const crypto::ec_point fcmp_pp_tree_root = tree_cache.get_tree_root();
+  crypto::ec_point fcmp_pp_tree_root;
+  const uint8_t fcmp_pp_n_tree_layers = tree_cache.get_tree_root(fcmp_pp_tree_root);
 
   CHECK_AND_ASSERT_MES(generator.construct_block_manually(blk_txes, blk_last, miner_account,
       test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_tx_hashes | test_generator::bf_hf_version | test_generator::bf_max_outs | test_generator::bf_tx_fees,
       hf_version, hf_version, blk_last.timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
-      crypto::hash(), 0, transaction(), starting_rct_tx_hashes, 0, 6, hf_version, fees, fcmp_pp_tree_root),
+      crypto::hash(), 0, transaction(), starting_rct_tx_hashes, 0, 6, hf_version, fees, fcmp_pp_n_tree_layers, fcmp_pp_tree_root),
       false, "Failed to generate block");
   if (!valid)
     DO_CALLBACK(events, "mark_invalid_block");

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -224,10 +224,19 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
     DO_CALLBACK(events, "mark_invalid_tx");
   events.push_back(rct_txes);
 
+  // To calculate the block's tree root once this next block enters the chain,
+  // we sync an empty block so all outputs staged for insertion in the cache
+  // enter the tree. This assumes no outputs unlock in the same block they are
+  // created. It also assumes we don't need the tree cache after this. We can
+  // call pop_block after reading the root to reverse this if we need the cache
+  // to be in the correct state after this op.
+  tree_cache.sync_block(n_synced_blocks, crypto::hash{}, blocks[n_manual_blocks - 1].hash, {});
+  const crypto::ec_point fcmp_pp_tree_root = tree_cache.get_tree_root();
+
   CHECK_AND_ASSERT_MES(generator.construct_block_manually(blk_txes, blk_last, miner_account,
       test_generator::bf_major_ver | test_generator::bf_minor_ver | test_generator::bf_timestamp | test_generator::bf_tx_hashes | test_generator::bf_hf_version | test_generator::bf_max_outs | test_generator::bf_tx_fees,
       hf_version, hf_version, blk_last.timestamp + DIFFICULTY_BLOCKS_ESTIMATE_TIMESPAN * 2, // v2 has blocks twice as long
-      crypto::hash(), 0, transaction(), starting_rct_tx_hashes, 0, 6, hf_version, fees),
+      crypto::hash(), 0, transaction(), starting_rct_tx_hashes, 0, 6, hf_version, fees, fcmp_pp_tree_root),
       false, "Failed to generate block");
   if (!valid)
     DO_CALLBACK(events, "mark_invalid_block");


### PR DESCRIPTION
As soon as a block is added to the chain, we grow the chain with outputs w/last locked block 9 blocks after that block, i.e. with the earliest possible last locked block for outputs included in the block we just added. We keep the tree ahead of the chain, so that miners can immediately start mining the next block reading the root from the db without needing to do tree building themselves, and maximizing PoW built on top of a tree root for when it is later usable to construct an FCMP++ tx.