### PR TITLE
Carrot+FCMP: CLI and RPC wallet integration

### DIFF
--- a/src/carrot_impl/tx_proposal_utils.cpp
+++ b/src/carrot_impl/tx_proposal_utils.cpp
@@ -171,7 +171,7 @@ void make_carrot_transaction_proposal_v1(const std::vector<CarrotPaymentProposal
     std::map<size_t, rct::xmr_amount> fee_per_input_count;
     for (size_t num_ins = 1; num_ins <= CARROT_MAX_TX_INPUTS; ++num_ins)
     {
-        const uint64_t tx_weight = get_fcmppp_tx_weight(num_ins, num_outs, tx_extra_size);
+        const uint64_t tx_weight = cryptonote::get_fcmp_pp_transaction_weight_v1(num_ins, num_outs, tx_extra_size);
         CHECK_AND_ASSERT_THROW_MES(tx_weight != std::numeric_limits<uint64_t>::max(),
             "make_carrot_transaction_proposal_v1: invalid weight returned for ins=" << num_ins
             << " outs=" << num_outs << " extra_size=" << tx_extra_size);

--- a/src/carrot_impl/tx_proposal_utils.h
+++ b/src/carrot_impl/tx_proposal_utils.h
@@ -74,14 +74,6 @@ using carve_fees_and_balance_func_t = std::function<void(
 
 std::uint64_t get_carrot_default_tx_extra_size(const std::size_t n_outputs);
 
-static inline std::size_t get_fcmppp_tx_weight(const std::size_t num_inputs,
-    const std::size_t num_outputs,
-    const std::size_t tx_extra_size)
-{
-    // @TODO: actually implement
-    return 200 + num_inputs * 1000 + num_outputs * 100 + tx_extra_size;
-}
-
 void make_carrot_transaction_proposal_v1(const std::vector<CarrotPaymentProposalV1> &normal_payment_proposals,
     const std::vector<CarrotPaymentProposalVerifiableSelfSendV1> &selfsend_payment_proposals,
     const rct::xmr_amount fee_per_weight,

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -70,6 +70,7 @@
 #include "common/json_util.h"
 #include "ringct/rctSigs.h"
 #include "multisig/multisig.h"
+#include "wallet/tx_builder.h"
 #include "wallet/wallet_args.h"
 #include "version.h"
 #include <stdexcept>
@@ -1446,7 +1447,10 @@ bool simple_wallet::import_multisig_main(const std::vector<std::string> &args, b
 bool simple_wallet::accept_loaded_tx(const tools::wallet2::multisig_tx_set &txs)
 {
   std::string extra_message;
-  return accept_loaded_tx([&txs](){return txs.m_ptx.size();}, [&txs](size_t n)->const tools::wallet2::tx_construction_data&{return txs.m_ptx[n].construction_data;}, extra_message);
+  return accept_loaded_tx(
+    [&txs](){return txs.m_ptx.size();},
+    [&txs](size_t n)->const auto&{return std::get<tools::wallet2::tx_construction_data>(txs.m_ptx[n].construction_data);},
+    extra_message);
 }
 
 bool simple_wallet::sign_multisig(const std::vector<std::string> &args)
@@ -6200,7 +6204,9 @@ bool simple_wallet::process_ring_members(const std::vector<tools::wallet2::pendi
   for (size_t n = 0; n < ptx_vector.size(); ++n)
   {
     const cryptonote::transaction& tx = ptx_vector[n].tx;
-    const tools::wallet2::tx_construction_data& construction_data = ptx_vector[n].construction_data;
+    if (tx.rct_signatures.type >= rct::RCTTypeFcmpPlusPlus)
+      continue;
+    const auto& construction_data = std::get<tools::wallet2::tx_construction_data>(ptx_vector[n].construction_data);
     if (verbose)
       ostr << boost::format(tr("\nTransaction %llu/%llu: txid=%s")) % (n + 1) % ptx_vector.size() % cryptonote::get_transaction_hash(tx);
     // for each input
@@ -6723,8 +6729,8 @@ bool simple_wallet::transfer_main(const std::vector<std::string> &args_, bool ca
         {
           prompt << tr("\nTransaction ") << (n + 1) << "/" << ptx_vector.size() << ":\n";
           subaddr_indices.clear();
-          for (uint32_t i : ptx_vector[n].construction_data.subaddr_indices)
-            subaddr_indices.insert(i);
+          for (const std::size_t selected_transfer : ptx_vector.at(n).selected_transfers)
+            subaddr_indices.insert(m_wallet->get_transfer_details(selected_transfer).m_subaddr_index.minor);
           for (uint32_t i : subaddr_indices)
             prompt << boost::format(tr("Spending from address index %d\n")) % i;
           if (subaddr_indices.size() > 1)
@@ -7153,8 +7159,8 @@ bool simple_wallet::sweep_main(uint32_t account, uint64_t below, const std::vect
     {
       prompt << tr("\nTransaction ") << (n + 1) << "/" << ptx_vector.size() << ":\n";
       subaddr_indices.clear();
-      for (uint32_t i : ptx_vector[n].construction_data.subaddr_indices)
-        subaddr_indices.insert(i);
+      for (const std::size_t selected_transfer : ptx_vector.at(n).selected_transfers)
+        subaddr_indices.insert(m_wallet->get_transfer_details(selected_transfer).m_subaddr_index.minor);
       for (uint32_t i : subaddr_indices)
         prompt << boost::format(tr("Spending from address index %d\n")) % i;
       if (subaddr_indices.size() > 1)
@@ -7769,7 +7775,10 @@ bool simple_wallet::accept_loaded_tx(const tools::wallet2::signed_tx_set &txs)
   std::string extra_message;
   if (!txs.key_images.empty())
     extra_message = (boost::format("%u key images to import. ") % (unsigned)txs.key_images.size()).str();
-  return accept_loaded_tx([&txs](){return txs.ptx.size();}, [&txs](size_t n)->const tools::wallet2::tx_construction_data&{return txs.ptx[n].construction_data;}, extra_message);
+  return accept_loaded_tx(
+    [&txs](){return txs.ptx.size();},
+    [&txs](size_t n)->const auto&{return std::get<tools::wallet2::tx_construction_data>(txs.ptx[n].construction_data);},
+    extra_message);
 }
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::sign_transfer(const std::vector<std::string> &args_)

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -70,7 +70,6 @@
 #include "common/json_util.h"
 #include "ringct/rctSigs.h"
 #include "multisig/multisig.h"
-#include "wallet/tx_builder.h"
 #include "wallet/wallet_args.h"
 #include "version.h"
 #include <stdexcept>

--- a/src/wallet/api/pending_transaction.cpp
+++ b/src/wallet/api/pending_transaction.cpp
@@ -200,7 +200,13 @@ std::vector<uint32_t> PendingTransactionImpl::subaddrAccount() const
 {
     std::vector<uint32_t> result;
     for (const auto& ptx : m_pending_tx)
-        result.push_back(ptx.construction_data.subaddr_account);
+    {
+        const auto *pre_carrot_constr_data = std::get_if<tools::wallet2::tx_construction_data>(&ptx.construction_data);
+        if (nullptr != pre_carrot_constr_data)
+            result.push_back(pre_carrot_constr_data->subaddr_account);
+        else
+            result.push_back(ptx.subaddr_account);
+    }
     return result;
 }
 
@@ -208,7 +214,13 @@ std::vector<std::set<uint32_t>> PendingTransactionImpl::subaddrIndices() const
 {
     std::vector<std::set<uint32_t>> result;
     for (const auto& ptx : m_pending_tx)
-        result.push_back(ptx.construction_data.subaddr_indices);
+    {
+        const auto *pre_carrot_constr_data = std::get_if<tools::wallet2::tx_construction_data>(&ptx.construction_data);
+        if (nullptr != pre_carrot_constr_data)
+            result.push_back(pre_carrot_constr_data->subaddr_indices);
+        else
+            result.push_back(ptx.subaddr_indices);
+    }
     return result;
 }
 

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -398,8 +398,6 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const std::vector<uint8_t> &extra,
     const std::uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
-    const rct::xmr_amount ignore_above,
-    const rct::xmr_amount ignore_below,
     const wallet2::unique_index_container &subtract_fee_from_outputs)
 {
     wallet2::transfer_container transfers;
@@ -425,8 +423,8 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
         extra,
         subaddr_account,
         subaddr_indices,
-        ignore_above,
-        ignore_below,
+        w.ignore_outputs_above(),
+        w.ignore_outputs_below(),
         subtract_fee_from_outputs,
         top_block_index,
         w.get_account().get_keys());
@@ -1281,6 +1279,166 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     }
 
     return tx;
+}
+//-------------------------------------------------------------------------------------------------------------------
+wallet2::pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const wallet2::transfer_container &transfers,
+    const cryptonote::account_keys &acc_keys)
+{
+    const std::size_t n_inputs = tx_proposal.key_images_sorted.size();
+    const std::size_t n_outputs = tx_proposal.normal_payment_proposals.size() +
+        tx_proposal.selfsend_payment_proposals.size();
+    const bool shared_ephemeral_pubkey = n_outputs == 2;
+
+    const crypto::key_image &tx_first_key_image = tx_proposal.key_images_sorted.at(0);
+
+    // collect non-burned transfers
+    const std::unordered_map<crypto::key_image, std::size_t> unburned_transfers_by_key_image = 
+        collect_non_burned_transfers_by_key_image(transfers);
+
+    // collect selected_transfers and key_images string
+    std::vector<std::size_t> selected_transfers;
+    selected_transfers.reserve(n_inputs);
+    std::stringstream key_images_string;
+    for (size_t i = 0; i < n_inputs; ++i)
+    {
+        const crypto::key_image &ki = tx_proposal.key_images_sorted.at(i);
+        const auto ki_it = unburned_transfers_by_key_image.find(ki);
+        CHECK_AND_ASSERT_THROW_MES(ki_it != unburned_transfers_by_key_image.cend(),
+            "make_pending_carrot_tx: unrecognized key image in transfers list");
+        selected_transfers.push_back(ki_it->second);
+        if (i)
+            key_images_string << ' ';
+        key_images_string << ki;
+    }
+
+    //! @TODO: HW device
+    carrot::view_incoming_key_ram_borrowed_device k_view_dev(acc_keys.m_view_secret_key);
+
+    // get order of payment proposals
+    std::vector<carrot::RCTOutputEnoteProposal> output_enote_proposals;
+    carrot::encrypted_payment_id_t encrypted_payment_id;
+    std::vector<std::pair<bool, std::size_t>> sorted_payment_proposal_indices;
+    carrot::get_output_enote_proposals_from_proposal_v1(tx_proposal,
+        /*s_view_balance_dev=*/nullptr,
+        &k_view_dev,
+        output_enote_proposals,
+        encrypted_payment_id,
+        &sorted_payment_proposal_indices);
+
+    // calculate change_dst index based whether 2-out tx has a dummy output
+    // change_dst is set to dummy in 2-out self-send, otherwise last self-send
+    const bool has_2out_dummy = n_outputs == 2
+        && tx_proposal.normal_payment_proposals.size() == 1
+        && tx_proposal.normal_payment_proposals.at(0).amount == 0;
+    CHECK_AND_ASSERT_THROW_MES(!tx_proposal.selfsend_payment_proposals.empty(),
+        "make_pending_carrot_tx: carrot tx proposal missing a self-send proposal");
+    const std::pair<bool, std::size_t> change_dst_index{!has_2out_dummy,
+        has_2out_dummy ? 0 : tx_proposal.selfsend_payment_proposals.size()-1};
+
+    // collect destinations and private tx keys for normal enotes
+    //! @TODO: payment proofs for special self-send, perhaps generate d_e deterministically
+    cryptonote::tx_destination_entry change_dts;
+    std::vector<cryptonote::tx_destination_entry> dests;
+    std::vector<crypto::secret_key> ephemeral_privkeys;
+    dests.reserve(n_outputs);
+    ephemeral_privkeys.reserve(n_outputs);
+    for (const std::pair<bool, std::size_t> &payment_idx : sorted_payment_proposal_indices)
+    {
+        cryptonote::tx_destination_entry dest;
+
+        const bool is_selfsend = payment_idx.first;
+        if (is_selfsend)
+        {
+            dest = make_tx_destination_entry(tx_proposal.selfsend_payment_proposals.at(payment_idx.second),
+                k_view_dev);
+            ephemeral_privkeys.push_back(crypto::null_skey);
+        }
+        else // !is_selfsend
+        {
+            const carrot::CarrotPaymentProposalV1 &normal_payment_proposal =
+                tx_proposal.normal_payment_proposals.at(payment_idx.second);
+            dest = make_tx_destination_entry(normal_payment_proposal);
+            ephemeral_privkeys.push_back(carrot::get_enote_ephemeral_privkey(normal_payment_proposal,
+                carrot::make_carrot_input_context(tx_first_key_image)));
+        }
+
+        if (payment_idx == change_dst_index)
+            change_dts = dest;
+        else
+            dests.push_back(dest);
+    }
+
+    // collect subaddr account and minor indices
+    const std::uint32_t subaddr_account = transfers.at(selected_transfers.at(0)).m_subaddr_index.major;
+    std::set<std::uint32_t> subaddr_indices;
+    for (const size_t selected_transfer : selected_transfers)
+    {
+        const wallet2::transfer_details &td = transfers.at(selected_transfer);
+        const std::uint32_t other_subaddr_account = td.m_subaddr_index.major;
+        if (other_subaddr_account != subaddr_account)
+        {
+            MWARNING("make_pending_carrot_tx: conflicting account indices: " << subaddr_account << " vs "
+                << other_subaddr_account);
+        }
+        subaddr_indices.insert(td.m_subaddr_index.minor);
+    }
+
+    wallet2::pending_tx ptx;
+    ptx.tx.set_null();
+    ptx.dust = 0;
+    ptx.fee = tx_proposal.fee;
+    ptx.dust_added_to_fee = false;
+    ptx.change_dts = change_dts;
+    ptx.selected_transfers = std::move(selected_transfers);
+    ptx.key_images = key_images_string.str();
+    ptx.tx_key = shared_ephemeral_pubkey ? ephemeral_privkeys.at(0) : crypto::null_skey;
+    if (shared_ephemeral_pubkey)
+        ptx.additional_tx_keys = std::move(ephemeral_privkeys);
+    else
+        ptx.additional_tx_keys.clear();
+    ptx.dests = std::move(dests);
+    ptx.multisig_sigs = {};
+    ptx.multisig_tx_key_entropy = {};
+    ptx.subaddr_account = subaddr_account;
+    ptx.subaddr_indices = std::move(subaddr_indices);
+    ptx.construction_data = tx_proposal;
+    return ptx;
+}
+//-------------------------------------------------------------------------------------------------------------------
+wallet2::pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const wallet2::transfer_container &transfers,
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
+    const cryptonote::account_keys &acc_keys)
+{
+    wallet2::pending_tx ptx = make_pending_carrot_tx(tx_proposal,
+        transfers,
+        acc_keys);
+
+    ptx.tx = finalize_all_proofs_from_transfer_details(tx_proposal,
+        transfers,
+        tree_cache,
+        curve_trees,
+        acc_keys);
+
+    return ptx;
+}
+//-------------------------------------------------------------------------------------------------------------------
+wallet2::pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const wallet2 &w)
+{
+    wallet2::transfer_container transfers;
+    w.get_transfers(transfers);
+
+    return finalize_all_proofs_from_transfer_details_as_pending_tx(
+        tx_proposal,
+        transfers,
+        w.get_tree_cache_ref(),
+        w.get_curve_trees_ref(),
+        w.get_account().get_keys());
 }
 //-------------------------------------------------------------------------------------------------------------------
 } //namespace wallet

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -79,8 +79,6 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const std::vector<uint8_t> &extra,
     const std::uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
-    const rct::xmr_amount ignore_above,
-    const rct::xmr_amount ignore_below,
     const wallet2::unique_index_container &subtract_fee_from_outputs);
 
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
@@ -145,5 +143,19 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
     const cryptonote::account_keys &acc_keys);
+
+wallet2::pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const wallet2::transfer_container &transfers,
+    const cryptonote::account_keys &acc_keys);
+
+wallet2::pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const wallet2::transfer_container &transfers,
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
+    const cryptonote::account_keys &acc_keys);
+wallet2::pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const wallet2 &w);
 } //namespace wallet
 } //namespace tools

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -70,8 +70,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const rct::xmr_amount ignore_above,
     const rct::xmr_amount ignore_below,
     wallet2::unique_index_container subtract_fee_from_outputs,
