### PR TITLE
Fix tx_builder includes

### DIFF
--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -44,7 +44,7 @@
 #include "common/threadpool.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/blockchain.h"
-#include "fcmp_pp/proof_len.cpp"
+#include "fcmp_pp/proof_len.h"
 #include "fcmp_pp/prove.h"
 #include "fcmp_pp/tower_cycle.h"
 #include "ringct/bulletproofs_plus.h"


### PR DESCRIPTION
Causes release builds to fail to compile because of duplicate symbols, not sure how debug builds were compiling.