### PR TITLE
fcmp++: fix restoring tree cache on scan error

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3008,13 +3008,18 @@ static TreeSyncStartParams tree_sync_reorg_check(const uint64_t parsed_blocks_st
   return TreeSyncStartParams { sync_start_block_idx, start_parsed_block_i, prev_block_hash };
 }
 
-static void tree_sync_blocks_async(const TreeSyncStartParams &tree_sync_start_params, const std::vector<tools::wallet2::parsed_block> &parsed_blocks, tools::wallet2::TreeCacheV1 &tree_cache_inout, uint64_t &outs_by_last_locked_time_ms_inout, uint64_t &sync_blocks_time_ms_inout, std::vector<crypto::hash> &new_block_hashes_out, fcmp_pp::curve_trees::CurveTreesV1::TreeExtension &tree_extension_out, std::vector<uint64_t> &new_leaf_tuples_per_block_out)
+static void tree_sync_blocks_async(const TreeSyncStartParams &tree_sync_start_params,
+    const std::vector<tools::wallet2::parsed_block> &parsed_blocks,
+    const tools::wallet2::TreeCacheV1 &tree_cache,
+    uint64_t &outs_by_last_locked_time_ms_inout,
+    uint64_t &sync_blocks_time_ms_inout,
+    std::vector<crypto::hash> &new_block_hashes_out,
+    fcmp_pp::curve_trees::TreeCacheV1::CacheStateChange &cache_state_change_out)
 {
   TIME_MEASURE_START(sync_blocks_time);
 
   new_block_hashes_out.clear();
-  new_leaf_tuples_per_block_out.clear();
-  tree_extension_out = fcmp_pp::curve_trees::CurveTreesV1::TreeExtension{};
+  cache_state_change_out = {};
 
   const uint64_t sync_start_block_idx = tree_sync_start_params.start_block_idx;
   const uint64_t start_parsed_block_i = tree_sync_start_params.start_parsed_block_i;
@@ -3033,7 +3038,7 @@ static void tree_sync_blocks_async(const TreeSyncStartParams &tree_sync_start_pa
   new_block_hashes_out.reserve(n_new_blocks);
   outs_by_last_locked_blocks.reserve(n_new_blocks);
 
-  uint64_t first_output_id = tree_cache_inout.get_output_count();
+  uint64_t first_output_id = tree_cache.get_output_count();
   for (size_t i = start_parsed_block_i; i < parsed_blocks.size(); ++i)
   {
     const uint64_t created_block_idx = sync_start_block_idx + (i - start_parsed_block_i);
@@ -3055,12 +3060,11 @@ static void tree_sync_blocks_async(const TreeSyncStartParams &tree_sync_start_pa
   TIME_MEASURE_FINISH(collecting_outs_by_last_locked_block);
 
   // Get a tree extension with the outputs that will unlock in this chunk of blocks
-  tree_cache_inout.prepare_to_sync_blocks(sync_start_block_idx,
+  tree_cache.prepare_to_grow_cache(sync_start_block_idx,
     prev_block_hash,
     new_block_hashes_out,
     outs_by_last_locked_blocks,
-    tree_extension_out,
-    new_leaf_tuples_per_block_out);
+    cache_state_change_out);
 
   TIME_MEASURE_FINISH(sync_blocks_time);
 
@@ -3105,15 +3109,14 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const std::vect
   const auto tree_sync_start_params = tree_sync_reorg_check(start_height, parsed_blocks, n_blocks_already_synced, m_blockchain, m_max_reorg_depth, m_tree_cache);
 
   std::vector<crypto::hash> new_block_hashes;
-  fcmp_pp::curve_trees::CurveTreesV1::TreeExtension tree_extension;
-  std::vector<uint64_t> new_leaf_tuples_per_block;
+  fcmp_pp::curve_trees::TreeCacheV1::CacheStateChange tree_cache_state_change;
 
   // Get the tree extension in parallel to identifying receives in the rest of
   // this function. After identifying receives in parallel, we'll then process
   // the tree extension, saving any path elements we need for received outputs,
   // and throwing away excess tree elems we won't need to continue syncing.
-  tpool.submit(&tree_sync_blocks_waiter, [this, &parsed_blocks, &new_block_hashes, &tree_extension, &new_leaf_tuples_per_block, tree_sync_start_params]() {
-      tree_sync_blocks_async(tree_sync_start_params, parsed_blocks, m_tree_cache, m_outs_by_last_locked_time_ms, m_sync_blocks_time_ms, new_block_hashes, tree_extension, new_leaf_tuples_per_block);
+  tpool.submit(&tree_sync_blocks_waiter, [this, &parsed_blocks, &new_block_hashes, &tree_cache_state_change, tree_sync_start_params]() {
+      tree_sync_blocks_async(tree_sync_start_params, parsed_blocks, m_tree_cache, m_outs_by_last_locked_time_ms, m_sync_blocks_time_ms, new_block_hashes, tree_cache_state_change);
     });
 
   const auto tree_sync_post_check = epee::misc_utils::create_scope_leave_handler([&, this]() {
@@ -3239,34 +3242,49 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const std::vect
     }
     else
     {
-      // Finish processing synced blocks on tree
-      m_tree_cache.process_synced_blocks(tree_sync_start_params.start_block_idx, new_block_hashes, tree_extension, new_leaf_tuples_per_block);
+      LOG_PRINT_L2("Caught an error in the scanner, restoring the tree cache");
+
+      // Finish growing the cache with the state change. We skip shrinking the
+      // cache to the reorg depth in case we need to revert the tree to an
+      // earlier block below.
+      m_tree_cache.grow_cache(tree_sync_start_params.start_block_idx,
+        new_block_hashes,
+        std::move(tree_cache_state_change),
+        true/*skip_shrink_to_reorg_depth*/);
 
       // We had an error in the scanner. Next time the scanner runs, it starts
       // from where it left off. We need to make sure the scanner state matches
       // the tree sync state, so that they start from the same place. Thus, we
       // pop from the tree sync cache until they've synced the same # of blocks.
-      // The reason we call process_synced_blocks above is because
-      // prepare_to_sync_blocks modifies cache state and requires the
-      // corresponding call to process_synced_blocks to complete before popping.
-      // This could be done in a simpler way.
+      // The reason we call grow_cache first is because it is faster/simpler
+      // to add the tree elems in memory first and then remove them.
       while (m_tree_cache.n_synced_blocks() > m_blockchain.size())
       {
+        // Note: it would be fastest to implement popping back to a specific block
         THROW_WALLET_EXCEPTION_IF(!m_tree_cache.pop_block(), error::wallet_internal_error, "Failed to pop block from tree cache");
       }
+
+      // We make sure to call this *after* in case the cache still has more
+      // elems than the reorg depth. We don't call it *before*
+      // (or inside grow_cache) because we may have needed to revert the tree
+      // back to a block before the reorg depth when popping above.
+      m_tree_cache.shrink_to_reorg_depth();
+
+      LOG_PRINT_L2("Finished restoring the tree cache");
     }
 
     std::rethrow_exception(std::current_exception());
     return;
   }
 
-  // Now that we've processed all received outputs, call process_synced_blocks
+  // Now that we've processed all received outputs, call grow_cache
   // to save the elems we need from the tree, and get rid of the rest of the
   // tree elems we no longer need.
   LOG_PRINT_L3("Building the tree...");
   THROW_WALLET_EXCEPTION_IF(!tree_sync_blocks_waiter.wait(), error::wallet_internal_error, "Exception in thread pool");
   LOG_PRINT_L3("Done waiting on tree build");
-  m_tree_cache.process_synced_blocks(tree_sync_start_params.start_block_idx, new_block_hashes, tree_extension, new_leaf_tuples_per_block);
+  m_tree_cache.grow_cache(tree_sync_start_params.start_block_idx, new_block_hashes, std::move(tree_cache_state_change));
+  LOG_PRINT_L3("Done growing the tree cache");
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::refresh(bool trusted_daemon)

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -123,10 +123,9 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
   tree_cache.register_output(output_pair, cryptonote::get_last_locked_block_index(blocks[0].miner_tx.unlock_time, 0));
 
   // Build the tree, keeping track of output's path in the tree
-  fcmp_pp::curve_trees::CurveTreesV1::TreeExtension tree_extension;
-  std::vector<uint64_t> n_new_leaf_tuples_per_block;
-  tree_cache.prepare_to_sync_blocks(0, {}, new_block_hashes, outs_by_last_locked_blocks, tree_extension, n_new_leaf_tuples_per_block);
-  tree_cache.process_synced_blocks(0, new_block_hashes, tree_extension, n_new_leaf_tuples_per_block);
+  fcmp_pp::curve_trees::TreeCacheV1::CacheStateChange tree_cache_state_change;
+  tree_cache.prepare_to_grow_cache(0, {}, new_block_hashes, outs_by_last_locked_blocks, tree_cache_state_change);
+  tree_cache.grow_cache(0, new_block_hashes, std::move(tree_cache_state_change));
   const uint64_t n_synced_blocks = tree_cache.n_synced_blocks();
   if (n_synced_blocks == 0)
   {

--- a/tests/unit_tests/tree_cache.cpp
+++ b/tests/unit_tests/tree_cache.cpp
@@ -188,20 +188,17 @@ TEST(tree_cache, sync_n_chunks_of_blocks)
     {
         const uint64_t start_block_idx = i * N_BLOCKS_PER_CHUNK;
 
-        fcmp_pp::curve_trees::CurveTrees<Selene, Helios>::TreeExtension tree_extension;
-        std::vector<uint64_t> n_new_leaf_tuples_per_block;
+        fcmp_pp::curve_trees::TreeCache<Selene, Helios>::CacheStateChange cache_state_change;
 
-        tree_cache->prepare_to_sync_blocks(start_block_idx,
+        tree_cache->prepare_to_grow_cache(start_block_idx,
             mock_block_hash,
             chunks_of_block_hashes[i],
             chunks_of_outputs[i],
-            tree_extension,
-            n_new_leaf_tuples_per_block);
+            cache_state_change);
 
-        tree_cache->process_synced_blocks(start_block_idx,
+        tree_cache->grow_cache(start_block_idx,
             chunks_of_block_hashes[i],
-            tree_extension,
-            n_new_leaf_tuples_per_block);
+            std::move(cache_state_change));
 
         // Audit the output's path in the tree
         CurveTreesV1::Path output_path;


### PR DESCRIPTION
**Context**

When processing a chunk of blocks in wallet2, the "tree cache" and the "wallet scanner" make progress in separate threads, and when both are done, I make sure they've processed to the same block at the end of `process_parsed_blocks`.

It's possible that the wallet scanner encounters an error part way through scanning a chunk of blocks (e.g. identifies a receive and user needs to provide their password), and then stops progressing and throws an error. However, the tree cache continues its work for the full chunk of blocks. Thus, when handling the wallet scanner error, we need to be sure to reconcile this discrepancy and make sure that the tree cache ends up at the same block as the scanner.

**The problem**

 When the tree cache advanced > 100 blocks past the wallet scanner (i.e. the discrepancy between wallet scanner and tree cache exceeds the max reorg depth), the tree cache was not able to recover properly because it was throwing away data from before the reorg depth that it would need in order to get the tree to the correct state.
 
 **The solution**
 
 Add a function `TreeCache<C1, C2>::shrink_to_reorg_depth()` so that when wallet2 encounters the wallet scan error, it can delay throwing away potentially needed data until after it has reached parity with the wallet scanner.
 
 **Other stuff in this PR**
 
 Sorry I also threw in some other stuff here I've been wanting to do in a cleanup pass that I initially thought I would need for this:

- Implemented a const `prepare_to_grow_cache` function which returns a struct we can use to call `grow_cache`. This replaces the `prepare_to_sync_blocks` and `process_synced_blocks` functions respectively. I didn't like how `prepare_to_sync_blocks` made stateful changes to the cache, it complicated the mental model for the cache. This feels cleaner (although represents the bulk of changes in this PR and wasn't exactly required to solve the bug).
- Demoted some debug statements to log level 3 to cut down on some noise.