-    const std::uint64_t top_block_index,
-    const cryptonote::account_keys &acc_keys);
+    const std::uint64_t top_block_index);
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_transfer(
     wallet2 &w,
     const std::vector<cryptonote::tx_destination_entry> &dsts,
@@ -90,8 +89,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const size_t n_dests,
     const rct::xmr_amount fee_per_weight,
     const std::vector<uint8_t> &extra,
-    const std::uint64_t top_block_index,
-    const cryptonote::account_keys &acc_keys);
+    const std::uint64_t top_block_index);
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
     wallet2 &w,
     const std::vector<crypto::key_image> &input_key_images,
@@ -112,8 +110,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const std::vector<uint8_t> &extra,
     const std::uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
-    const std::uint64_t top_block_index,
-    const cryptonote::account_keys &acc_keys);
+    const std::uint64_t top_block_index);
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep_all(
     wallet2 &w,
     const rct::xmr_amount only_below,
@@ -146,7 +143,8 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
 
 wallet2::pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const wallet2::transfer_container &transfers,
-    const cryptonote::account_keys &acc_keys);
+    const crypto::secret_key &k_view,
+    hw::device &hwdev);
 
 wallet2::pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -95,6 +95,7 @@ using namespace epee;
 #include "net/socks_connect.h"
 #include "fcmp_pp/tx_utils.h"
 #include "carrot_impl/format_utils.h"
