### PR TITLE
Carrot: finalize_all_proofs_from_transfer_details

### DIFF
--- a/src/carrot_impl/carrot_tx_builder_inputs.cpp
+++ b/src/carrot_impl/carrot_tx_builder_inputs.cpp
@@ -223,7 +223,6 @@ static void make_sal_proof_nominal_address_carrot_coinbase_v1(const crypto::hash
 
     crypto::secret_key sender_extension_g;
     crypto::secret_key sender_extension_t;
-    crypto::public_key address_spend_pubkey;
 
     // first, try do an internal scan of the enote
     const bool scanned = try_ecdh_and_scan_carrot_coinbase_enote(opening_hint.source_enote,

--- a/src/carrot_impl/carrot_tx_builder_utils.cpp
+++ b/src/carrot_impl/carrot_tx_builder_utils.cpp
@@ -492,6 +492,9 @@ void make_signable_tx_hash_from_carrot_transaction_proposal_v1(const CarrotTrans
     //! @TODO: better input number calculation in get_pre_mlsag_hash. possible?
     pruned_tx.rct_signatures.p.pseudoOuts.resize(pruned_tx.vin.size());
 
+    // see cryptonote::Blockchain::expand_transaction_2()
+    pruned_tx.rct_signatures.message = rct::hash2rct(cryptonote::get_transaction_prefix_hash(pruned_tx));
+
     hw::device &hwdev = hw::get_device("default");
     const rct::key signable_tx_hash_k = rct::get_pre_mlsag_hash(pruned_tx.rct_signatures, hwdev);
 

--- a/src/carrot_impl/carrot_tx_format_utils.cpp
+++ b/src/carrot_impl/carrot_tx_format_utils.cpp
@@ -284,7 +284,7 @@ bool try_load_carrot_from_transaction_v1(const cryptonote::transaction &tx,
         return false;
 
     const size_t n_ephemeral = enote_ephemeral_pubkeys.size();
-    if (n_ephemeral < 0 || n_ephemeral > nouts)
+    if (n_ephemeral == 0 || n_ephemeral > nouts)
         return false;
 
     // collect D_e
@@ -391,7 +391,7 @@ bool try_load_carrot_from_coinbase_transaction_v1(const cryptonote::transaction 
 }
 //-------------------------------------------------------------------------------------------------------------------
 rct::rctSigPrunable store_fcmp_proofs_to_rct_prunable_v1(
-    std::vector<rct::BulletproofPlus> &&bulletproofs_plus,
+    rct::BulletproofPlus &&bulletproof_plus,
     const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
     const std::vector<fcmp_pp::FcmpPpSalProof> &sal_proofs,
     const fcmp_pp::FcmpMembershipProof &membership_proof,
@@ -436,7 +436,7 @@ rct::rctSigPrunable store_fcmp_proofs_to_rct_prunable_v1(
         "store fcmp proofs to rct prunable v1: bug: bad proof building");
 
     return rct::rctSigPrunable{
-        .bulletproofs_plus = std::move(bulletproofs_plus),
+        .bulletproofs_plus = {bulletproof_plus},
         .pseudoOuts = std::move(pseudoOuts),
         .reference_block = fcmp_reference_block,
         .n_tree_layers = n_tree_layers,

--- a/src/carrot_impl/carrot_tx_format_utils.h
+++ b/src/carrot_impl/carrot_tx_format_utils.h
@@ -124,7 +124,7 @@ bool try_load_carrot_from_coinbase_transaction_v1(const cryptonote::transaction 
     std::vector<CarrotCoinbaseEnoteV1> &enotes_out);
 /**
  * brief: store_fcmp_proofs_to_rct_prunable_v1 -
- * param: bulletproofs_plus -
+ * param: bulletproof_plus -
  * param: rerandomized_outputs -
  * param: sal_proofs -
  * param: membership_proof -
@@ -133,7 +133,7 @@ bool try_load_carrot_from_coinbase_transaction_v1(const cryptonote::transaction 
  * return: prunable RCT signature data that can be attached to corresponding pruned tx
  */
 rct::rctSigPrunable store_fcmp_proofs_to_rct_prunable_v1(
-    std::vector<rct::BulletproofPlus> &&bulletproofs_plus,
+    rct::BulletproofPlus &&bulletproof_plus,
     const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
     const std::vector<fcmp_pp::FcmpPpSalProof> &sal_proofs,
     const fcmp_pp::FcmpMembershipProof &membership_proof,

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -371,6 +371,7 @@ inline const unsigned char* to_bytes(const crypto::ec_scalar &scalar) { return &
 inline unsigned char* to_bytes(crypto::ec_point &point) { return &reinterpret_cast<unsigned char&>(point); }
 inline const unsigned char* to_bytes(const crypto::ec_point &point) { return &reinterpret_cast<const unsigned char&>(point); }
 
+CRYPTO_MAKE_HASHABLE(ec_point)
 CRYPTO_MAKE_HASHABLE(public_key)
 CRYPTO_MAKE_HASHABLE_CONSTANT_TIME(secret_key)
 CRYPTO_MAKE_HASHABLE_CONSTANT_TIME(public_key_memsafe)

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3292,7 +3292,7 @@ bool Blockchain::have_tx_keyimges_as_spent(const transaction &tx) const
   }
   return false;
 }
-bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, uint8_t *tree_root)
+bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const uint8_t *tree_root)
 {
   PERF_TIMER(expand_transaction_2);
   CHECK_AND_ASSERT_MES(tx.version == 2, false, "Transaction version is not 2");

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -614,7 +614,7 @@ namespace cryptonote
      * can be reconstituted by the receiver. This function expands
      * that implicit data.
      */
-    static bool expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, uint8_t *tree_root);
+    static bool expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const uint8_t *tree_root);
 
     /**
      * @brief validates a transaction's inputs

--- a/src/fcmp_pp/curve_trees.h
+++ b/src/fcmp_pp/curve_trees.h
@@ -294,7 +294,7 @@ public:
             c2_layers.clear();
         }
 
-        bool empty() { return leaves.empty() && c1_layers.empty() && c2_layers.empty(); }
+        bool empty() const { return leaves.empty() && c1_layers.empty() && c2_layers.empty(); }
     };
 
     // A path ready to be used to construct an FCMP++ proof

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -91,7 +91,7 @@ struct ProofParams final
 
 struct FcmpVerifyHelperData final
 {
-    uint8_t *tree_root;
+    const uint8_t *tree_root; // borrowing, *not* owning
     std::vector<crypto::key_image> key_images;
 };
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -380,7 +380,7 @@ std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signa
     return {std::move(p), L};
 }
 //----------------------------------------------------------------------------------------------------------------------
-FcmpMembershipProof prove_membership(const std::vector<const uint8_t *> &fcmp_prove_inputs,
+FcmpMembershipProof prove_membership(const std::vector<uint8_t *> &fcmp_prove_inputs,
     const std::size_t n_tree_layers)
 {
     FcmpPpSalProof p;

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -111,7 +111,7 @@ std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signa
     const crypto::secret_key &y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-FcmpMembershipProof prove_membership(const std::vector<const uint8_t *> &fcmp_prove_inputs,
+FcmpMembershipProof prove_membership(const std::vector<uint8_t *> &fcmp_prove_inputs,
     const std::size_t n_tree_layers);
 
 uint8_t *fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -70,7 +70,7 @@ carrot::CarrotTransactionProposalV1 make_carrot_transaction_proposal_wallet2_tra
     const rct::xmr_amount ignore_below,
     const wallet2::unique_index_container &subtract_fee_from_outputs,
     const std::uint64_t top_block_index,
-    const cryptonote::account_base &acb);
+    const cryptonote::account_keys &acc_keys);
 
 carrot::CarrotTransactionProposalV1 make_carrot_transaction_proposal_wallet2_transfer(
     const wallet2::transfer_container &transfers,
@@ -83,7 +83,7 @@ carrot::CarrotTransactionProposalV1 make_carrot_transaction_proposal_wallet2_tra
     const rct::xmr_amount ignore_above,
     const rct::xmr_amount ignore_below,
     const std::uint64_t top_block_index,
-    const cryptonote::account_base &acb);
+    const cryptonote::account_keys &acc_keys);
 
 carrot::CarrotTransactionProposalV1 make_carrot_transaction_proposal_wallet2_sweep(
     const wallet2::transfer_container &transfers,
@@ -95,7 +95,7 @@ carrot::CarrotTransactionProposalV1 make_carrot_transaction_proposal_wallet2_swe
     const rct::xmr_amount fee_per_weight,
     const std::vector<uint8_t> &extra,
     const std::uint64_t top_block_index,
-    const cryptonote::account_base &acb);
+    const cryptonote::account_keys &acc_keys);
 
 carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(
     const wallet2::transfer_details &td,
@@ -106,6 +106,14 @@ std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_trans
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
     const wallet2::transfer_container &transfers,
+    const cryptonote::account_keys &acc_keys);
+
+//! @TODO: accept already-calculated rerandomized outputs and their blinds
+cryptonote::transaction finalize_all_proofs_from_transfer_details(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const wallet2::transfer_container &transfers,
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
     const cryptonote::account_keys &acc_keys);
 } //namespace wallet
 } //namespace tools

--- a/tests/crypto/main.cpp
+++ b/tests/crypto/main.cpp
@@ -49,10 +49,6 @@ bool operator !=(const ec_scalar &a, const ec_scalar &b) {
   return 0 != memcmp(&a, &b, sizeof(ec_scalar));
 }
 
-bool operator !=(const ec_point &a, const ec_point &b) {
-  return 0 != memcmp(&a, &b, sizeof(ec_point));
-}
-
 bool operator !=(const key_derivation &a, const key_derivation &b) {
   return 0 != memcmp(&a, &b, sizeof(key_derivation));
 }

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -416,8 +416,8 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
 
     // Generate bulletproof+
     LOG_PRINT_L1("Generating Bulletproof+");
-    tx.rct_signatures.p.bulletproofs_plus.push_back(rct::bulletproof_plus_PROVE(output_amounts, output_amount_blinding_factors));
-    ASSERT_EQ(n_outputs, tx.rct_signatures.p.bulletproofs_plus.at(0).V.size());
+    rct::BulletproofPlus bpp = rct::bulletproof_plus_PROVE(output_amounts, output_amount_blinding_factors);
+    ASSERT_EQ(n_outputs, bpp.V.size());
 
     // expand tx and calculate signable tx hash
     LOG_PRINT_L1("Calculating signable tx hash");
@@ -529,7 +529,7 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
 
     // Make FCMP membership proof
     LOG_PRINT_L1("Generating FCMP++ membership proofs");
-    std::vector<const uint8_t*> fcmp_proof_inputs_rust;
+    std::vector<uint8_t*> fcmp_proof_inputs_rust;
     for (size_t i = 0; i < n_inputs; ++i)
     {
         fcmp_pp::ProofInput &proof_input = fcmp_proof_inputs.at(i);
@@ -550,13 +550,13 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
         n_tree_layers);
 
     // Dealloc FCMP proof inputs
-    for (const uint8_t *proof_input : fcmp_proof_inputs_rust)
-      free(const_cast<uint8_t*>(proof_input));
+    for (uint8_t *proof_input : fcmp_proof_inputs_rust)
+      free(proof_input);
 
     // Attach rctSigPrunable to tx
     LOG_PRINT_L1("Storing rctSig prunable");
     const std::uint64_t fcmp_block_reference_index = mock::gen_block_index();
-    tx.rct_signatures.p = store_fcmp_proofs_to_rct_prunable_v1(std::move(tx.rct_signatures.p.bulletproofs_plus),
+    tx.rct_signatures.p = store_fcmp_proofs_to_rct_prunable_v1(std::move(bpp),
         rerandomized_outputs,
         sal_proofs,
         membership_proof,

--- a/tests/unit_tests/crypto.cpp
+++ b/tests/unit_tests/crypto.cpp
@@ -499,3 +499,13 @@ TEST(Crypto, torsion_check_torsioned_point)
   const rct::key cleared = fcmp_pp::clear_torsion(x);
   ASSERT_NE(k, cleared);
 }
+
+TEST(Crypto, genesis_tx_output_torsion)
+{
+  rct::key k;
+  // see config::GENESIS_TX
+  epee::string_tools::hex_to_pod("9b2e4c0281c0b02e7c53291a94d1d0cbff8883f8024f5142ee494ffbbd088071", k);
+  ge_p3 x;
+  ASSERT_EQ(ge_frombytes_vartime(&x, k.bytes), 0);
+  EXPECT_FALSE(rct::isInMainSubgroup(k));
+}

--- a/tests/unit_tests/fake_pruned_blockchain.cpp
+++ b/tests/unit_tests/fake_pruned_blockchain.cpp
@@ -38,6 +38,7 @@
 #include "carrot_impl/carrot_tx_format_utils.h"
 #include "common/container_helpers.h"
 #include "crypto/generators.h"
+#include "ringct/rctOps.h"
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "unit_tests.fake_pruned_bc"
@@ -45,11 +46,119 @@
 namespace mock
 {
 //----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+static constexpr std::size_t selene_chunk_width = fcmp_pp::curve_trees::SELENE_CHUNK_WIDTH;
+static constexpr std::size_t helios_chunk_width = fcmp_pp::curve_trees::HELIOS_CHUNK_WIDTH;
+const auto curve_trees = fcmp_pp::curve_trees::curve_trees_v1(selene_chunk_width, helios_chunk_width);
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+template <class C>
+static bool compare_curve_point(const typename C::Point &p1, const typename C::Point &p2)
+{
+    const crypto::ec_point p1_compressed = C().to_bytes(p1);
+    const crypto::ec_point p2_compressed = C().to_bytes(p2);
+    return p1_compressed == p2_compressed;
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+template <class C>
+static bool compare_curve_layer(const std::vector<typename C::Point> &p1s,
+    const std::vector<typename C::Point> &p2s)
+{
+    if (p1s.size() != p2s.size())
+        return false;
+    for (size_t i = 0; i < p1s.size(); ++i)
+    {
+        if (!compare_curve_point<C>(p1s.at(i), p2s.at(i)))
+            return false;
+    }
+    return true;
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+template <class C>
+static bool compare_curve_chunks(const std::vector<std::vector<typename C::Point>> &chunks1,
+    const std::vector<std::vector<typename C::Point>> &chunks2)
+{
+    if (chunks1.size() != chunks2.size())
+        return false;
+    for (size_t i = 0; i < chunks1.size(); ++i)
+    {
+        if (!compare_curve_layer<C>(chunks1.at(i), chunks2.at(i)))
+            return false;
+    }
+    return true;
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+static bool compare_output_tuple(const fcmp_pp::curve_trees::OutputTuple &tup1,
+    const fcmp_pp::curve_trees::OutputTuple &tup2)
+{
+    return tup1.O == tup2.O && tup1.I == tup2.I && tup1.C == tup2.C;
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+static bool compare_leaf_layer(const std::vector<fcmp_pp::curve_trees::OutputTuple> &leaves1,
+    const std::vector<fcmp_pp::curve_trees::OutputTuple> &leaves2)
+{
+    MDEBUG("compare_leaf_layer: " << leaves1.size() << " vs " << leaves2.size());
+    if (leaves1.size() != leaves2.size())
+        return false;
+    bool r = true;
+    for (size_t i = 0; i < leaves1.size(); ++i)
+    {
+        MDEBUG("    Leaf O: " << leaves1.at(i).O << " vs " << leaves2.at(i).O);
+        if (!compare_output_tuple(leaves1.at(i), leaves2.at(i)))
+            r = false;
+    }
+    return r;
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+static bool compare_paths_between_tree_cache_and_global_tree(
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const CurveTreesGlobalTree &global_tree,
+    const std::vector<fcmp_pp::curve_trees::OutputContext> &leaves)
+{
+    // this check compares the paths returned by tree_cache and global_tree against each other for a
+    // given set of leaves
+
+    using namespace fcmp_pp::curve_trees;
+
+    CHECK_AND_ASSERT_MES(tree_cache.get_n_leaf_tuples() == global_tree.get_n_leaf_tuples(), false, 
+        "mismatch in number of leaf tuples");
+    for (const OutputContext &leaf : leaves)
+    {
+        CurveTreesV1::Path path_in_cache;
+        CHECK_AND_ASSERT_THROW_MES(tree_cache.get_output_path(leaf.output_pair, path_in_cache),
+            "could not get path from tree cache");
+        const CurveTreesV1::Path path_in_global =
+            global_tree.get_path_at_leaf_idx(leaf.output_id);
+        CHECK_AND_ASSERT_MES(compare_leaf_layer(path_in_cache.leaves, path_in_global.leaves), false,
+            "paths' leaves are not equal");
+        CHECK_AND_ASSERT_MES(compare_curve_chunks<Selene>(path_in_cache.c1_layers, path_in_global.c1_layers),
+            false,
+            "paths' c1 layers are not equal");
+        CHECK_AND_ASSERT_MES(compare_curve_chunks<Helios>(path_in_cache.c2_layers, path_in_global.c2_layers),
+            false,
+            "paths' c2 layers are not equal");
+    }
+    return true;
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+static bool is_valid_output_pair_for_tree(const fcmp_pp::curve_trees::OutputPair &p)
+{
+    return rct::isInMainSubgroup(rct::pk2rct(p.output_pubkey)) && rct::isInMainSubgroup(p.commitment);
+}
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 bool construct_miner_tx_fake_reward_1out(const size_t height,
     const rct::xmr_amount reward,
     const cryptonote::account_public_address &miner_address,
     cryptonote::transaction& tx,
-    const uint8_t hf_version)
+    const uint8_t hf_version,
+    const size_t num_tx_outputs)
 {
     const bool is_carrot = hf_version >= HF_VERSION_CARROT;
     if (is_carrot)
@@ -58,15 +167,20 @@ bool construct_miner_tx_fake_reward_1out(const size_t height,
         make_carrot_main_address_v1(miner_address.m_spend_public_key,
             miner_address.m_view_public_key,
             miner_destination);
-        
-        const carrot::CarrotPaymentProposalV1 normal_payment_proposal{
-            .destination = miner_destination,
-            .amount = reward,
-            .randomness = carrot::gen_janus_anchor()
-        };
+
+        std::vector<carrot::CarrotPaymentProposalV1> normal_payment_proposals;
+        normal_payment_proposals.reserve(num_tx_outputs);
+        for (size_t i = 0; i < num_tx_outputs; ++i)
+        {
+            normal_payment_proposals.push_back(carrot::CarrotPaymentProposalV1{
+                .destination = miner_destination,
+                .amount = reward,
+                .randomness = carrot::gen_janus_anchor()
+            });
+        }
 
         std::vector<carrot::CarrotCoinbaseEnoteV1> coinbase_enotes;
-        carrot::get_coinbase_output_enotes({normal_payment_proposal},
+        carrot::get_coinbase_output_enotes(normal_payment_proposals,
             height,
             coinbase_enotes);
 
@@ -81,34 +195,6 @@ bool construct_miner_tx_fake_reward_1out(const size_t height,
         cryptonote::txin_gen in;
         in.height = height;
 
-        cryptonote::keypair txkey = cryptonote::keypair::generate(hw::get_device("default"));
-        cryptonote::add_tx_pub_key_to_extra(tx, txkey.pub);
-        if (!cryptonote::sort_tx_extra(tx.extra, tx.extra))
-            return false;
-
-        crypto::key_derivation derivation;
-        crypto::public_key out_eph_public_key;
-        bool r = crypto::generate_key_derivation(miner_address.m_view_public_key, txkey.sec, derivation);
-        CHECK_AND_ASSERT_MES(r, false,
-            "while creating outs: failed to generate_key_derivation(" << miner_address.m_view_public_key << ", "
-            << crypto::secret_key_explicit_print_ref{txkey.sec} << ")");
-
-        const size_t local_output_index = 0;
-        r = crypto::derive_public_key(derivation, local_output_index, miner_address.m_spend_public_key, out_eph_public_key);
-        CHECK_AND_ASSERT_MES(r, false,
-            "while creating outs: failed to derive_public_key(" << derivation << ", "
-            << local_output_index << ", "<< miner_address.m_spend_public_key << ")");
-
-        const bool use_view_tags = hf_version >= HF_VERSION_VIEW_TAGS;
-        crypto::view_tag view_tag;
-        if (use_view_tags)
-            crypto::derive_view_tag(derivation, local_output_index, view_tag);
-
-        cryptonote::tx_out out;
-        cryptonote::set_tx_out(reward, out_eph_public_key, use_view_tags, view_tag, out);
-
-        tx.vout.push_back(out);
-
         if (hf_version >= 4)
             tx.version = 2;
         else
@@ -116,6 +202,37 @@ bool construct_miner_tx_fake_reward_1out(const size_t height,
 
         tx.unlock_time = height + CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
         tx.vin.push_back(in);
+
+        for (size_t i = 0; i < num_tx_outputs; ++i)
+        {
+            cryptonote::keypair txkey = cryptonote::keypair::generate(hw::get_device("default"));
+            cryptonote::add_tx_pub_key_to_extra(tx, txkey.pub);
+            if (!cryptonote::sort_tx_extra(tx.extra, tx.extra))
+                return false;
+
+            crypto::key_derivation derivation;
+            crypto::public_key out_eph_public_key;
+            bool r = crypto::generate_key_derivation(miner_address.m_view_public_key, txkey.sec, derivation);
+            CHECK_AND_ASSERT_MES(r, false,
+                "while creating outs: failed to generate_key_derivation(" << miner_address.m_view_public_key << ", "
+                << crypto::secret_key_explicit_print_ref{txkey.sec} << ")");
+
+            const size_t local_output_index = 0;
+            r = crypto::derive_public_key(derivation, local_output_index, miner_address.m_spend_public_key, out_eph_public_key);
+            CHECK_AND_ASSERT_MES(r, false,
+                "while creating outs: failed to derive_public_key(" << derivation << ", "
+                << local_output_index << ", "<< miner_address.m_spend_public_key << ")");
+
+            const bool use_view_tags = hf_version >= HF_VERSION_VIEW_TAGS;
+            crypto::view_tag view_tag;
+            if (use_view_tags)
+                crypto::derive_view_tag(derivation, local_output_index, view_tag);
+
+            cryptonote::tx_out out;
+            cryptonote::set_tx_out(reward, out_eph_public_key, use_view_tags, view_tag, out);
+
+            tx.vout.push_back(out);
+        }
 
         tx.invalidate_hashes();
     }
@@ -126,10 +243,11 @@ bool construct_miner_tx_fake_reward_1out(const size_t height,
 cryptonote::transaction construct_miner_tx_fake_reward_1out(const size_t height,
     const rct::xmr_amount reward,
     const cryptonote::account_public_address &miner_address,
-    const uint8_t hf_version)
+    const uint8_t hf_version,
+    const size_t num_tx_outputs)
 {
     cryptonote::transaction tx;
-    const bool r = construct_miner_tx_fake_reward_1out(height, reward, miner_address, tx, hf_version);
+    const bool r = construct_miner_tx_fake_reward_1out(height, reward, miner_address, tx, hf_version, num_tx_outputs);
     CHECK_AND_ASSERT_THROW_MES(r, "failed to construct miner tx");
     return tx;
 }
@@ -189,7 +307,7 @@ cryptonote::tx_source_entry gen_tx_source_entry_fake_members(
 //----------------------------------------------------------------------------------------------------------------------
 cryptonote::transaction construct_pre_carrot_tx_with_fake_inputs(
     const cryptonote::account_keys &sender_account_keys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses,
+    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &sender_subaddress_map,
     std::vector<stripped_down_tx_source_entry_t> &&stripped_sources,
     std::vector<cryptonote::tx_destination_entry> &destinations,
     const boost::optional<cryptonote::account_public_address> &change_addr,
@@ -296,7 +414,7 @@ cryptonote::transaction construct_pre_carrot_tx_with_fake_inputs(
     fcmp_pp::ProofParams dummy_fcmp_params;
     const bool r = cryptonote::construct_tx_and_get_tx_key(
         sender_account_keys,
-        subaddresses,
+        sender_subaddress_map,
         sources,
         destinations,
         change_addr,
@@ -310,6 +428,28 @@ cryptonote::transaction construct_pre_carrot_tx_with_fake_inputs(
         use_view_tags);
     CHECK_AND_ASSERT_THROW_MES(r, "failed to construct tx");
     return tx;
+}
+//----------------------------------------------------------------------------------------------------------------------
+cryptonote::transaction construct_pre_carrot_tx_with_fake_inputs(
+    std::vector<cryptonote::tx_destination_entry> &destinations,
+    const rct::xmr_amount fee,
+    const uint8_t hf_version,
+    const bool sweep_unmixable_override)
+{
+    cryptonote::account_base aether_acb;
+    aether_acb.generate();
+    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> sender_subaddress_map = {
+        { aether_acb.get_keys().m_account_address.m_spend_public_key, {0, 0 } }
+    };
+
+    return construct_pre_carrot_tx_with_fake_inputs(aether_acb.get_keys(),
+        sender_subaddress_map,
+        /*stripped_sources=*/{},
+        destinations,
+        /*change_addr*/boost::none,
+        fee,
+        hf_version,
+        sweep_unmixable_override);
 }
 //----------------------------------------------------------------------------------------------------------------------
 cryptonote::transaction construct_carrot_pruned_transaction_fake_inputs(
@@ -358,9 +498,20 @@ const cryptonote::account_public_address null_addr{
     .m_view_public_key = crypto::get_G()
 };
 //----------------------------------------------------------------------------------------------------------------------
+fake_pruned_blockchain::fake_pruned_blockchain(const uint64_t start_block_index,
+    const cryptonote::network_type nettype):
+    m_start_block_index(start_block_index),
+    m_nettype(nettype),
+    m_num_outputs(0),
+    m_global_curve_tree(*curve_trees)
+{
+    add_starting_block();
+}
+//----------------------------------------------------------------------------------------------------------------------
 void fake_pruned_blockchain::add_block(const uint8_t hf_version,
     std::vector<cryptonote::transaction> &&txs,
-    const cryptonote::account_public_address &miner_address)
+    const cryptonote::account_public_address &miner_address,
+    const size_t num_miner_tx_outputs)
 {
     std::vector<crypto::hash> tx_prunable_hashes(txs.size());
     std::vector<crypto::hash> tx_hashes(txs.size());
@@ -384,7 +535,8 @@ void fake_pruned_blockchain::add_block(const uint8_t hf_version,
     cryptonote::transaction miner_tx = construct_miner_tx_fake_reward_1out(this->height(),
         miner_reward,
         miner_address,
-        hf_version);
+        hf_version,
+        num_miner_tx_outputs);
 
     cryptonote::block blk;
     blk.major_version = hf_version;
@@ -402,22 +554,37 @@ void fake_pruned_blockchain::add_block(cryptonote::block &&blk,
     std::vector<cryptonote::transaction> &&pruned_txs,
     std::vector<crypto::hash> &&prunable_hashes)
 {
+    // sanity checks and block rules
     assert_chain_count();
     CHECK_AND_ASSERT_THROW_MES(blk.major_version >= this->hf_version(), 
         "hf version too low");
+    CHECK_AND_ASSERT_THROW_MES(blk.miner_tx.vin.size() == 1,
+        "miner tx wrong input count");
+    CHECK_AND_ASSERT_THROW_MES(blk.miner_tx.vin.front().type() == typeid(cryptonote::txin_gen),
+        "miner tx wrong input type");
+    CHECK_AND_ASSERT_THROW_MES(boost::get<cryptonote::txin_gen>(blk.miner_tx.vin.front()).height == this->height(),
+        "miner tx wrong height");
+    CHECK_AND_ASSERT_THROW_MES(blk.miner_tx.unlock_time == this->height() + CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW,
+        "miner tx wrong unlock time");
     CHECK_AND_ASSERT_THROW_MES(blk.tx_hashes.size() == pruned_txs.size(),
         "wrong number of txs provided");
     CHECK_AND_ASSERT_THROW_MES(blk.tx_hashes.size() == prunable_hashes.size(),
         "wrong number of prunable hashes provided");
+    CHECK_AND_ASSERT_THROW_MES(m_parsed_blocks.empty() || m_parsed_blocks.back().hash == blk.prev_id,
+        "wrong block prev_id");
 
+    // calculate weight and num outputs in block
     size_t total_block_weight = 0;
+    size_t num_new_block_outputs = blk.miner_tx.vout.size();
     for (const cryptonote::transaction &tx : pruned_txs)
     {
         total_block_weight += tx.pruned
                 ? cryptonote::get_pruned_transaction_weight(tx)
                 : cryptonote::get_transaction_weight(tx);
+        num_new_block_outputs += tx.vout.size();
     }
 
+    // make block_complete_entry
     cryptonote::block_complete_entry blk_entry;
     blk_entry.pruned = true;
     blk_entry.block = cryptonote::block_to_blob(blk);
@@ -431,35 +598,113 @@ void fake_pruned_blockchain::add_block(cryptonote::block &&blk,
         blk_entry.txs.push_back(cryptonote::tx_blob_entry(ss.str(), prunable_hashes.at(i)));
     }
 
+    size_t running_num_chain_outputs = m_num_outputs;
+
+    // make parsed_block
     tools::wallet2::parsed_block par_blk;
     par_blk.hash = cryptonote::get_block_hash(blk);
     par_blk.block = std::move(blk);
     par_blk.txes = std::move(pruned_txs);
     {
         auto &tx_o_indices = tools::add_element(par_blk.o_indices.indices);
-        for (size_t n = 0; n < par_blk.block.miner_tx.vout.size(); ++n)
-            tx_o_indices.indices.push_back(m_output_index++);
+        for (size_t i = 0; i < par_blk.block.miner_tx.vout.size(); ++i)
+        {
+            tx_o_indices.indices.push_back(running_num_chain_outputs);
+            ++running_num_chain_outputs;
+        }
     }
     for (const cryptonote::transaction &tx : par_blk.txes)
     {
+        CHECK_AND_ASSERT_THROW_MES(tx.unlock_time == 0,
+            "I don't want to code tree logic for custom unlock times plz");
         auto &tx_o_indices = tools::add_element(par_blk.o_indices.indices);
-        for (size_t n = 0; n < tx.vout.size(); ++n)
-            tx_o_indices.indices.push_back(m_output_index++);
+        for (size_t i = 0; i < tx.vout.size(); ++i)
+        {
+            tx_o_indices.indices.push_back(running_num_chain_outputs);
+            ++running_num_chain_outputs;
+        }
     }
     par_blk.error = false;
 
+    CHECK_AND_ASSERT_THROW_MES(running_num_chain_outputs - m_num_outputs == num_new_block_outputs,
+        "new block output count mismatch (1)");
+
+    const size_t next_height = this->height() + 1;
+    const bool should_try_expand_fcmp_tree = next_height >= CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE;
+    if (should_try_expand_fcmp_tree)
+    {
+        // pull miner outputs from CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW blocks ago, 
+        // and non-miner outputs from CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE blocks ago
+        const bool should_try_pull_coinbase_outs = next_height >= CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW;
+        static_assert(CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW >= CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE,
+            "Cannot assume that we should always try pulling non-miner outputs when we can pull miner outputs");
+
+        std::vector<fcmp_pp::curve_trees::OutputContext> new_spendable_outputs;
+        if (should_try_pull_coinbase_outs)
+        {
+            const tools::wallet2::parsed_block parsed_block_with_unlocked_miner_tx = 
+                this->get_parsed_block(next_height - CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW);
+            const cryptonote::transaction &unlocked_miner_tx =
+                parsed_block_with_unlocked_miner_tx.block.miner_tx;
+            for (size_t local_output_index = 0; local_output_index < unlocked_miner_tx.vout.size(); ++local_output_index)
+            {
+                const cryptonote::tx_out &o = unlocked_miner_tx.vout.at(local_output_index);
+                crypto::public_key output_pubkey;
+                CHECK_AND_ASSERT_THROW_MES(cryptonote::get_output_public_key(o, output_pubkey),
+                    "cannot get output pubkey");
+                const rct::key amount_commitment = rct::zeroCommitVartime(o.amount);
+                const fcmp_pp::curve_trees::OutputPair output_pair{output_pubkey, amount_commitment};
+                if (!is_valid_output_pair_for_tree(output_pair))
+                    continue;
+                const uint64_t global_output_index =
+                    parsed_block_with_unlocked_miner_tx.o_indices.indices.at(0).indices.at(local_output_index);
+                new_spendable_outputs.push_back(fcmp_pp::curve_trees::OutputContext{
+                    global_output_index, output_pair
+                });
+            }
+        }
+
+        const tools::wallet2::parsed_block parsed_block_with_unlocked_txs = 
+            this->get_parsed_block(next_height - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
+        for (size_t tx_index = 0; tx_index < parsed_block_with_unlocked_txs.txes.size(); ++tx_index)
+        {
+            const cryptonote::transaction &unlocked_tx = parsed_block_with_unlocked_txs.txes.at(tx_index);
+            for (size_t local_output_index = 0; local_output_index < unlocked_tx.vout.size(); ++local_output_index)
+            {
+                const cryptonote::tx_out &o = unlocked_tx.vout.at(local_output_index);
+                crypto::public_key output_pubkey;
+                CHECK_AND_ASSERT_THROW_MES(cryptonote::get_output_public_key(o, output_pubkey),
+                    "cannot get output pubkey");
+                const rct::key amount_commitment = o.amount
+                    ? rct::zeroCommitVartime(o.amount) : unlocked_tx.rct_signatures.outPk.at(local_output_index).mask;
+                const fcmp_pp::curve_trees::OutputPair output_pair{output_pubkey, amount_commitment};
+                if (!is_valid_output_pair_for_tree(output_pair))
+                    continue;
+                const uint64_t global_output_index =
+                    parsed_block_with_unlocked_txs.o_indices.indices.at(tx_index + 1).indices.at(local_output_index);
+                new_spendable_outputs.push_back(fcmp_pp::curve_trees::OutputContext{
+                    global_output_index, output_pair
+                });
+            }
+        }
+
+        if (!new_spendable_outputs.empty())
+        {
+            const bool tree_grow_success = m_global_curve_tree.grow_tree(
+                m_global_curve_tree.get_n_leaf_tuples(),
+                new_spendable_outputs.size(),
+                new_spendable_outputs);
+
+            CHECK_AND_ASSERT_THROW_MES(tree_grow_success,
+                "fake_pruned_blockchain::add_block: error while growing tree!!!");
+        }
+    }
+
+    // everything looks good! time to update fields
+    m_num_outputs = running_num_chain_outputs;
     m_block_entries.emplace_back(std::move(blk_entry));
     m_parsed_blocks.emplace_back(std::move(par_blk));
-}
-//----------------------------------------------------------------------------------------------------------------------
-void fake_pruned_blockchain::pop_block()
-{
-    assert_chain_count();
-
-    CHECK_AND_ASSERT_THROW_MES(m_block_entries.size() >= 2, "Cannot pop starting block");
-
-    m_block_entries.pop_back();
-    m_parsed_blocks.pop_back();
+    m_curve_tree_roots.emplace_back(make_fcmp_generic_object(m_global_curve_tree.get_tree_root()));
 }
 //----------------------------------------------------------------------------------------------------------------------
 void fake_pruned_blockchain::get_blocks_data(const uint64_t start_block_index,
@@ -486,7 +731,7 @@ void fake_pruned_blockchain::get_blocks_data(const uint64_t start_block_index,
 void fake_pruned_blockchain::init_wallet_for_starting_block(tools::wallet2 &w) const
 {
     assert_chain_count();
-    CHECK_AND_ASSERT_THROW_MES(!m_block_entries.empty(), "blockchain missing starting block");
+    CHECK_AND_ASSERT_THROW_MES(!m_parsed_blocks.empty(), "blockchain missing starting block");
 
     w.set_refresh_from_block_height(m_start_block_index);
 
@@ -502,6 +747,52 @@ void fake_pruned_blockchain::init_wallet_for_starting_block(tools::wallet2 &w) c
         /*n_leaf_tuples=*/0,
         /*last_path=*/{},
         /*locked_outputs=*/{});
+}
+//----------------------------------------------------------------------------------------------------------------------
+uint64_t fake_pruned_blockchain::refresh_wallet(tools::wallet2 &w, const size_t start_height) const
+{
+    // fetch blocks data
+    std::vector<cryptonote::block_complete_entry> blk_entries;
+    std::vector<tools::wallet2::parsed_block> parsed_blks;
+    this->get_blocks_data(start_height, this->height()-1, blk_entries, parsed_blks);
+
+    // wallet process blocks data
+    uint64_t blocks_added;
+    auto output_tracker_cache = w.create_output_tracker_cache();
+    w.process_parsed_blocks(start_height, blk_entries, parsed_blks, blocks_added, output_tracker_cache);
+
+    // collect paths_to_check
+    std::vector<fcmp_pp::curve_trees::OutputContext> paths_to_check;
+    paths_to_check.reserve(w.m_transfers.size());
+    for (const tools::wallet2::transfer_details &td : w.m_transfers)
+    {
+        const uint64_t unlock_block_index = td.m_tx.unlock_time
+            ? td.m_tx.unlock_time
+            : (td.m_block_height +  CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
+        if (unlock_block_index > this->height())
+            continue;
+        paths_to_check.push_back({td.m_global_output_index, td.get_output_pair()});
+    }
+
+    // check effective FCMP tree equality between blockchain and wallet
+    const bool tree_cache_and_global_tree_synced = compare_paths_between_tree_cache_and_global_tree(
+        w.m_tree_cache, m_global_curve_tree, paths_to_check);
+    CHECK_AND_ASSERT_THROW_MES(tree_cache_and_global_tree_synced,
+        "fake_pruned_blockchain: mismatched wallet tree cache and blockchain global tree");
+
+    return blocks_added;
+}
+//----------------------------------------------------------------------------------------------------------------------
+void fake_pruned_blockchain::assert_chain_count() const
+{
+    CHECK_AND_ASSERT_THROW_MES(m_block_entries.size() == m_parsed_blocks.size(),
+        "blockchain size mismatch");
+    CHECK_AND_ASSERT_THROW_MES(m_block_entries.size() == m_curve_tree_roots.size(),
+        "curve tree roots size mismatch");
+    CHECK_AND_ASSERT_THROW_MES(m_block_entries.empty() || m_num_outputs > 0,
+        "missing outputs in starting block");
+    CHECK_AND_ASSERT_THROW_MES(m_global_curve_tree.get_n_leaf_tuples() <= m_num_outputs,
+        "tree has wrong number of leafs");
 }
 //----------------------------------------------------------------------------------------------------------------------
 void fake_pruned_blockchain::add_starting_block()

--- a/tests/unit_tests/fake_pruned_blockchain.h
+++ b/tests/unit_tests/fake_pruned_blockchain.h
@@ -31,6 +31,7 @@
 #define IN_UNIT_TESTS
 
 #include "carrot_impl/carrot_tx_builder_types.h"
+#include "curve_trees.h"
 #include "wallet/wallet2.h"
 
 namespace mock
@@ -41,13 +42,15 @@ bool construct_miner_tx_fake_reward_1out(const size_t height,
     const rct::xmr_amount reward,
     const cryptonote::account_public_address &miner_address,
     cryptonote::transaction& tx,
-    const uint8_t hf_version);
+    const uint8_t hf_version,
+    const size_t num_tx_outputs = 1);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 cryptonote::transaction construct_miner_tx_fake_reward_1out(const size_t height,
     const rct::xmr_amount reward,
     const cryptonote::account_public_address &miner_address,
-    const uint8_t hf_version);
+    const uint8_t hf_version,
+    const size_t num_tx_outputs = 1);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 struct stripped_down_tx_source_entry_t
@@ -70,10 +73,17 @@ cryptonote::tx_source_entry gen_tx_source_entry_fake_members(
 //----------------------------------------------------------------------------------------------------------------------
 cryptonote::transaction construct_pre_carrot_tx_with_fake_inputs(
     const cryptonote::account_keys &sender_account_keys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddresses,
+    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &sender_subaddress_map,
     std::vector<stripped_down_tx_source_entry_t> &&stripped_sources,
     std::vector<cryptonote::tx_destination_entry> &destinations,
     const boost::optional<cryptonote::account_public_address> &change_addr,
+    const rct::xmr_amount fee,
+    const uint8_t hf_version,
+    const bool sweep_unmixable_override = false);
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+cryptonote::transaction construct_pre_carrot_tx_with_fake_inputs(
+    std::vector<cryptonote::tx_destination_entry> &destinations,
     const rct::xmr_amount fee,
     const uint8_t hf_version,
     const bool sweep_unmixable_override = false);
@@ -91,29 +101,26 @@ cryptonote::transaction construct_carrot_pruned_transaction_fake_inputs(
 extern const cryptonote::account_public_address null_addr;
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
+using fcmp_generic_object_t = std::unique_ptr<void, decltype(&free)>;
+static inline fcmp_generic_object_t make_fcmp_generic_object(void *p) { return fcmp_generic_object_t(p, &free); }
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
 class fake_pruned_blockchain
 {
 public:
     static constexpr rct::xmr_amount miner_reward = 600000000000; // 0.6 XMR
 
     fake_pruned_blockchain(const uint64_t start_block_index = 0,
-            const cryptonote::network_type nettype = cryptonote::MAINNET):
-        m_start_block_index(start_block_index),
-        m_nettype(nettype),
-        m_output_index()
-    {
-        add_starting_block();
-    }
+        const cryptonote::network_type nettype = cryptonote::MAINNET);
 
     void add_block(const uint8_t hf_version,
         std::vector<cryptonote::transaction> &&txs,
-        const cryptonote::account_public_address &miner_address);
+        const cryptonote::account_public_address &miner_address,
+        const size_t num_miner_tx_outputs = 1);
 
     void add_block(cryptonote::block &&blk,
         std::vector<cryptonote::transaction> &&pruned_txs,
         std::vector<crypto::hash> &&prunable_hashes);
-
-    void pop_block();
 
     void get_blocks_data(const uint64_t start_block_index,
         const uint64_t stop_block_index,
@@ -121,6 +128,14 @@ public:
         std::vector<tools::wallet2::parsed_block> &parsed_blocks_out) const;
 
     void init_wallet_for_starting_block(tools::wallet2 &w) const;
+
+    /**
+     * brief: refresh_wallet - pulls block data from chain and calls process_parsed_blocks()
+     * param: w -
+     * param: start_height - start height to pull block data from (inclusive)
+     * return: number of blocks added by process_parsed_blocks()
+     */
+    uint64_t refresh_wallet(tools::wallet2 &w, const size_t start_height) const;
 
     uint8_t hf_version() const
     {
@@ -147,6 +162,11 @@ public:
         return m_parsed_blocks.empty() ? crypto::null_hash : m_parsed_blocks.back().hash;
     }
 
+    uint64_t num_outputs() const
+    {
+        return m_num_outputs;
+    }
+
     tools::wallet2::parsed_block get_parsed_block(const uint64_t block_index) const
     {
         if (block_index >= this->height() || block_index < this->m_start_block_index)
@@ -155,19 +175,27 @@ public:
         return m_parsed_blocks.at(block_index - this->m_start_block_index);
     }
 
-private:
-    void assert_chain_count() const
+    const uint8_t *get_fcmp_tree_root_at(const uint64_t block_index) const
     {
-        CHECK_AND_ASSERT_THROW_MES(m_block_entries.size() == m_parsed_blocks.size(), "blockchain size mismatch");
+        if (block_index >= this->height() || block_index < this->m_start_block_index)
+            throw std::out_of_range("get_fcmp_tree_root_at requested block index");
+
+        return reinterpret_cast<uint8_t*>(m_curve_tree_roots.at(block_index - this->m_start_block_index).get());
     }
+
+private:
+    void assert_chain_count() const;
 
     void add_starting_block();
 
     uint64_t m_start_block_index;
     cryptonote::network_type m_nettype;
-    uint64_t m_output_index;
+    uint64_t m_num_outputs;
     std::vector<cryptonote::block_complete_entry> m_block_entries;
     std::vector<tools::wallet2::parsed_block> m_parsed_blocks;
+    std::vector<fcmp_generic_object_t> m_curve_tree_roots;
+
+    CurveTreesGlobalTree m_global_curve_tree;
 };
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -412,7 +412,7 @@ TEST(fcmp_pp, membership_completeness)
         std::set<size_t> selected_indices;
         std::vector<FcmpInputCompressed> fcmp_raw_inputs;
         fcmp_raw_inputs.reserve(num_inputs);
-        std::vector<const uint8_t*> fcmp_provable_inputs;
+        std::vector<uint8_t*> fcmp_provable_inputs;
         fcmp_provable_inputs.reserve(num_inputs);
         while (selected_indices.size() < num_inputs)
         {
@@ -544,8 +544,8 @@ TEST(fcmp_pp, membership_completeness)
         EXPECT_TRUE(fcmp_pp::verify_membership(proof, n_layers, global_tree.get_tree_root(), fcmp_raw_inputs));
 
         // Dealloc
-        for (const uint8_t *input : fcmp_provable_inputs)
-            free(const_cast<uint8_t*>(input));
+        for (uint8_t *input : fcmp_provable_inputs)
+            free(input);
     }
 }
 //----------------------------------------------------------------------------------------------------------------------

--- a/tests/unit_tests/wallet_scanning.cpp
+++ b/tests/unit_tests/wallet_scanning.cpp
@@ -75,12 +75,7 @@ TEST(wallet_scanning, positive_smallout_main_addr_all_types_outputs)
         const boost::multiprecision::int128_t old_balance = w.balance(0, true);
 
         // note: doesn't handle reorgs
-        std::vector<cryptonote::block_complete_entry> block_entries;
-        std::vector<tools::wallet2::parsed_block> parsed_blocks;
-        bc.get_blocks_data(0, bc.height()-1, block_entries, parsed_blocks); //! @TODO: figure out why starting from refresh_height doesn't work
-        uint64_t blocks_added{};
-        auto output_tracker_cache = w.create_output_tracker_cache();
-        w.process_parsed_blocks(0, block_entries, parsed_blocks, blocks_added, output_tracker_cache);
+        bc.refresh_wallet(w, 0);
 
         // update refresh_height
         refresh_height = bc.height();
@@ -176,11 +171,7 @@ TEST(wallet_scanning, positive_smallout_main_addr_all_types_outputs)
         std::vector<cryptonote::tx_destination_entry> dests = {
             cryptonote::tx_destination_entry(amount_b, acc_keys.m_account_address, false)};
         cryptonote::transaction curr_tx = mock::construct_pre_carrot_tx_with_fake_inputs(
-            acc_keys,
-            w.m_subaddresses,
-            /*stripped_sources=*/{},
             dests,
-            acc_keys.m_account_address,
             fee,
             /*hf_version=*/1);
         ASSERT_FALSE(cryptonote::is_coinbase(curr_tx));
@@ -220,11 +211,7 @@ TEST(wallet_scanning, positive_smallout_main_addr_all_types_outputs)
         std::vector<cryptonote::tx_destination_entry> dests = {
             cryptonote::tx_destination_entry(amount_d, acc_keys.m_account_address, false)};
         cryptonote::transaction curr_tx = mock::construct_pre_carrot_tx_with_fake_inputs(
-            acc_keys,
-            w.m_subaddresses,
-            /*stripped_sources=*/{},
             dests,
-            acc_keys.m_account_address,
             fee,
             HF_VERSION_DYNAMIC_FEE);
         ASSERT_FALSE(cryptonote::is_coinbase(curr_tx));
@@ -247,11 +234,7 @@ TEST(wallet_scanning, positive_smallout_main_addr_all_types_outputs)
         std::vector<cryptonote::tx_destination_entry> dests = {
             cryptonote::tx_destination_entry(amount_e, acc_keys.m_account_address, false)};
         cryptonote::transaction curr_tx = mock::construct_pre_carrot_tx_with_fake_inputs(
-            acc_keys,
-            w.m_subaddresses,
-            /*stripped_sources=*/{},
             dests,
-            acc_keys.m_account_address,
             fee,
             HF_VERSION_SMALLER_BP);
         ASSERT_FALSE(cryptonote::is_coinbase(curr_tx));
@@ -292,11 +275,7 @@ TEST(wallet_scanning, positive_smallout_main_addr_all_types_outputs)
         std::vector<cryptonote::tx_destination_entry> dests = {
             cryptonote::tx_destination_entry(amount_g, acc_keys.m_account_address, false)};
         cryptonote::transaction curr_tx = mock::construct_pre_carrot_tx_with_fake_inputs(
-            acc_keys,
-            w.m_subaddresses,
-            /*stripped_sources=*/{},
             dests,
-            acc_keys.m_account_address,
             fee,
             HF_VERSION_VIEW_TAGS,
             /*sweep_unmixable_override=*/true);
@@ -320,11 +299,7 @@ TEST(wallet_scanning, positive_smallout_main_addr_all_types_outputs)
         std::vector<cryptonote::tx_destination_entry> dests = {
             cryptonote::tx_destination_entry(amount_h, acc_keys.m_account_address, false)};
         cryptonote::transaction curr_tx = mock::construct_pre_carrot_tx_with_fake_inputs(
-            acc_keys,
-            w.m_subaddresses,
-            /*stripped_sources=*/{},
             dests,
-            acc_keys.m_account_address,
             fee,
             HF_VERSION_VIEW_TAGS);
         ASSERT_FALSE(cryptonote::is_coinbase(curr_tx));

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -26,14 +26,23 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "unit_tests_utils.h"
 #include "gtest/gtest.h"
 
 #include "carrot_core/config.h"
 #include "carrot_impl/carrot_tx_builder_utils.h"
+#include "carrot_mock_helpers.h"
 #include "common/container_helpers.h"
+#include "cryptonote_core/blockchain.h"
+#include "cryptonote_core/tx_verification_utils.h"
+#include "fake_pruned_blockchain.h"
+#include "fcmp_pp/prove.h"
 #include "ringct/rctOps.h"
+#include "ringct/rctSigs.h"
 #include "wallet/tx_builder.h"
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "unit_tests.wallet_scanning"
+
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 static tools::wallet2::transfer_details gen_transfer_details()
@@ -171,7 +180,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposal_wallet2_transfer_1)
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
         top_block_index,
-        alice);
+        alice.get_keys());
 
     std::vector<crypto::key_image> expected_key_images{
         transfers.front().m_key_image,
@@ -212,7 +221,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposal_wallet2_sweep_1)
         /*fee_per_weight=*/1,
         /*extra=*/{},
         transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE,