+#include "tx_builder.h"
 
 extern "C"
 {
@@ -10410,6 +10411,17 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   boost::unique_lock<hw::device> hwdev_lock (hwdev);
   hw::reset_mode rst(hwdev);  
 
+  const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
+  if (do_carrot_tx_construction)
+  {
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(*this, dsts, priority, extra, subaddr_account, subaddr_indices, subtract_fee_from_outputs);
+    std::vector<pending_tx> ptx_vector;
+    ptx_vector.reserve(tx_proposals.size());
+    for (const auto &tx_proposal : tx_proposals)
+      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+    return ptx_vector;
+  }
+
   auto original_dsts = dsts;
 
   std::vector<std::pair<uint32_t, std::vector<size_t>>> unused_transfers_indices_per_subaddr;
@@ -11181,6 +11193,17 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, c
 
 std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 {
+  const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
+  if (do_carrot_tx_construction)
+  {
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep_all(*this, below, address, is_subaddress, outputs, priority, extra, subaddr_account, subaddr_indices);
+    std::vector<pending_tx> ptx_vector;
+    ptx_vector.reserve(tx_proposals.size());
+    for (const auto &tx_proposal : tx_proposals)
+      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+    return ptx_vector;
+  }
+
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
   const bool use_fcmp = use_fork_rules(HF_VERSION_FCMP_PLUS_PLUS, 0);
@@ -11257,6 +11280,17 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
 
 std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra)
 {
+  const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
+  if (do_carrot_tx_construction)
+  {
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(*this, {ki}, address, is_subaddress, outputs, priority, extra);
+    std::vector<pending_tx> ptx_vector;
+    ptx_vector.reserve(tx_proposals.size());
+    for (const auto &tx_proposal : tx_proposals)
+      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+    return ptx_vector;
+  }
+
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
   const bool use_fcmp = use_fork_rules(HF_VERSION_FCMP_PLUS_PLUS, 0);
@@ -11280,6 +11314,25 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypt
 
 std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, uint32_t priority, const std::vector<uint8_t>& extra)
 {
+  const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
+  if (do_carrot_tx_construction)
+  {
+    // collect key images from provided transfer indices
+    std::vector<crypto::key_image> input_key_images;
+    input_key_images.reserve(unused_transfers_indices.size() + unused_dust_indices.size());
+    for (const size_t transfer_idx : unused_transfers_indices)
+      input_key_images.push_back(m_transfers.at(transfer_idx).m_key_image);
+    for (const size_t transfer_idx : unused_dust_indices)
+      input_key_images.push_back(m_transfers.at(transfer_idx).m_key_image);
+
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(*this, input_key_images, address, is_subaddress, outputs, priority, extra);
+    std::vector<pending_tx> ptx_vector;
+    ptx_vector.reserve(tx_proposals.size());
+    for (const auto &tx_proposal : tx_proposals)
+      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+    return ptx_vector;
+  }
+
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
   boost::unique_lock<hw::device> hwdev_lock (hwdev);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -925,9 +925,25 @@ bool get_short_payment_id(crypto::hash8 &payment_id8, const tools::wallet2::pend
   return false;
 }
 
+static const tools::wallet2::tx_construction_data &get_construction_data(const tools::wallet2::pending_tx &ptx)
+{
+  THROW_WALLET_EXCEPTION_IF(!std::holds_alternative<tools::wallet2::tx_construction_data>(ptx.construction_data),
+    tools::error::wallet_internal_error,
+    "Getting pre-carrot construction data only works for pre-carrot pending txs");
+  return std::get<tools::wallet2::tx_construction_data>(ptx.construction_data);
+}
+
+static tools::wallet2::tx_construction_data &get_construction_data(tools::wallet2::pending_tx &ptx)
+{
+  THROW_WALLET_EXCEPTION_IF(!std::holds_alternative<tools::wallet2::tx_construction_data>(ptx.construction_data),
+    tools::error::wallet_internal_error,
+    "Getting pre-carrot construction data only works for pre-carrot pending txs");
+  return std::get<tools::wallet2::tx_construction_data>(ptx.construction_data);
+}
+
 tools::wallet2::tx_construction_data get_construction_data_with_decrypted_short_payment_id(const tools::wallet2::pending_tx &ptx, hw::device &hwdev)
 {
-  tools::wallet2::tx_construction_data construction_data = ptx.construction_data;
+  tools::wallet2::tx_construction_data construction_data = get_construction_data(ptx);
   crypto::hash8 payment_id = null_hash8;
   if (get_short_payment_id(payment_id, ptx, hwdev))
   {
@@ -2033,7 +2049,7 @@ bool wallet2::frozen(const multisig_tx_set& txs) const
   std::unordered_set<crypto::key_image> kis_to_sign;
   for (const auto& ptx : txs.m_ptx)
   {
-    const tools::wallet2::tx_construction_data& cd = ptx.construction_data;
+    const tools::wallet2::tx_construction_data& cd = get_construction_data(ptx);
     CHECK_AND_ASSERT_THROW_MES(cd.sources.size() == ptx.tx.vin.size(), "mismatched multisg tx set source sizes");
     for (size_t src_idx = 0; src_idx < cd.sources.size(); ++src_idx)
     {
@@ -7476,6 +7492,25 @@ void wallet2::commit_tx(pending_tx& ptx)
     return;
   }
 
+  // collect subaddr account and subaddr indices
+  std::optional<std::uint32_t> subaddr_account_opt;
+  std::set<std::uint32_t> subaddr_indices;
+  for (const size_t selected_transfer : ptx.selected_transfers)
+  {
+    const transfer_details &td = m_transfers.at(selected_transfer);
+    if (subaddr_account_opt && *subaddr_account_opt != td.m_subaddr_index.major)
+    {
+      MWARNING("Mismatched subaddr accounts in inputs: " << *subaddr_account_opt << " vs " << td.m_subaddr_index.major);
+    }
+    else
+    {
+      subaddr_account_opt = td.m_subaddr_index.major;
+    }
+
+    subaddr_indices.insert(td.m_subaddr_index.minor);
+  }
+  const std::uint32_t subaddr_account = subaddr_account_opt.value_or(0);
+
   crypto::hash payment_id = crypto::null_hash;
   std::vector<cryptonote::tx_destination_entry> dests;
   uint64_t amount_in = 0;
@@ -7486,7 +7521,7 @@ void wallet2::commit_tx(pending_tx& ptx)
     for(size_t idx: ptx.selected_transfers)
       amount_in += m_transfers[idx].amount();
   }
-  add_unconfirmed_tx(ptx.tx, amount_in, dests, payment_id, ptx.change_dts.amount, ptx.construction_data.subaddr_account, ptx.construction_data.subaddr_indices);
+  add_unconfirmed_tx(ptx.tx, amount_in, dests, payment_id, ptx.change_dts.amount, subaddr_account, subaddr_indices);
   if (store_tx_info() && ptx.tx_key != crypto::null_skey)
   {
     m_tx_keys[txid] = ptx.tx_key;
@@ -7510,8 +7545,8 @@ void wallet2::commit_tx(pending_tx& ptx)
   //fee includes dust if dust policy specified it.
   LOG_PRINT_L1("Transaction successfully sent. <" << txid << ">" << ENDL
             << "Commission: " << print_money(ptx.fee) << " (dust sent to dust addr: " << print_money((ptx.dust_added_to_fee ? 0 : ptx.dust)) << ")" << ENDL
-            << "Balance: " << print_money(balance(ptx.construction_data.subaddr_account, false)) << ENDL
-            << "Unlocked: " << print_money(unlocked_balance(ptx.construction_data.subaddr_account, false)) << ENDL
+            << "Balance: " << print_money(balance(subaddr_account, false)) << ENDL
+            << "Unlocked: " << print_money(unlocked_balance(subaddr_account, false)) << ENDL
             << "Please, wait for confirmation for your balance to be unlocked.");
 }
 
@@ -8008,7 +8043,7 @@ std::string wallet2::save_multisig_tx(multisig_tx_set txs)
 
   // txes generated, get rid of used k values
   for (size_t n = 0; n < txs.m_ptx.size(); ++n)
-    for (size_t idx: txs.m_ptx[n].construction_data.selected_transfers)
+    for (size_t idx: get_construction_data(txs.m_ptx[n]).selected_transfers)
     {
       memwipe(m_transfers[idx].m_multisig_k.data(), m_transfers[idx].m_multisig_k.size() * sizeof(m_transfers[idx].m_multisig_k[0]));
       m_transfers[idx].m_multisig_k.clear();
@@ -8017,7 +8052,7 @@ std::string wallet2::save_multisig_tx(multisig_tx_set txs)
   // zero out some data we don't want to share
   for (auto &ptx: txs.m_ptx)
   {
-    for (auto &e: ptx.construction_data.sources)
+    for (auto &e: get_construction_data(ptx).sources)
       memwipe(&e.multisig_kLRki.k, sizeof(e.multisig_kLRki.k));
   }
 
@@ -8130,10 +8165,10 @@ bool wallet2::parse_multisig_tx_from_str(std::string multisig_tx_st, multisig_tx
     CHECK_AND_ASSERT_MES(ptx.selected_transfers.size() == ptx.tx.vin.size(), false, "Mismatched selected_transfers/vin sizes");
     for (size_t idx: ptx.selected_transfers)
       CHECK_AND_ASSERT_MES(idx < m_transfers.size(), false, "Transfer index out of range");
-    CHECK_AND_ASSERT_MES(ptx.construction_data.selected_transfers.size() == ptx.tx.vin.size(), false, "Mismatched cd selected_transfers/vin sizes");
-    for (size_t idx: ptx.construction_data.selected_transfers)
+    CHECK_AND_ASSERT_MES(get_construction_data(ptx).selected_transfers.size() == ptx.tx.vin.size(), false, "Mismatched cd selected_transfers/vin sizes");
+    for (size_t idx: get_construction_data(ptx).selected_transfers)
       CHECK_AND_ASSERT_MES(idx < m_transfers.size(), false, "Transfer index out of range");
-    CHECK_AND_ASSERT_MES(ptx.construction_data.sources.size() == ptx.tx.vin.size(), false, "Mismatched sources/vin sizes");
+    CHECK_AND_ASSERT_MES(get_construction_data(ptx).sources.size() == ptx.tx.vin.size(), false, "Mismatched sources/vin sizes");
   }
 
   return true;
@@ -8221,7 +8256,7 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto
   {
     tools::wallet2::pending_tx &ptx = exported_txs.m_ptx[n];
     THROW_WALLET_EXCEPTION_IF(ptx.multisig_sigs.empty(), error::wallet_internal_error, "No signatures found in multisig tx");
-    const tools::wallet2::tx_construction_data &sd = ptx.construction_data;
+    tools::wallet2::tx_construction_data &sd = get_construction_data(ptx);
     LOG_PRINT_L1(" " << (n+1) << ": " << sd.sources.size() << " inputs, ring size " << (sd.sources[0].outputs.size()) <<
         ", signed by " << exported_txs.m_signers.size() << "/" << m_multisig_threshold);
 
@@ -8231,14 +8266,14 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto
     THROW_WALLET_EXCEPTION_IF(
       not multisig_tx_builder.init(
         m_account.get_keys(),
-        ptx.construction_data.extra,
-        ptx.construction_data.subaddr_account,
-        ptx.construction_data.subaddr_indices,
-        ptx.construction_data.sources,
-        ptx.construction_data.splitted_dsts,
-        ptx.construction_data.change_dts,
-        ptx.construction_data.rct_config,
-        ptx.construction_data.use_rct,
+        sd.extra,
+        sd.subaddr_account,
+        sd.subaddr_indices,
+        sd.sources,
+        sd.splitted_dsts,
+        sd.change_dts,
+        sd.rct_config,
+        sd.use_rct,
         true,  //true = we are reconstructing the tx (it was first constructed by the tx proposer)
         ptx.tx_key,
         ptx.additional_tx_keys,
@@ -8312,7 +8347,7 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto
         {
           THROW_WALLET_EXCEPTION_IF(found, error::wallet_internal_error, "More than one transaction is final");
           THROW_WALLET_EXCEPTION_IF(
-            not multisig_tx_builder.finalize_tx(ptx.construction_data.sources, sig.c_0, sig.s, ptx.tx),
+            not multisig_tx_builder.finalize_tx(get_construction_data(ptx).sources, sig.c_0, sig.s, ptx.tx),
             error::wallet_internal_error,
             "error: multisig::signing::tx_builder_ringct_t::finalize_tx"
           );
@@ -8334,7 +8369,7 @@ bool wallet2::sign_multisig_tx(multisig_tx_set &exported_txs, std::vector<crypto
   // signatures generated, get rid of any unused k values (must do export_multisig() to make more tx attempts with the
   //   inputs in the transactions worked on here)
   for (size_t n = 0; n < exported_txs.m_ptx.size(); ++n)
-    for (size_t idx: exported_txs.m_ptx[n].construction_data.selected_transfers)
+    for (size_t idx: get_construction_data(exported_txs.m_ptx[n]).selected_transfers)
     {
       memwipe(m_transfers[idx].m_multisig_k.data(), m_transfers[idx].m_multisig_k.size() * sizeof(m_transfers[idx].m_multisig_k[0]));
       m_transfers[idx].m_multisig_k.clear();
@@ -9819,21 +9854,23 @@ void wallet2::transfer_selected(const std::vector<cryptonote::tx_destination_ent
   ptx.tx_key = tx_key;
   ptx.additional_tx_keys = additional_tx_keys;
   ptx.dests = dsts;
-  ptx.construction_data.sources = sources;
-  ptx.construction_data.change_dts = change_dts;
-  ptx.construction_data.splitted_dsts = splitted_dsts;
-  ptx.construction_data.selected_transfers = selected_transfers;
-  ptx.construction_data.extra = tx.extra;
-  ptx.construction_data.unlock_time = 0;
-  ptx.construction_data.use_rct = false;
-  ptx.construction_data.rct_config = { rct::RangeProofBorromean, 0 };
-  ptx.construction_data.use_view_tags = use_view_tags;
-  ptx.construction_data.dests = dsts;
+  tx_construction_data pre_carrot_construction_data;
+  pre_carrot_construction_data.sources = sources;
+  pre_carrot_construction_data.change_dts = change_dts;
+  pre_carrot_construction_data.splitted_dsts = splitted_dsts;
+  pre_carrot_construction_data.selected_transfers = selected_transfers;
+  pre_carrot_construction_data.extra = tx.extra;
+  pre_carrot_construction_data.unlock_time = 0;
+  pre_carrot_construction_data.use_rct = false;
+  pre_carrot_construction_data.rct_config = { rct::RangeProofBorromean, 0 };
+  pre_carrot_construction_data.use_view_tags = use_view_tags;
+  pre_carrot_construction_data.dests = dsts;
   // record which subaddress indices are being used as inputs
-  ptx.construction_data.subaddr_account = subaddr_account;
-  ptx.construction_data.subaddr_indices.clear();
+  pre_carrot_construction_data.subaddr_account = subaddr_account;
+  pre_carrot_construction_data.subaddr_indices.clear();
   for (size_t idx: selected_transfers)
-    ptx.construction_data.subaddr_indices.insert(m_transfers[idx].m_subaddr_index.minor);
+    pre_carrot_construction_data.subaddr_indices.insert(m_transfers[idx].m_subaddr_index.minor);
+  ptx.construction_data = pre_carrot_construction_data;
   LOG_PRINT_L2("transfer_selected done");
 }
 
@@ -10198,24 +10235,26 @@ void wallet2::transfer_selected_rct(std::vector<cryptonote::tx_destination_entry
   ptx.dests = dsts;
   ptx.multisig_sigs = multisig_sigs;
   ptx.multisig_tx_key_entropy = multisig_tx_key_entropy;
-  ptx.construction_data.sources = sources_copy;
-  ptx.construction_data.change_dts = change_dts;
-  ptx.construction_data.splitted_dsts = splitted_dsts;
-  ptx.construction_data.selected_transfers = ptx.selected_transfers;
-  ptx.construction_data.extra = tx.extra;
-  ptx.construction_data.unlock_time = 0;
-  ptx.construction_data.use_rct = true;
-  ptx.construction_data.rct_config = {
+  tx_construction_data pre_carrot_construction_data;
+  pre_carrot_construction_data.sources = sources_copy;
+  pre_carrot_construction_data.change_dts = change_dts;
+  pre_carrot_construction_data.splitted_dsts = splitted_dsts;
+  pre_carrot_construction_data.selected_transfers = ptx.selected_transfers;
+  pre_carrot_construction_data.extra = tx.extra;
+  pre_carrot_construction_data.unlock_time = 0;
+  pre_carrot_construction_data.use_rct = true;
+  pre_carrot_construction_data.rct_config = {
     rct::RangeProofPaddedBulletproof,
     use_fork_rules(HF_VERSION_BULLETPROOF_PLUS, -10) ? 4 : 3
   };
-  ptx.construction_data.use_view_tags = use_fork_rules(get_view_tag_fork(), 0);
-  ptx.construction_data.dests = dsts;
+  pre_carrot_construction_data.use_view_tags = use_fork_rules(get_view_tag_fork(), 0);
+  pre_carrot_construction_data.dests = dsts;
   // record which subaddress indices are being used as inputs
-  ptx.construction_data.subaddr_account = subaddr_account;
-  ptx.construction_data.subaddr_indices.clear();
+  pre_carrot_construction_data.subaddr_account = subaddr_account;
+  pre_carrot_construction_data.subaddr_indices.clear();
   for (size_t idx: selected_transfers)
-    ptx.construction_data.subaddr_indices.insert(m_transfers[idx].m_subaddr_index.minor);
+    pre_carrot_construction_data.subaddr_indices.insert(m_transfers[idx].m_subaddr_index.minor);
+  ptx.construction_data = pre_carrot_construction_data;
   LOG_PRINT_L2("transfer_selected_rct done");
 }
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -40,11 +40,13 @@
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/deque.hpp>
+#include <boost/serialization/std_variant_shim.hpp>
 #include <boost/thread/lock_guard.hpp>
 #include <atomic>
 #include <random>
 
 #include "include_base_utils.h"
+#include "carrot_impl/carrot_offchain_serialization.h"
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/account_boost_serialization.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
@@ -659,11 +661,17 @@ private:
       std::vector<cryptonote::tx_destination_entry> dests;
       std::vector<multisig_sig> multisig_sigs;
       crypto::secret_key multisig_tx_key_entropy;
+      uint32_t subaddr_account;            // subaddress account of your wallet to be used in this transfer
+      std::set<uint32_t> subaddr_indices;  // set of address indices used as inputs in this transfer
 
-      tx_construction_data construction_data;
+      using tx_reconstruct_variant_t = std::variant<
+          tx_construction_data,
+          carrot::CarrotTransactionProposalV1
+        >;
+      tx_reconstruct_variant_t construction_data;
 
       BEGIN_SERIALIZE_OBJECT()
-        VERSION_FIELD(1)
+        VERSION_FIELD(2)
         FIELD(tx)
         FIELD(dust)
         FIELD(fee)
@@ -674,7 +682,20 @@ private:
         FIELD(tx_key)
         FIELD(additional_tx_keys)
         FIELD(dests)
-        FIELD(construction_data)
+        if (version < 2)
+        {
+          tx_construction_data pre_carrot_construction_data;
+          FIELD_N("construction_data", pre_carrot_construction_data)
+          construction_data = pre_carrot_construction_data;
+          subaddr_account = pre_carrot_construction_data.subaddr_account;
+          subaddr_indices = pre_carrot_construction_data.subaddr_indices;
+        }
+        else // version >= 2
+        {
+          FIELD(construction_data)
+          FIELD(subaddr_account)
+          FIELD(subaddr_indices)
+        }
         FIELD(multisig_sigs)
         if (version < 1)
         {
@@ -2117,7 +2138,7 @@ BOOST_CLASS_VERSION(tools::wallet2::reserve_proof_entry, 0)
 BOOST_CLASS_VERSION(tools::wallet2::unsigned_tx_set, 1)
 BOOST_CLASS_VERSION(tools::wallet2::signed_tx_set, 1)
 BOOST_CLASS_VERSION(tools::wallet2::tx_construction_data, 4)
-BOOST_CLASS_VERSION(tools::wallet2::pending_tx, 3)
+BOOST_CLASS_VERSION(tools::wallet2::pending_tx, 4)
 BOOST_CLASS_VERSION(tools::wallet2::multisig_sig, 1)
 BOOST_CLASS_VERSION(tools::wallet2::background_synced_tx_t, 0)
 BOOST_CLASS_VERSION(tools::wallet2::background_sync_data_t, 0)
@@ -2608,7 +2629,16 @@ namespace boost
       a & x.key_images;
       a & x.tx_key;
       a & x.dests;
-      a & x.construction_data;
+      if (ver < 4)
+      {
+        tools::wallet2::tx_construction_data pre_carrot_construction_data;
+        a & pre_carrot_construction_data;
+        x.construction_data = pre_carrot_construction_data;
+      }
+      else // ver >= 4
+      {
+        a & x.construction_data;
+      }
       if (ver < 1)
         return;
       a & x.additional_tx_keys;
@@ -2618,6 +2648,10 @@ namespace boost
       if (ver < 3)
         return;
       a & x.multisig_sigs;
+      if (ver < 4)
+        return;
+      a & x.subaddr_account;
+      a & x.subaddr_indices;
     }
 
     template <class Archive>
@@ -2700,3 +2734,6 @@ namespace tools
   }
   //----------------------------------------------------------------------------------------------------
 }
+
+VARIANT_TAG(binary_archive, tools::wallet2::tx_construction_data, 0x21);
+VARIANT_TAG(binary_archive, carrot::CarrotTransactionProposalV1, 0x22);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -2634,6 +2634,8 @@ namespace boost
         tools::wallet2::tx_construction_data pre_carrot_construction_data;
         a & pre_carrot_construction_data;
         x.construction_data = pre_carrot_construction_data;
+        x.subaddr_account = pre_carrot_construction_data.subaddr_account;
+        x.subaddr_indices = pre_carrot_construction_data.subaddr_indices;
       }
       else // ver >= 4
       {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1416,7 +1416,7 @@ namespace tools
         }
 
         for (size_t n = 0; n < exported_txs.m_ptx.size(); ++n) {
-          tx_constructions.push_back(std::get<tools::wallet2::tx_construction_data>(exported_txs.m_ptx[n].construction_data));
+          tx_constructions.push_back(std::get<wallet2::tx_construction_data>(exported_txs.m_ptx[n].construction_data));
         }
       }
       catch (const std::exception &e) {

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1416,7 +1416,7 @@ namespace tools
         }
 
         for (size_t n = 0; n < exported_txs.m_ptx.size(); ++n) {
-          tx_constructions.push_back(exported_txs.m_ptx[n].construction_data);
+          tx_constructions.push_back(std::get<tools::wallet2::tx_construction_data>(exported_txs.m_ptx[n].construction_data));
         }
       }
       catch (const std::exception &e) {

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -28,6 +28,7 @@
 
 #include "gtest/gtest.h"
 
+#include "carrot_impl/tx_proposal_utils.h"
 #include "common/container_helpers.h"
 #include "common/threadpool.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
@@ -1089,6 +1090,46 @@ TEST(fcmp_pp, tx_weight_prefix_and_unprunable_byte_accuracy)
                 ASSERT_GE(unprunable_weight, example_tx.unprunable_size);
                 ASSERT_LE(unprunable_weight - example_tx.unprunable_size, allowed_weight_margin);
             }
+        }
+    }
+}
+//----------------------------------------------------------------------------------------------------------------------
+TEST(fcmp_pp, dump_tx_bytesizes)
+{
+    for (unsigned max_int_fields = 0; max_int_fields < 2; ++max_int_fields)
+    {
+        for (uint8_t n_tree_layers = 6; n_tree_layers <= 7; ++n_tree_layers)
+        {
+            std::cout << "layers=" << static_cast<int>(n_tree_layers) << " ";
+            if (max_int_fields)
+                std::cout << "maxvarint,";
+            else
+                std::cout << "minvarint,";
+
+            for (std::size_t n = 2; n <= FCMP_PLUS_PLUS_MAX_OUTPUTS; ++n)
+                std::cout << n << ',';
+            std::cout << '\n';
+
+            for (std::size_t m = 1; m <= FCMP_PLUS_PLUS_MAX_INPUTS; ++m)
+            {
+                std::cout << m << ',';
+                for (std::size_t n = 2; n <= FCMP_PLUS_PLUS_MAX_OUTPUTS; ++n)
+                {
+                    cryptonote::transaction example_tx = make_empty_fcmp_pp_tx_of_size(
+                        m,
+                        n,
+                        carrot::get_carrot_default_tx_extra_size(n),
+                        n_tree_layers,
+                        max_int_fields);
+
+                    const cryptonote::blobdata serialized_blob = cryptonote::tx_to_blob(example_tx);
+
+                    std::cout << serialized_blob.size() << ',';
+                }
+                std::cout << '\n';
+            }
+
+            std::cout << "-----------------------------------------\n";
         }
     }
 }

--- a/tests/unit_tests/serialization.cpp
+++ b/tests/unit_tests/serialization.cpp
@@ -1121,7 +1121,7 @@ TEST(Serialization, portability_signed_tx)
   ASSERT_TRUE(ptx.dests[0].amount == 1400000000000);
   ASSERT_TRUE(cryptonote::get_account_address_as_str(nettype, false, ptx.dests[0].addr) == "9xnhrMczQkPeoGi6dyu6BgKAYX4tZsDs6KHCkyTStDBKL4M4pM1gfCR3utmTAcSaKHGa1R5o266FbdnubErmij3oMdLyYgA");
   // ptx.construction_data
-  auto& tcd = ptx.construction_data;
+  auto& tcd = std::get<tools::wallet2::tx_construction_data>(ptx.construction_data);
   ASSERT_TRUE(tcd.sources.size() == 1);
   auto& tse = tcd.sources[0];
   // ptx.construction_data.sources[0].outputs

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -181,8 +181,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_1)
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
         {},
-        top_block_index,
-        alice.get_keys());
+        top_block_index);
 
     ASSERT_EQ(1, tx_proposals.size());
     const carrot::CarrotTransactionProposalV1 tx_proposal = tx_proposals.at(0);
@@ -245,8 +244,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_2)
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
         {},
-        top_block_index,
-        alice.legacy_acb.get_keys());
+        top_block_index);
 
     ASSERT_EQ(1, tx_proposals.size());
     const carrot::CarrotTransactionProposalV1 &tx_proposal = tx_proposals.at(0);
@@ -311,8 +309,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_1)
         /*n_dests=*/1,
         /*fee_per_weight=*/1,
         /*extra=*/{},
-        transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE,
-        alice.get_keys());
+        transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
     ASSERT_EQ(1, tx_proposals.size());
     const carrot::CarrotTransactionProposalV1 &tx_proposal = tx_proposals.at(0);
 
@@ -346,8 +343,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_2)
         /*n_dests=*/FCMP_PLUS_PLUS_MAX_OUTPUTS - 1,
         /*fee_per_weight=*/1,
         /*extra=*/{},
-        transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE,
-        alice.get_keys());
+        transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
     ASSERT_EQ(1, tx_proposals.size());
     const carrot::CarrotTransactionProposalV1 &tx_proposal = tx_proposals.at(0);
 
@@ -389,8 +385,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_3)
         /*n_dests=*/FCMP_PLUS_PLUS_MAX_OUTPUTS,
         /*fee_per_weight=*/1,
         /*extra=*/{},
-        transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE,
-        alice.get_keys());
+        transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
     ASSERT_EQ(1, tx_proposals.size());
     const carrot::CarrotTransactionProposalV1 &tx_proposal = tx_proposals.at(0);
 