-        alice);
+        alice.get_keys());
 
     // Assert basic length facts about tx proposal
     ASSERT_EQ(1, tx_proposal.key_images_sorted.size());
@@ -224,5 +233,145 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposal_wallet2_sweep_1)
     // Assert amounts
     EXPECT_EQ(0, tx_proposal.selfsend_payment_proposals.front().proposal.amount);
     EXPECT_EQ(transfers.front().amount(), tx_proposal.fee + tx_proposal.normal_payment_proposals.front().amount);
+}
+//----------------------------------------------------------------------------------------------------------------------
+TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
+{
+    // 1. create fake blockchain
+    // 2. create Alice, Bob wallet2 instance
+    // 3. send a mix of fake-input legacy and carrot txs to Alice
+    // 4. step blockchain forward 10 blocks
+    // 5. scan blockchain with Alice wallet
+    // 6. create carrot transaction proposal
+    // 7. construct proofs for transaction
+    // 8. serialize tx
+    // 9. deserialize tx
+    // 10. check ver_non_input_consensus()
+    // 11. check verRctNonSemanticsSimple()
+    // 12. add Alice's transaction to blockchain
+    // 13. scan blockchain with Bob's wallet and assert money received
+    // 14. scan blockchain with Alice's wallet and assert money left
+
+    // 1.
+    LOG_PRINT_L2("Initiating my imaginary, friendly chain of blocks");
+    mock::fake_pruned_blockchain bc(0);
+
+    // 2.
+    LOG_PRINT_L2("Generating wallets for Alice and Bob, the usual suspects");
+    tools::wallet2 alice(cryptonote::MAINNET, /*kdf_rounds=*/1, /*unattended=*/true);
+    tools::wallet2 bob(cryptonote::MAINNET, /*kdf_rounds=*/1, /*unattended=*/true);
+    alice.set_offline(true);
+    bob.set_offline(true);
+    alice.generate("", "");
+    bob.generate("", "");
+    const cryptonote::account_keys &alice_keys = alice.get_account().get_keys();
+    const cryptonote::account_public_address alice_main_addr = alice.get_account().get_keys().m_account_address;
+    const cryptonote::account_public_address bob_main_addr = bob.get_account().get_keys().m_account_address;
+    bc.init_wallet_for_starting_block(alice);
+    bc.init_wallet_for_starting_block(bob);
+
+    // 3.
+    LOG_PRINT_L2("Sending transactions from the aether to Alice (0)");
+    const rct::xmr_amount amount0 = rct::randXmrAmount(COIN);
+    std::vector<cryptonote::tx_destination_entry> dests0{cryptonote::tx_destination_entry(amount0, alice_main_addr, false)};
+    cryptonote::transaction tx = mock::construct_pre_carrot_tx_with_fake_inputs(dests0, /*fee=*/1234, /*hf_version=*/2);
+    bc.add_block(2, {std::move(tx)}, mock::null_addr);
+    LOG_PRINT_L2("Sending transactions from the aether to Alice (1)");
+    const rct::xmr_amount amount1 = rct::randXmrAmount(COIN);
+    std::vector<cryptonote::tx_destination_entry> dests1{cryptonote::tx_destination_entry(amount1, alice.get_subaddress({0, 13}), true)};
+    cryptonote::account_base aether;
+    aether.generate();
+    tx = mock::construct_carrot_pruned_transaction_fake_inputs({carrot::mock::convert_normal_payment_proposal_v1(dests1.front())}, {}, aether.get_keys());
+    bc.add_block(HF_VERSION_CARROT, {std::move(tx)}, mock::null_addr);
+
+    // 4. 
+    //!@TODO: figure out why membership proving fails if there's fewer leaves than the curve1 width
+    const size_t target_num_outputs = fcmp_pp::curve_trees::SELENE_CHUNK_WIDTH * fcmp_pp::curve_trees::HELIOS_CHUNK_WIDTH + 7;
+    while (bc.num_outputs() < target_num_outputs)
+        bc.add_block(HF_VERSION_CARROT, {}, mock::null_addr, target_num_outputs - bc.num_outputs());
+
+    LOG_PRINT_L2("Twiddling thumbs");
+    for (size_t i = 0; i < CRYPTONOTE_MINED_MONEY_UNLOCK_WINDOW; ++i)
+        bc.add_block(HF_VERSION_CARROT, {}, mock::null_addr);
+
+    // 5.
+    LOG_PRINT_L2("Alice's vision is filled with shadowy keys, hashes, points, rings, trees, curves, chains, all flowing in and out of one another");
+    uint64_t blocks_added = bc.refresh_wallet(alice, 0);
+    ASSERT_EQ(bc.height()-1, blocks_added);
+    ASSERT_EQ(2, alice.m_transfers.size());
+    ASSERT_EQ(amount0 + amount1, alice.balance_all(true)); // really, we care about unlocked_balance_all() for sending, but that call uses RPC
+
+    // 6. 
+    LOG_PRINT_L2("Alice feels pity on Bob and proposes to send his broke ass some dough");
+    const rct::xmr_amount out_amount = rct::randXmrAmount(amount0 + amount1);
+    const carrot::CarrotTransactionProposalV1 tx_proposal = 
+        tools::wallet::make_carrot_transaction_proposal_wallet2_transfer( // stupidly long function name ;(
+            alice.m_transfers,
+            alice.m_subaddresses,
+            {cryptonote::tx_destination_entry(out_amount, bob_main_addr, false)},
+            /*fee_per_weight=*/1,
+            /*extra=*/{},
+            /*subaddr_account=*/0,
+            /*subaddr_indices=*/{},
+            /*ignore_above=*/std::numeric_limits<rct::xmr_amount>::max(),
+            /*ignore_below=*/0,
+            /*top_block_index=*/bc.height()-1,
+            alice_keys);
+
+    // 7.
+    LOG_PRINT_L2("Alice has something to prove");
+    tx = tools::wallet::finalize_all_proofs_from_transfer_details(tx_proposal,
+        alice.m_transfers,
+        alice.m_tree_cache,
+        *alice.m_curve_trees,
+        alice_keys);
+
+    // 8.
+    LOG_PRINT_L2("Hello, Mr. Blobby");
+    const cryptonote::blobdata alicebob_tx_blob = cryptonote::tx_to_blob(tx);
+
+    // 9.
+    LOG_PRINT_L2("Goodbye, Mr. Blobby");
+    cryptonote::transaction alicebob_tx;
+    ASSERT_TRUE(cryptonote::parse_and_validate_tx_from_blob(alicebob_tx_blob, alicebob_tx));
+
+    // 10.
+    LOG_PRINT_L2("Bob couldn't believe someone to be so generous in his time of need, so he verifies");
+    ASSERT_GE(bc.hf_version(), HF_VERSION_FCMP_PLUS_PLUS);
+    cryptonote::tx_verification_context tvc{};
+    ASSERT_TRUE(cryptonote::ver_non_input_consensus(alicebob_tx, tvc, bc.hf_version()));
+    EXPECT_FALSE(tvc.m_verifivation_failed);
+
+    // 11.
+    LOG_PRINT_L2("'Perhaps this is valid money that belongs to another chain', Bob postulates");
+    const uint8_t *tree_root = bc.get_fcmp_tree_root_at(bc.height() - 1);
+    ASSERT_TRUE(cryptonote::Blockchain::expand_transaction_2(alicebob_tx,
+        cryptonote::get_transaction_prefix_hash(alicebob_tx),
+        /*pubkeys=*/{},
+        tree_root));
+    EXPECT_TRUE(rct::verRctNonSemanticsSimple(alicebob_tx.rct_signatures));
+
+    // 12.
+    LOG_PRINT_L2("'Chain, chain, chain (Chain, chain, chain)' - Aretha Franklin");
+    const rct::xmr_amount alicebob_tx_fee = alicebob_tx.rct_signatures.txnFee;
+    bc.add_block(HF_VERSION_CARROT, {std::move(alicebob_tx)}, mock::null_addr);
+
+    // 13. 
+    LOG_PRINT_L2("A great day for Bob");
+    ASSERT_EQ(0, bob.balance_all(true));
+    blocks_added = bc.refresh_wallet(bob, 0);
+    ASSERT_EQ(bc.height()-1, blocks_added);
+    ASSERT_EQ(1, bob.m_transfers.size());
+    EXPECT_EQ(out_amount, bob.balance_all(true));
+
+    // 14.
+    LOG_PRINT_L2("Alice obtains the fulfillment that only stems from selfless generosity");
+    const rct::xmr_amount alice_old_balance = alice.balance_all(true);
+    ASSERT_GE(alice_old_balance, out_amount + alicebob_tx_fee);
+    blocks_added = bc.refresh_wallet(alice, 0);
+    ASSERT_EQ(1, blocks_added);
+    const rct::xmr_amount alice_new_balance = alice.balance_all(true);
+    ASSERT_LT(alice_new_balance, alice_old_balance);
+    EXPECT_EQ(alice_new_balance + out_amount + alicebob_tx_fee, alice_old_balance);
 }
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This function takes a transaction proposals, the information in `wallet2::m_transfers`, account keys, and the tree cache `wallet2::m_tree_cache` to format a finished transaction and finalize all proofs.

To-do in future PRs:
1. Blinds cache
2. Multisig support
3. Hardware device integration