@@ -465,8 +460,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_4)
         /*n_dests=*/n_dests,
         /*fee_per_weight=*/1,
         /*extra=*/{},
-        top_block_index,
-        alice.get_keys());
+        top_block_index);
     ASSERT_EQ(4, tx_proposals.size());
 
     std::set<crypto::key_image> actual_seen_kis;
@@ -548,8 +542,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_5)
         /*n_dests=*/n_dests,
         /*fee_per_weight=*/1,
         /*extra=*/{},
-        top_block_index,
-        alice.get_keys());
+        top_block_index);
     ASSERT_EQ(8, tx_proposals.size());
 
     std::set<crypto::key_image> actual_seen_kis;
@@ -631,8 +624,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_6)
         /*n_dests=*/n_dests,
         /*fee_per_weight=*/1,
         /*extra=*/{},
-        top_block_index,
-        alice.get_keys());
+        top_block_index);
     ASSERT_EQ(1, tx_proposals.size());
     const carrot::CarrotTransactionProposalV1 &tx_proposal = tx_proposals.at(0);
 
@@ -743,8 +735,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
             /*ignore_above=*/std::numeric_limits<rct::xmr_amount>::max(),
             /*ignore_below=*/0,
             {},
-            /*top_block_index=*/bc.height()-1,
-            alice_keys);
+            /*top_block_index=*/bc.height()-1);
     
     ASSERT_EQ(1, tx_proposals.size());
     const carrot::CarrotTransactionProposalV1 tx_proposal = tx_proposals.at(0);


### PR DESCRIPTION
This WIP branch can transfer and receive Carrot+FCMP transactions in the CLI and RPC wallets. 

CLI: Use the `transfer`, `sweep_single`, and `sweep_all` commands like you normally would.
RPC: Use the `transfer`, `transfer_split`, `sweep_single`, and `sweep_all` endpoints like you normally would.

Edit: You also have to edit the hard fork table to add v17 and v18, I'm using made-up values for the v17 and v18 entries in my local branch. You can apply the following git diff:

```
diff --git a/src/hardforks/hardforks.cpp b/src/hardforks/hardforks.cpp
index 571ba3818..c11fe64e9 100644
--- a/src/hardforks/hardforks.cpp
+++ b/src/hardforks/hardforks.cpp
@@ -73,6 +73,8 @@ const hardfork_t mainnet_hard_forks[] = {
 
   { 15, 2688888, 0, 1656629117 },
   { 16, 2689608, 0, 1656629118 },
+  { 17, 2690608, 0, 1656729118 },
+  { 18, 2691608, 0, 1656829118 },
 };
 const size_t num_mainnet_hard_forks = sizeof(mainnet_hard_forks) / sizeof(mainnet_hard_forks[0]);
 const uint64_t mainnet_hard_fork_version_1_till = 1009826;
```

Then run `monerod` with the `--regtest` option, which runs a modification of the mainnet hard fork table. 

Depends: #26 #34