### PR TITLE
Destroy Rust FFI types correctly

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3328,7 +3328,7 @@ bool Blockchain::have_tx_keyimges_as_spent(const transaction &tx) const
   }
   return false;
 }
-bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const uint8_t *tree_root)
+bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const fcmp_pp::TreeRoot &tree_root)
 {
   PERF_TIMER(expand_transaction_2);
   CHECK_AND_ASSERT_MES(tx.version == 2, false, "Transaction version is not 2");

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3328,7 +3328,7 @@ bool Blockchain::have_tx_keyimges_as_spent(const transaction &tx) const
   }
   return false;
 }
-bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const fcmp_pp::TreeRoot &tree_root)
+bool Blockchain::expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const fcmp_pp::TreeRootShared &tree_root)
 {
   PERF_TIMER(expand_transaction_2);
   CHECK_AND_ASSERT_MES(tx.version == 2, false, "Transaction version is not 2");

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -616,7 +616,7 @@ namespace cryptonote
      * can be reconstituted by the receiver. This function expands
      * that implicit data.
      */
-    static bool expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const uint8_t *tree_root);
+    static bool expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const fcmp_pp::TreeRoot &tree_root);
 
     /**
      * @brief validates a transaction's inputs

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -616,7 +616,7 @@ namespace cryptonote
      * can be reconstituted by the receiver. This function expands
      * that implicit data.
      */
-    static bool expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const fcmp_pp::TreeRoot &tree_root);
+    static bool expand_transaction_2(transaction &tx, const crypto::hash &tx_prefix_hash, const std::vector<std::vector<rct::ctkey>> &pubkeys, const fcmp_pp::TreeRootShared &tree_root);
 
     /**
      * @brief validates a transaction's inputs

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -140,7 +140,7 @@ static bool expand_post_fcmp_tx(transaction& tx, const crypto::hash& tx_prefix_h
     return check_post_fcmp_expanded_tx(tx);
 }
 
-static bool expand_fcmp_pp_tx(cryptonote::transaction& tx, const fcmp_pp::TreeRoot &tree_root)
+static bool expand_fcmp_pp_tx(cryptonote::transaction& tx, const fcmp_pp::TreeRootShared &tree_root)
 {
     // Pruned transactions can not be expanded and verified because they are missing RCT data
     VER_ASSERT(!tx.pruned, "Pruned transaction will not pass verification");
@@ -375,7 +375,7 @@ static crypto::hash calc_tx_anon_set_hash(const cryptonote::transaction& tx,
 static bool collect_fcmp_pp_tx_verify_inputs(cryptonote::transaction &tx,
     rct_ver_cache_t& cache,
     const std::unordered_map<uint64_t, std::pair<crypto::ec_point, uint8_t>>& tree_root_by_block_index,
-    std::unordered_map<uint64_t, fcmp_pp::TreeRoot> &decompressed_tree_roots_by_block_index,
+    std::unordered_map<uint64_t, fcmp_pp::TreeRootShared> &decompressed_tree_roots_by_block_index,
     std::vector<fcmp_pp::FcmpPpVerifyInput> &fcmp_pp_verify_inputs,
     std::vector<crypto::hash> &new_cache_hashes)
 {
@@ -695,7 +695,7 @@ bool batch_ver_fcmp_pp_consensus
     VER_ASSERT(caching_fcmp_pp_txs, "Make sure batch verification works correctly with this type and then enable it in the code here.");
 
     // Collect unverified FCMP++ txs for batch verfication
-    std::unordered_map<uint64_t, fcmp_pp::TreeRoot> decompressed_tree_roots_by_block_index;
+    std::unordered_map<uint64_t, fcmp_pp::TreeRootShared> decompressed_tree_roots_by_block_index;
     std::vector<fcmp_pp::FcmpPpVerifyInput> fcmp_pp_verify_inputs;
     std::vector<crypto::hash> new_cache_hashes;
 

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -376,7 +376,7 @@ static bool collect_fcmp_pp_tx_verify_inputs(cryptonote::transaction &tx,
     rct_ver_cache_t& cache,
     const std::unordered_map<uint64_t, std::pair<crypto::ec_point, uint8_t>>& tree_root_by_block_index,
     std::unordered_map<uint64_t, fcmp_pp::TreeRoot> &decompressed_tree_roots_by_block_index,
-    std::vector<fcmp_pp::FcmpVerifyInput> &fcmp_pp_verify_inputs,
+    std::vector<fcmp_pp::FcmpPpVerifyInput> &fcmp_pp_verify_inputs,
     std::vector<crypto::hash> &new_cache_hashes)
 {
     VER_ASSERT(tx.rct_signatures.type == rct::RCTTypeFcmpPlusPlus, "expected FCMP++ RCT Type");
@@ -440,7 +440,7 @@ static bool collect_fcmp_pp_tx_verify_inputs(cryptonote::transaction &tx,
     for (const auto &po : pseudoOuts)
         pseudo_outs.emplace_back(rct::rct2pt(po));
 
-    auto fcmp_pp_verify_input = fcmp_pp::fcmp_verify_input_new(
+    auto fcmp_pp_verify_input = fcmp_pp::fcmp_pp_verify_input_new(
             rct::rct2hash(signable_tx_hash),
             rv.p.fcmp_pp,
             n_tree_layers,
@@ -696,7 +696,7 @@ bool batch_ver_fcmp_pp_consensus
 
     // Collect unverified FCMP++ txs for batch verfication
     std::unordered_map<uint64_t, fcmp_pp::TreeRoot> decompressed_tree_roots_by_block_index;
-    std::vector<fcmp_pp::FcmpVerifyInput> fcmp_pp_verify_inputs;
+    std::vector<fcmp_pp::FcmpPpVerifyInput> fcmp_pp_verify_inputs;
     std::vector<crypto::hash> new_cache_hashes;
 
     fcmp_pp_verify_inputs.reserve(ps.txs_by_txid.size());

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -376,7 +376,7 @@ static bool collect_fcmp_pp_tx_verify_inputs(cryptonote::transaction &tx,
     rct_ver_cache_t& cache,
     const std::unordered_map<uint64_t, std::pair<crypto::ec_point, uint8_t>>& tree_root_by_block_index,
     std::unordered_map<uint64_t, fcmp_pp::TreeRoot> &decompressed_tree_roots_by_block_index,
-    std::vector<const uint8_t*> &fcmp_pp_verify_inputs,
+    std::vector<fcmp_pp::FcmpVerifyInput> &fcmp_pp_verify_inputs,
     std::vector<crypto::hash> &new_cache_hashes)
 {
     VER_ASSERT(tx.rct_signatures.type == rct::RCTTypeFcmpPlusPlus, "expected FCMP++ RCT Type");
@@ -440,7 +440,7 @@ static bool collect_fcmp_pp_tx_verify_inputs(cryptonote::transaction &tx,
     for (const auto &po : pseudoOuts)
         pseudo_outs.emplace_back(rct::rct2pt(po));
 
-    uint8_t *fcmp_pp_verify_input = fcmp_pp::fcmp_pp_verify_input_new(
+    auto fcmp_pp_verify_input = fcmp_pp::fcmp_verify_input_new(
             rct::rct2hash(signable_tx_hash),
             rv.p.fcmp_pp,
             n_tree_layers,
@@ -696,7 +696,7 @@ bool batch_ver_fcmp_pp_consensus
 
     // Collect unverified FCMP++ txs for batch verfication
     std::unordered_map<uint64_t, fcmp_pp::TreeRoot> decompressed_tree_roots_by_block_index;
-    std::vector<const uint8_t*> fcmp_pp_verify_inputs;
+    std::vector<fcmp_pp::FcmpVerifyInput> fcmp_pp_verify_inputs;
     std::vector<crypto::hash> new_cache_hashes;
 
     fcmp_pp_verify_inputs.reserve(ps.txs_by_txid.size());
@@ -731,7 +731,7 @@ bool batch_ver_fcmp_pp_consensus
 
     // Ok, we're ready to batch verify all FCMP++ txs now
     MDEBUG("Batch verifying " << fcmp_pp_verify_inputs.size() << " FCMP++ txs");
-    if (!fcmp_pp::batch_verify(fcmp_pp_verify_inputs))
+    if (!fcmp_pp::verify(fcmp_pp_verify_inputs))
     {
         return false;
     }

--- a/src/cryptonote_core/tx_verification_utils.cpp
+++ b/src/cryptonote_core/tx_verification_utils.cpp
@@ -140,7 +140,7 @@ static bool expand_post_fcmp_tx(transaction& tx, const crypto::hash& tx_prefix_h
     return check_post_fcmp_expanded_tx(tx);
 }
 
-static bool expand_fcmp_pp_tx(cryptonote::transaction& tx, uint8_t *tree_root)
+static bool expand_fcmp_pp_tx(cryptonote::transaction& tx, const fcmp_pp::TreeRoot &tree_root)
 {
     // Pruned transactions can not be expanded and verified because they are missing RCT data
     VER_ASSERT(!tx.pruned, "Pruned transaction will not pass verification");
@@ -375,7 +375,7 @@ static crypto::hash calc_tx_anon_set_hash(const cryptonote::transaction& tx,
 static bool collect_fcmp_pp_tx_verify_inputs(cryptonote::transaction &tx,
     rct_ver_cache_t& cache,
     const std::unordered_map<uint64_t, std::pair<crypto::ec_point, uint8_t>>& tree_root_by_block_index,
-    std::unordered_map<uint64_t, uint8_t *> &decompressed_tree_roots_by_block_index,
+    std::unordered_map<uint64_t, fcmp_pp::TreeRoot> &decompressed_tree_roots_by_block_index,
     std::vector<const uint8_t*> &fcmp_pp_verify_inputs,
     std::vector<crypto::hash> &new_cache_hashes)
 {
@@ -421,7 +421,7 @@ static bool collect_fcmp_pp_tx_verify_inputs(cryptonote::transaction &tx,
     }
 
     // Get decompressed tree root from map
-    uint8_t *decompressed_tree_root = decompressed_tree_roots_by_block_index[ref_block_index];
+    const auto &decompressed_tree_root = decompressed_tree_roots_by_block_index[ref_block_index];
 
     if (!expand_fcmp_pp_tx(tx, decompressed_tree_root))
     {
@@ -695,7 +695,7 @@ bool batch_ver_fcmp_pp_consensus
     VER_ASSERT(caching_fcmp_pp_txs, "Make sure batch verification works correctly with this type and then enable it in the code here.");
 
     // Collect unverified FCMP++ txs for batch verfication
-    std::unordered_map<uint64_t, uint8_t *> decompressed_tree_roots_by_block_index;
+    std::unordered_map<uint64_t, fcmp_pp::TreeRoot> decompressed_tree_roots_by_block_index;
     std::vector<const uint8_t*> fcmp_pp_verify_inputs;
     std::vector<crypto::hash> new_cache_hashes;
 

--- a/src/fcmp_pp/CMakeLists.txt
+++ b/src/fcmp_pp/CMakeLists.txt
@@ -29,6 +29,7 @@
 set(fcmp_pp_sources
   curve_trees.cpp
   fcmp_pp_crypto.cpp
+  fcmp_pp_types.cpp
   proof_len.cpp
   prove.cpp
   tower_cycle.cpp

--- a/src/fcmp_pp/curve_trees.cpp
+++ b/src/fcmp_pp/curve_trees.cpp
@@ -1485,7 +1485,7 @@ GrowLayerInstructions CurveTrees<C1, C2>::set_next_layer_extension(
 };
 //----------------------------------------------------------------------------------------------------------------------
 template<>
-TreeRoot CurveTrees<Selene, Helios>::get_tree_root_from_bytes(const std::size_t n_layers,
+TreeRootShared CurveTrees<Selene, Helios>::get_tree_root_from_bytes(const std::size_t n_layers,
     const crypto::ec_point &tree_root) const
 {
     if (n_layers == 0)

--- a/src/fcmp_pp/curve_trees.cpp
+++ b/src/fcmp_pp/curve_trees.cpp
@@ -1485,16 +1485,16 @@ GrowLayerInstructions CurveTrees<C1, C2>::set_next_layer_extension(
 };
 //----------------------------------------------------------------------------------------------------------------------
 template<>
-uint8_t *CurveTrees<Selene, Helios>::get_tree_root_from_bytes(const std::size_t n_layers,
+TreeRoot CurveTrees<Selene, Helios>::get_tree_root_from_bytes(const std::size_t n_layers,
     const crypto::ec_point &tree_root) const
 {
     if (n_layers == 0)
         return nullptr;
 
     if ((n_layers % 2) == 0)
-        return fcmp_pp::tower_cycle::helios_tree_root(m_c2->from_bytes(tree_root));
+        return fcmp_pp::helios_tree_root(m_c2->from_bytes(tree_root));
     else
-        return fcmp_pp::tower_cycle::selene_tree_root(m_c1->from_bytes(tree_root));
+        return fcmp_pp::selene_tree_root(m_c1->from_bytes(tree_root));
 }
 //----------------------------------------------------------------------------------------------------------------------
 template<>

--- a/src/fcmp_pp/curve_trees.h
+++ b/src/fcmp_pp/curve_trees.h
@@ -356,7 +356,7 @@ public:
     // Audit the provided path
     bool audit_path(const Path &path, const OutputPair &output, const uint64_t n_leaf_tuples_in_tree) const;
 
-    uint8_t *get_tree_root_from_bytes(const std::size_t n_layers, const crypto::ec_point &tree_root) const;
+    TreeRoot get_tree_root_from_bytes(const std::size_t n_layers, const crypto::ec_point &tree_root) const;
 
     PathForProof path_for_proof(const Path &path, const OutputTuple &output_tuple) const;
 

--- a/src/fcmp_pp/curve_trees.h
+++ b/src/fcmp_pp/curve_trees.h
@@ -356,7 +356,7 @@ public:
     // Audit the provided path
     bool audit_path(const Path &path, const OutputPair &output, const uint64_t n_leaf_tuples_in_tree) const;
 
-    TreeRoot get_tree_root_from_bytes(const std::size_t n_layers, const crypto::ec_point &tree_root) const;
+    TreeRootShared get_tree_root_from_bytes(const std::size_t n_layers, const crypto::ec_point &tree_root) const;
 
     PathForProof path_for_proof(const Path &path, const OutputTuple &output_tuple) const;
 

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -268,20 +268,6 @@ CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rera
                                         struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                         struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
 
-CResult fcmp_pp_prove_input_new(const uint8_t *x,
-                                             const uint8_t *y,
-                                             const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
-                                             const struct PathUnsafe *path,
-                                             const struct OutputBlindsUnsafe *output_blinds,
-                                             struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
-                                             struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
-
-CResult balance_last_pseudo_out(const uint8_t *sum_input_masks,
-                                             const uint8_t *sum_output_masks,
-                                             struct ObjectSlice fcmp_prove_inputs);
-
-uint8_t *read_input_pseudo_out(const uint8_t *fcmp_prove_input);
-
 CResult prove(const uint8_t *signable_tx_hash,
                                              struct ObjectSlice fcmp_prove_inputs,
                                              uintptr_t n_tree_layers);

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -147,6 +147,8 @@ struct ObjectSlice
 
 struct TreeRootUnsafe;
 
+struct PathUnsafe;
+
 struct HeliosBranchBlindUnsafe;
 struct SeleneBranchBlindUnsafe;
 
@@ -214,10 +216,13 @@ int hash_grow_selene(struct SelenePoint existing_hash,
                                              struct SeleneScalarSlice new_children,
                                              struct SelenePoint *hash_out);
 
-CResult path_new(struct OutputSlice leaves,
+int path_new(struct OutputSlice leaves,
                                              uintptr_t output_idx,
                                              struct HeliosScalarChunks helios_layer_chunks,
-                                             struct SeleneScalarChunks selene_layer_chunks);
+                                             struct SeleneScalarChunks selene_layer_chunks,
+                                             struct PathUnsafe **path_out);
+
+void destroy_path(struct PathUnsafe *path);
 
 int rerandomize_output(struct OutputBytes output,
                                             struct FcmpRerandomizedOutputCompressed *rerandomized_output_out);
@@ -253,7 +258,7 @@ void destroy_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_b
 void destroy_selene_branch_blind(struct SeleneBranchBlindUnsafe *selene_branch_blind);
 
 CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
-                                        const uint8_t *path,
+                                        const struct PathUnsafe *path,
                                         const uint8_t *output_blinds,
                                         struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                         struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
@@ -261,7 +266,7 @@ CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rera
 CResult fcmp_pp_prove_input_new(const uint8_t *x,
                                              const uint8_t *y,
                                              const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
-                                             const uint8_t *path,
+                                             const struct PathUnsafe *path,
                                              const uint8_t *output_blinds,
                                              struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                              struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -147,7 +147,7 @@ struct ObjectSlice
 
 struct HeliosBranchBlindUnsafe;
 
-struct HeliosBranchBlindSlice
+struct HeliosBranchBlindSliceUnsafe
 {
   const struct HeliosBranchBlindUnsafe * const *buf;
   uintptr_t len;
@@ -234,7 +234,7 @@ CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rera
                                         const uint8_t *path,
                                         const uint8_t *output_blinds,
                                         struct ObjectSlice selene_branch_blinds,
-                                        struct HeliosBranchBlindSlice helios_branch_blinds);
+                                        struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
 
 CResult fcmp_pp_prove_input_new(const uint8_t *x,
                                              const uint8_t *y,
@@ -242,7 +242,7 @@ CResult fcmp_pp_prove_input_new(const uint8_t *x,
                                              const uint8_t *path,
                                              const uint8_t *output_blinds,
                                              struct ObjectSlice selene_branch_blinds,
-                                             struct HeliosBranchBlindSlice helios_branch_blinds);
+                                             struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
 
 CResult balance_last_pseudo_out(const uint8_t *sum_input_masks,
                                              const uint8_t *sum_output_masks,

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -145,6 +145,8 @@ struct ObjectSlice
   uintptr_t len;
 };
 
+struct HeliosBranchBlindUnsafe;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -219,9 +221,9 @@ CResult output_blinds_new(const uint8_t *o_blind,
 CResult helios_branch_blind(void);
 CResult selene_branch_blind(void);
 
-int helios_branch_blind2(uint8_t **branch_blind_out);
+int new_helios_branch_blind(struct HeliosBranchBlindUnsafe **branch_blind_out);
 
-void free_helios_branch_blind(uint8_t *helios_branch_blind);
+void free_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_blind);
 
 CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
                                         const uint8_t *path,

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -154,8 +154,8 @@ struct BlindedCBlindUnsafe;
 
 struct OutputBlindsUnsafe;
 
-struct FcmpProveInputUnsafe;
-struct FcmpVerifyInputUnsafe;
+struct FcmpPpProveInputUnsafe;
+struct FcmpPpVerifyInputUnsafe;
 
 struct HeliosBranchBlindSliceUnsafe
 {
@@ -169,15 +169,15 @@ struct SeleneBranchBlindSliceUnsafe
   uintptr_t len;
 };
 
-struct FcmpProveInputSliceUnsafe
+struct FcmpPpProveInputSliceUnsafe
 {
-  const struct FcmpProveInputUnsafe * const *buf;
+  const struct FcmpPpProveInputUnsafe * const *buf;
   uintptr_t len;
 };
 
-struct FcmpVerifyInputSliceUnsafe
+struct FcmpPpVerifyInputSliceUnsafe
 {
-  const struct FcmpVerifyInputUnsafe * const *buf;
+  const struct FcmpPpVerifyInputUnsafe * const *buf;
   uintptr_t len;
 };
 
@@ -272,13 +272,13 @@ int generate_selene_branch_blind(struct SeleneBranchBlindUnsafe **branch_blind_o
 void destroy_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_blind);
 void destroy_selene_branch_blind(struct SeleneBranchBlindUnsafe *selene_branch_blind);
 
-int fcmp_prove_input_new(const struct PathUnsafe *path,
+int fcmp_pp_prove_input_new(const struct PathUnsafe *path,
                                         const struct OutputBlindsUnsafe *output_blinds,
                                         struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                         struct HeliosBranchBlindSliceUnsafe helios_branch_blinds,
-                                        struct FcmpProveInputUnsafe **fcmp_prove_input_out);
+                                        struct FcmpPpProveInputUnsafe **fcmp_pp_prove_input_out);
 
-void destroy_fcmp_prove_input(struct FcmpProveInputUnsafe *fcmp_prove_input);
+void destroy_fcmp_pp_prove_input(struct FcmpPpProveInputUnsafe *fcmp_pp_prove_input);
 
 /**
  * brief: fcmp_pp_prove_sal - Make a FCMP++ spend auth & linkability proof
@@ -303,14 +303,14 @@ int fcmp_pp_prove_sal(const uint8_t signable_tx_hash[32],
 
 /**
  * brief: fcmp_pp_prove_membership - Make a FCMP++ membership proof for N inputs
- * param: inputs - a slice of FCMP provable inputs returned from fcmp_prove_input_new()
+ * param: inputs - a slice of FCMP provable inputs returned from fcmp_pp_prove_input_new()
  * param: n_tree_layers -
  * param: proof_len -
  * outparam: fcmp_proof_out - a buffer where the FCMP proof will be written to
  * outparam: fcmp_proof_out_size - the max length of the buffer fcmp_proof_out, is set to written proof size
  * return: an error on failure, nothing otherwise
  */
-int fcmp_pp_prove_membership(const struct FcmpProveInputSliceUnsafe fcmp_prove_inputs,
+int fcmp_pp_prove_membership(const struct FcmpPpProveInputSliceUnsafe fcmp_pp_prove_inputs,
                                              uintptr_t n_tree_layers,
                                              uintptr_t proof_len,
                                              uint8_t fcmp_proof_out[],
@@ -329,9 +329,9 @@ int fcmp_pp_verify_input_new(const uint8_t *signable_tx_hash,
                                              const struct TreeRootUnsafe *tree_root,
                                              struct ObjectSlice pseudo_outs,
                                              struct ObjectSlice key_images,
-                                             struct FcmpVerifyInputUnsafe **fcmp_verify_input_out);
+                                             struct FcmpPpVerifyInputUnsafe **fcmp_pp_verify_input_out);
 
-void destroy_fcmp_verify_input(struct FcmpVerifyInputUnsafe *fcmp_verify_input);
+void destroy_fcmp_pp_verify_input(struct FcmpPpVerifyInputUnsafe *fcmp_pp_verify_input);
 
 /**
  * brief: fcmp_pp_verify_sal - Verify a FCMP++ spend auth & linkability proof
@@ -360,7 +360,7 @@ bool fcmp_pp_verify_membership(struct InputSlice inputs,
   const uint8_t fcmp_proof[],
   const uintptr_t fcmp_proof_len);
 
-bool fcmp_pp_verify(const struct FcmpVerifyInputSliceUnsafe fcmp_pp_verify_inputs);
+bool fcmp_pp_verify(const struct FcmpPpVerifyInputSliceUnsafe fcmp_pp_verify_inputs);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -199,15 +199,17 @@ uint8_t *selene_tree_root(struct SelenePoint selene_point);
 
 uint8_t *helios_tree_root(struct HeliosPoint helios_point);
 
-CResult hash_grow_helios(struct HeliosPoint existing_hash,
+int hash_grow_helios(struct HeliosPoint existing_hash,
                                              uintptr_t offset,
                                              struct HeliosScalar existing_child_at_offset,
-                                             struct HeliosScalarSlice new_children);
+                                             struct HeliosScalarSlice new_children,
+                                             struct HeliosPoint *hash_out);
 
-CResult hash_grow_selene(struct SelenePoint existing_hash,
+int hash_grow_selene(struct SelenePoint existing_hash,
                                              uintptr_t offset,
                                              struct SeleneScalar existing_child_at_offset,
-                                             struct SeleneScalarSlice new_children);
+                                             struct SeleneScalarSlice new_children,
+                                             struct SelenePoint *hash_out);
 
 CResult path_new(struct OutputSlice leaves,
                                              uintptr_t output_idx,

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -154,7 +154,7 @@ struct BlindedCBlindUnsafe;
 
 struct OutputBlindsUnsafe;
 
-struct FcmpPpProveInputUnsafe;
+struct FcmpPpProveMembershipInputUnsafe;
 struct FcmpPpVerifyInputUnsafe;
 
 struct HeliosBranchBlindSliceUnsafe
@@ -169,9 +169,9 @@ struct SeleneBranchBlindSliceUnsafe
   uintptr_t len;
 };
 
-struct FcmpPpProveInputSliceUnsafe
+struct FcmpPpProveMembershipInputSliceUnsafe
 {
-  const struct FcmpPpProveInputUnsafe * const *buf;
+  const struct FcmpPpProveMembershipInputUnsafe * const *buf;
   uintptr_t len;
 };
 
@@ -276,9 +276,9 @@ int fcmp_pp_prove_input_new(const struct PathUnsafe *path,
                                         const struct OutputBlindsUnsafe *output_blinds,
                                         struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                         struct HeliosBranchBlindSliceUnsafe helios_branch_blinds,
-                                        struct FcmpPpProveInputUnsafe **fcmp_pp_prove_input_out);
+                                        struct FcmpPpProveMembershipInputUnsafe **fcmp_pp_prove_input_out);
 
-void destroy_fcmp_pp_prove_input(struct FcmpPpProveInputUnsafe *fcmp_pp_prove_input);
+void destroy_fcmp_pp_prove_input(struct FcmpPpProveMembershipInputUnsafe *fcmp_pp_prove_input);
 
 /**
  * brief: fcmp_pp_prove_sal - Make a FCMP++ spend auth & linkability proof
@@ -310,7 +310,7 @@ int fcmp_pp_prove_sal(const uint8_t signable_tx_hash[32],
  * outparam: fcmp_proof_out_size - the max length of the buffer fcmp_proof_out, is set to written proof size
  * return: an error on failure, nothing otherwise
  */
-int fcmp_pp_prove_membership(const struct FcmpPpProveInputSliceUnsafe fcmp_pp_prove_inputs,
+int fcmp_pp_prove_membership(const struct FcmpPpProveMembershipInputSliceUnsafe fcmp_pp_prove_inputs,
                                              uintptr_t n_tree_layers,
                                              uintptr_t proof_len,
                                              uint8_t fcmp_proof_out[],

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -146,10 +146,17 @@ struct ObjectSlice
 };
 
 struct HeliosBranchBlindUnsafe;
+struct SeleneBranchBlindUnsafe;
 
 struct HeliosBranchBlindSliceUnsafe
 {
   const struct HeliosBranchBlindUnsafe * const *buf;
+  uintptr_t len;
+};
+
+struct SeleneBranchBlindSliceUnsafe
+{
+  const struct SeleneBranchBlindUnsafe * const *buf;
   uintptr_t len;
 };
 
@@ -224,16 +231,16 @@ CResult output_blinds_new(const uint8_t *o_blind,
                                              const uint8_t *i_blind_blind,
                                              const uint8_t *c_blind);
 
-CResult selene_branch_blind(void);
-
 int generate_helios_branch_blind(struct HeliosBranchBlindUnsafe **branch_blind_out);
+int generate_selene_branch_blind(struct SeleneBranchBlindUnsafe **branch_blind_out);
 
 void destroy_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_blind);
+void destroy_selene_branch_blind(struct SeleneBranchBlindUnsafe *selene_branch_blind);
 
 CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
                                         const uint8_t *path,
                                         const uint8_t *output_blinds,
-                                        struct ObjectSlice selene_branch_blinds,
+                                        struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                         struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
 
 CResult fcmp_pp_prove_input_new(const uint8_t *x,
@@ -241,7 +248,7 @@ CResult fcmp_pp_prove_input_new(const uint8_t *x,
                                              const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
                                              const uint8_t *path,
                                              const uint8_t *output_blinds,
-                                             struct ObjectSlice selene_branch_blinds,
+                                             struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                              struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
 
 CResult balance_last_pseudo_out(const uint8_t *sum_input_masks,

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -145,6 +145,8 @@ struct ObjectSlice
   uintptr_t len;
 };
 
+struct TreeRootUnsafe;
+
 struct HeliosBranchBlindUnsafe;
 struct SeleneBranchBlindUnsafe;
 
@@ -195,9 +197,10 @@ struct HeliosScalar helios_zero_scalar(void);
 
 struct SeleneScalar selene_zero_scalar(void);
 
-uint8_t *selene_tree_root(struct SelenePoint selene_point);
+int selene_tree_root(struct SelenePoint selene_point, struct TreeRootUnsafe **tree_root_out);
+int helios_tree_root(struct HeliosPoint helios_point, struct TreeRootUnsafe **tree_root_out);
 
-uint8_t *helios_tree_root(struct HeliosPoint helios_point);
+void destroy_tree_root(struct TreeRootUnsafe *tree_root);
 
 int hash_grow_helios(struct HeliosPoint existing_hash,
                                              uintptr_t offset,
@@ -319,7 +322,7 @@ CResult fcmp_pp_verify_input_new(const uint8_t *signable_tx_hash,
                                              const uint8_t *fcmp_pp_proof,
                                              uintptr_t fcmp_pp_proof_len,
                                              uintptr_t n_tree_layers,
-                                             const uint8_t *tree_root,
+                                             const struct TreeRootUnsafe *tree_root,
                                              struct ObjectSlice pseudo_outs,
                                              struct ObjectSlice key_images);
 
@@ -327,7 +330,7 @@ bool verify(const uint8_t *signable_tx_hash,
                                              const uint8_t *fcmp_pp_proof,
                                              uintptr_t fcmp_pp_proof_len,
                                              uintptr_t n_tree_layers,
-                                             const uint8_t *tree_root,
+                                             const struct TreeRootUnsafe *tree_root,
                                              struct ObjectSlice pseudo_outs,
                                              struct ObjectSlice key_images);
 /**
@@ -352,7 +355,7 @@ bool fcmp_pp_verify_sal(const uint8_t signable_tx_hash[32],
  * return: true on verification success, false otherwise
  */
 bool fcmp_pp_verify_membership(struct InputSlice inputs,
-  const uint8_t *tree_root,
+  const struct TreeRootUnsafe *tree_root,
   const uintptr_t n_tree_layers,
   const uint8_t fcmp_proof[],
   const uintptr_t fcmp_proof_len);

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -221,9 +221,9 @@ CResult output_blinds_new(const uint8_t *o_blind,
 CResult helios_branch_blind(void);
 CResult selene_branch_blind(void);
 
-int new_helios_branch_blind(struct HeliosBranchBlindUnsafe **branch_blind_out);
+int generate_helios_branch_blind(struct HeliosBranchBlindUnsafe **branch_blind_out);
 
-void free_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_blind);
+void destroy_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_blind);
 
 CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
                                         const uint8_t *path,

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -70,11 +70,6 @@ struct SelenePoint {
 
 // ----- End deps C bindings -----
 
-typedef struct CResult {
-  void* value;
-  void* err;
-} CResult;
-
 struct OutputBytes {
   const uint8_t *O_bytes;
   const uint8_t *I_bytes;
@@ -160,6 +155,7 @@ struct BlindedCBlindUnsafe;
 struct OutputBlindsUnsafe;
 
 struct FcmpProveInputUnsafe;
+struct FcmpVerifyInputUnsafe;
 
 struct HeliosBranchBlindSliceUnsafe
 {
@@ -176,6 +172,12 @@ struct SeleneBranchBlindSliceUnsafe
 struct FcmpProveInputSliceUnsafe
 {
   const struct FcmpProveInputUnsafe * const *buf;
+  uintptr_t len;
+};
+
+struct FcmpVerifyInputSliceUnsafe
+{
+  const struct FcmpVerifyInputUnsafe * const *buf;
   uintptr_t len;
 };
 
@@ -320,21 +322,17 @@ uintptr_t _slow_membership_proof_size(uintptr_t n_inputs, uintptr_t n_tree_layer
 
 uintptr_t _slow_fcmp_pp_proof_size(uintptr_t n_inputs, uintptr_t n_tree_layers);
 
-CResult fcmp_pp_verify_input_new(const uint8_t *signable_tx_hash,
+int fcmp_pp_verify_input_new(const uint8_t *signable_tx_hash,
                                              const uint8_t *fcmp_pp_proof,
                                              uintptr_t fcmp_pp_proof_len,
                                              uintptr_t n_tree_layers,
                                              const struct TreeRootUnsafe *tree_root,
                                              struct ObjectSlice pseudo_outs,
-                                             struct ObjectSlice key_images);
+                                             struct ObjectSlice key_images,
+                                             struct FcmpVerifyInputUnsafe **fcmp_verify_input_out);
 
-bool verify(const uint8_t *signable_tx_hash,
-                                             const uint8_t *fcmp_pp_proof,
-                                             uintptr_t fcmp_pp_proof_len,
-                                             uintptr_t n_tree_layers,
-                                             const struct TreeRootUnsafe *tree_root,
-                                             struct ObjectSlice pseudo_outs,
-                                             struct ObjectSlice key_images);
+void destroy_fcmp_verify_input(struct FcmpVerifyInputUnsafe *fcmp_verify_input);
+
 /**
  * brief: fcmp_pp_verify_sal - Verify a FCMP++ spend auth & linkability proof
  * param: signable_tx_hash - message to verify
@@ -362,7 +360,7 @@ bool fcmp_pp_verify_membership(struct InputSlice inputs,
   const uint8_t fcmp_proof[],
   const uintptr_t fcmp_proof_len);
 
-bool fcmp_pp_batch_verify(struct ObjectSlice fcmp_pp_verify_inputs);
+bool fcmp_pp_verify(const struct FcmpVerifyInputSliceUnsafe fcmp_pp_verify_inputs);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -148,6 +148,11 @@ struct ObjectSlice
 struct HeliosBranchBlindUnsafe;
 struct SeleneBranchBlindUnsafe;
 
+struct BlindedOBlindUnsafe;
+struct BlindedIBlindUnsafe;
+struct BlindedIBlindBlindUnsafe;
+struct BlindedCBlindUnsafe;
+
 struct HeliosBranchBlindSliceUnsafe
 {
   const struct HeliosBranchBlindUnsafe * const *buf;
@@ -221,10 +226,15 @@ int i_blind_blind(const struct FcmpRerandomizedOutputCompressed *rerandomized_ou
 int c_blind(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
   struct SeleneScalar *c_blind_out);
 
-CResult blind_o_blind(const struct SeleneScalar *o_blind);
-CResult blind_i_blind(const struct SeleneScalar *i_blind);
-CResult blind_i_blind_blind(const struct SeleneScalar *i_blind_blind);
-CResult blind_c_blind(const struct SeleneScalar *c_blind);
+int blind_o_blind(const struct SeleneScalar *o_blind, struct BlindedOBlindUnsafe **blinded_o_blind_out);
+int blind_i_blind(const struct SeleneScalar *i_blind, struct BlindedIBlindUnsafe **blinded_i_blind_out);
+int blind_i_blind_blind(const struct SeleneScalar *i_blind_blind, struct BlindedIBlindBlindUnsafe **blinded_i_blind_blind_out);
+int blind_c_blind(const struct SeleneScalar *c_blind, struct BlindedCBlindUnsafe **blinded_c_blind_out);
+
+void destroy_blinded_o_blind(struct BlindedOBlindUnsafe *blinded_o_blind);
+void destroy_blinded_i_blind(struct BlindedIBlindUnsafe *blinded_i_blind);
+void destroy_blinded_i_blind_blind(struct BlindedIBlindBlindUnsafe *blinded_i_blind_blind);
+void destroy_blinded_c_blind(struct BlindedCBlindUnsafe *blinded_c_blind);
 
 CResult output_blinds_new(const uint8_t *o_blind,
                                              const uint8_t *i_blind,

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -157,6 +157,8 @@ struct BlindedIBlindUnsafe;
 struct BlindedIBlindBlindUnsafe;
 struct BlindedCBlindUnsafe;
 
+struct OutputBlindsUnsafe;
+
 struct HeliosBranchBlindSliceUnsafe
 {
   const struct HeliosBranchBlindUnsafe * const *buf;
@@ -246,10 +248,13 @@ void destroy_blinded_i_blind(struct BlindedIBlindUnsafe *blinded_i_blind);
 void destroy_blinded_i_blind_blind(struct BlindedIBlindBlindUnsafe *blinded_i_blind_blind);
 void destroy_blinded_c_blind(struct BlindedCBlindUnsafe *blinded_c_blind);
 
-CResult output_blinds_new(const uint8_t *o_blind,
-                                             const uint8_t *i_blind,
-                                             const uint8_t *i_blind_blind,
-                                             const uint8_t *c_blind);
+int output_blinds_new(const struct BlindedOBlindUnsafe *blinded_o_blind,
+                                             const struct BlindedIBlindUnsafe *blinded_i_blind,
+                                             const struct BlindedIBlindBlindUnsafe *blinded_i_blind_blind,
+                                             const struct BlindedCBlindUnsafe *blidned_c_blind,
+                                             struct OutputBlindsUnsafe **output_blinds_out);
+
+void destroy_output_blinds(struct OutputBlindsUnsafe *output_blinds);
 
 int generate_helios_branch_blind(struct HeliosBranchBlindUnsafe **branch_blind_out);
 int generate_selene_branch_blind(struct SeleneBranchBlindUnsafe **branch_blind_out);
@@ -259,7 +264,7 @@ void destroy_selene_branch_blind(struct SeleneBranchBlindUnsafe *selene_branch_b
 
 CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
                                         const struct PathUnsafe *path,
-                                        const uint8_t *output_blinds,
+                                        const struct OutputBlindsUnsafe *output_blinds,
                                         struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                         struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
 
@@ -267,7 +272,7 @@ CResult fcmp_pp_prove_input_new(const uint8_t *x,
                                              const uint8_t *y,
                                              const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
                                              const struct PathUnsafe *path,
-                                             const uint8_t *output_blinds,
+                                             const struct OutputBlindsUnsafe *output_blinds,
                                              struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                              struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
 

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -159,6 +159,8 @@ struct BlindedCBlindUnsafe;
 
 struct OutputBlindsUnsafe;
 
+struct FcmpProveInputUnsafe;
+
 struct HeliosBranchBlindSliceUnsafe
 {
   const struct HeliosBranchBlindUnsafe * const *buf;
@@ -168,6 +170,12 @@ struct HeliosBranchBlindSliceUnsafe
 struct SeleneBranchBlindSliceUnsafe
 {
   const struct SeleneBranchBlindUnsafe * const *buf;
+  uintptr_t len;
+};
+
+struct FcmpProveInputSliceUnsafe
+{
+  const struct FcmpProveInputUnsafe * const *buf;
   uintptr_t len;
 };
 
@@ -262,10 +270,13 @@ int generate_selene_branch_blind(struct SeleneBranchBlindUnsafe **branch_blind_o
 void destroy_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_blind);
 void destroy_selene_branch_blind(struct SeleneBranchBlindUnsafe *selene_branch_blind);
 
-CResult fcmp_prove_input_new(const struct PathUnsafe *path,
+int fcmp_prove_input_new(const struct PathUnsafe *path,
                                         const struct OutputBlindsUnsafe *output_blinds,
                                         struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
-                                        struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
+                                        struct HeliosBranchBlindSliceUnsafe helios_branch_blinds,
+                                        struct FcmpProveInputUnsafe **fcmp_prove_input_out);
+
+void destroy_fcmp_prove_input(struct FcmpProveInputUnsafe *fcmp_prove_input);
 
 /**
  * brief: fcmp_pp_prove_sal - Make a FCMP++ spend auth & linkability proof
@@ -297,7 +308,7 @@ int fcmp_pp_prove_sal(const uint8_t signable_tx_hash[32],
  * outparam: fcmp_proof_out_size - the max length of the buffer fcmp_proof_out, is set to written proof size
  * return: an error on failure, nothing otherwise
  */
-CResult fcmp_pp_prove_membership(struct ObjectSlice fcmp_prove_inputs,
+int fcmp_pp_prove_membership(const struct FcmpProveInputSliceUnsafe fcmp_prove_inputs,
                                              uintptr_t n_tree_layers,
                                              uintptr_t proof_len,
                                              uint8_t fcmp_proof_out[],

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -262,15 +262,10 @@ int generate_selene_branch_blind(struct SeleneBranchBlindUnsafe **branch_blind_o
 void destroy_helios_branch_blind(struct HeliosBranchBlindUnsafe *helios_branch_blind);
 void destroy_selene_branch_blind(struct SeleneBranchBlindUnsafe *selene_branch_blind);
 
-CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
-                                        const struct PathUnsafe *path,
+CResult fcmp_prove_input_new(const struct PathUnsafe *path,
                                         const struct OutputBlindsUnsafe *output_blinds,
                                         struct SeleneBranchBlindSliceUnsafe selene_branch_blinds,
                                         struct HeliosBranchBlindSliceUnsafe helios_branch_blinds);
-
-CResult prove(const uint8_t *signable_tx_hash,
-                                             struct ObjectSlice fcmp_prove_inputs,
-                                             uintptr_t n_tree_layers);
 
 /**
  * brief: fcmp_pp_prove_sal - Make a FCMP++ spend auth & linkability proof

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -147,6 +147,12 @@ struct ObjectSlice
 
 struct HeliosBranchBlindUnsafe;
 
+struct HeliosBranchBlindSlice
+{
+  const struct HeliosBranchBlindUnsafe * const *buf;
+  uintptr_t len;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -218,7 +224,6 @@ CResult output_blinds_new(const uint8_t *o_blind,
                                              const uint8_t *i_blind_blind,
                                              const uint8_t *c_blind);
 
-CResult helios_branch_blind(void);
 CResult selene_branch_blind(void);
 
 int generate_helios_branch_blind(struct HeliosBranchBlindUnsafe **branch_blind_out);
@@ -229,7 +234,7 @@ CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rera
                                         const uint8_t *path,
                                         const uint8_t *output_blinds,
                                         struct ObjectSlice selene_branch_blinds,
-                                        struct ObjectSlice helios_branch_blinds);
+                                        struct HeliosBranchBlindSlice helios_branch_blinds);
 
 CResult fcmp_pp_prove_input_new(const uint8_t *x,
                                              const uint8_t *y,
@@ -237,7 +242,7 @@ CResult fcmp_pp_prove_input_new(const uint8_t *x,
                                              const uint8_t *path,
                                              const uint8_t *output_blinds,
                                              struct ObjectSlice selene_branch_blinds,
-                                             struct ObjectSlice helios_branch_blinds);
+                                             struct HeliosBranchBlindSlice helios_branch_blinds);
 
 CResult balance_last_pseudo_out(const uint8_t *sum_input_masks,
                                              const uint8_t *sum_output_masks,

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -219,6 +219,10 @@ CResult output_blinds_new(const uint8_t *o_blind,
 CResult helios_branch_blind(void);
 CResult selene_branch_blind(void);
 
+int helios_branch_blind2(uint8_t **branch_blind_out);
+
+void free_helios_branch_blind(uint8_t *helios_branch_blind);
+
 CResult fcmp_prove_input_new(const struct FcmpRerandomizedOutputCompressed *rerandomized_output,
                                         const uint8_t *path,
                                         const uint8_t *output_blinds,

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -541,9 +541,9 @@ pub extern "C" fn helios_branch_blind() -> CResult<BranchBlind<<Helios as Cipher
 /// gets its raw pointer via Box::into_raw, then sets the input pointer's
 /// address to point to the raw box pointer. The input parameter must not
 /// be null. Also be sure to clean up the branch blind with
-/// free_helios_branch_blind below.
+/// destroy_helios_branch_blind below.
 #[no_mangle]
-pub unsafe extern "C" fn new_helios_branch_blind(
+pub unsafe extern "C" fn generate_helios_branch_blind(
     branch_blind_out: *mut *mut BranchBlind::<<Helios as Ciphersuite>::G>,
 ) -> c_int {
     let scalar_decomp = ScalarDecomposition::new(<Helios as Ciphersuite>::F::random(&mut OsRng));
@@ -564,7 +564,7 @@ pub unsafe extern "C" fn new_helios_branch_blind(
 /// This function assumes that branch_blind was allocated on the heap via
 /// Box::into_raw(Box::new())
 #[no_mangle]
-pub unsafe extern "C" fn free_helios_branch_blind(
+pub unsafe extern "C" fn destroy_helios_branch_blind(
     branch_blind: *mut BranchBlind<<Helios as Ciphersuite>::G>,
 ) {
     free_box(branch_blind);

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -192,15 +192,41 @@ pub extern "C" fn selene_zero_scalar() -> SeleneScalar {
     SeleneScalar::ZERO
 }
 
+/// # Safety
+///
+/// This function expects a non-null pointer to TreeRootUnsafe in tree_root_out.
 #[no_mangle]
-pub extern "C" fn selene_tree_root(selene_point: SelenePoint) -> *const u8 {
-    Box::into_raw(Box::new(TreeRoot::<Selene, Helios>::C1(selene_point))) as *const u8
+pub unsafe extern "C" fn selene_tree_root(
+    selene_point: SelenePoint,
+    tree_root_out: *mut *mut TreeRoot<Selene, Helios>,
+) -> c_int {
+    if tree_root_out.is_null() {
+        return -1;
+    }
+
+    let tree_root = TreeRoot::<Selene, Helios>::C1(selene_point);
+    unsafe { *tree_root_out = new_box_raw(tree_root) };
+    0
 }
 
+/// # Safety
+///
+/// This function expects a non-null pointer to TreeRootUnsafe in tree_root_out.
 #[no_mangle]
-pub extern "C" fn helios_tree_root(helios_point: HeliosPoint) -> *const u8 {
-    Box::into_raw(Box::new(TreeRoot::<Selene, Helios>::C2(helios_point))) as *const u8
+pub unsafe extern "C" fn helios_tree_root(
+    helios_point: HeliosPoint,
+    tree_root_out: *mut *mut TreeRoot<Selene, Helios>,
+) -> c_int {
+    if tree_root_out.is_null() {
+        return -1;
+    }
+
+    let tree_root = TreeRoot::<Selene, Helios>::C2(helios_point);
+    unsafe { *tree_root_out = new_box_raw(tree_root) };
+    0
 }
+
+destroy_fn!(destroy_tree_root, TreeRoot::<Selene, Helios>);
 
 #[allow(non_snake_case)]
 #[repr(C)]

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -735,14 +735,14 @@ unsafe fn prove_membership_native(inputs: &[*const FcmpPpProveInput], n_tree_lay
 /// allocated on the heap (via Box::into_raw(Box::new())), and the branch
 /// blinds are slices of BranchBlind allocated on the heap (via CResult).
 #[no_mangle]
-pub unsafe extern "C" fn fcmp_prove_input_new(
+pub unsafe extern "C" fn fcmp_pp_prove_input_new(
     path: *const Path<Curves>,
     output_blinds: *const OutputBlinds<EdwardsPoint>,
     selene_branch_blinds: SeleneBranchBlindSlice,
     helios_branch_blinds: HeliosBranchBlindSlice,
-    fcmp_prove_input_out: *mut *mut FcmpPpProveInput,
+    fcmp_pp_prove_input_out: *mut *mut FcmpPpProveInput,
 ) -> c_int {
-    if fcmp_prove_input_out.is_null() {
+    if fcmp_pp_prove_input_out.is_null() {
         return -1;
     }
 
@@ -765,17 +765,17 @@ pub unsafe extern "C" fn fcmp_prove_input_new(
         .map(|x| unsafe { (*x.to_owned()).clone() })
         .collect();
 
-    let fcmp_prove_input = FcmpPpProveInput {
+    let fcmp_pp_prove_input = FcmpPpProveInput {
         path,
         output_blinds,
         c1_branch_blinds,
         c2_branch_blinds,
     };
-    unsafe { *fcmp_prove_input_out = new_box_raw(fcmp_prove_input); };
+    unsafe { *fcmp_pp_prove_input_out = new_box_raw(fcmp_pp_prove_input); };
     0
 }
 
-destroy_fn!(destroy_fcmp_prove_input, FcmpPpProveInput);
+destroy_fn!(destroy_fcmp_pp_prove_input, FcmpPpProveInput);
 
 /// # Safety
 ///
@@ -877,9 +877,9 @@ pub unsafe extern "C" fn fcmp_pp_verify_input_new(
     tree_root: *const TreeRoot<Selene, Helios>,
     pseudo_outs: Slice<*const u8>,
     key_images: Slice<*const u8>,
-    fcmp_verify_input_out: *mut *mut FcmpPpVerifyInput,
+    fcmp_pp_verify_input_out: *mut *mut FcmpPpVerifyInput,
 ) -> c_int {
-    if fcmp_verify_input_out.is_null() {
+    if fcmp_pp_verify_input_out.is_null() {
         return -1;
     }
 
@@ -933,11 +933,11 @@ pub unsafe extern "C" fn fcmp_pp_verify_input_new(
         key_images,
     };
 
-    unsafe { *fcmp_verify_input_out = new_box_raw(fcmp_pp_verify_input) };
+    unsafe { *fcmp_pp_verify_input_out = new_box_raw(fcmp_pp_verify_input) };
     0
 }
 
-destroy_fn!(destroy_fcmp_verify_input, FcmpPpVerifyInput);
+destroy_fn!(destroy_fcmp_pp_verify_input, FcmpPpVerifyInput);
 
 /// # Safety
 ///

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -52,9 +52,8 @@ pub extern "C" fn selene_hash_init_point() -> SelenePoint {
     SELENE_HASH_INIT()
 }
 
-fn to_box_raw_u8<T>(obj: T) -> *mut u8 {
-    let arr_ptr = Box::into_raw(Box::new(obj));
-    arr_ptr as *mut u8
+fn new_box_raw<T>(obj: T) -> *mut T {
+    Box::into_raw(Box::new(obj))
 }
 
 // https://doc.rust-lang.org/std/boxed/struct.Box.html#method.from_raw
@@ -544,7 +543,9 @@ pub extern "C" fn helios_branch_blind() -> CResult<BranchBlind<<Helios as Cipher
 /// be null. Also be sure to clean up the branch blind with
 /// free_helios_branch_blind below.
 #[no_mangle]
-pub unsafe extern "C" fn helios_branch_blind2(branch_blind_out: *mut *mut u8) -> c_int {
+pub unsafe extern "C" fn new_helios_branch_blind(
+    branch_blind_out: *mut *mut BranchBlind::<<Helios as Ciphersuite>::G>,
+) -> c_int {
     let scalar_decomp = ScalarDecomposition::new(<Helios as Ciphersuite>::F::random(&mut OsRng));
     let Some(scalar_decomp) = scalar_decomp else {
         return -1;
@@ -553,7 +554,7 @@ pub unsafe extern "C" fn helios_branch_blind2(branch_blind_out: *mut *mut u8) ->
     let branch_blind =
         BranchBlind::<<Helios as Ciphersuite>::G>::new(HELIOS_GENERATORS().h(), scalar_decomp);
 
-    unsafe { *branch_blind_out = to_box_raw_u8(branch_blind) };
+    unsafe { *branch_blind_out = new_box_raw(branch_blind) };
 
     0
 }

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -57,7 +57,7 @@ fn new_box_raw<T>(obj: T) -> *mut T {
 }
 
 // https://doc.rust-lang.org/std/boxed/struct.Box.html#method.from_raw
-fn free_box<T>(ptr: *mut T) {
+fn destroy_box<T>(ptr: *mut T) {
     let _ = unsafe { Box::from_raw(ptr) };
 }
 
@@ -527,14 +527,6 @@ pub unsafe extern "C" fn output_blinds_new(
 
 //---------------------------------------------- BranchBlind
 
-#[no_mangle]
-pub extern "C" fn helios_branch_blind() -> CResult<BranchBlind<<Helios as Ciphersuite>::G>, ()> {
-    CResult::ok(BranchBlind::<<Helios as Ciphersuite>::G>::new(
-        HELIOS_GENERATORS().h(),
-        ScalarDecomposition::new(<Helios as Ciphersuite>::F::random(&mut OsRng)).unwrap(),
-    ))
-}
-
 /// # Safety
 ///
 /// This function allocates a branch blind on the heap via Box::new, then
@@ -567,7 +559,7 @@ pub unsafe extern "C" fn generate_helios_branch_blind(
 pub unsafe extern "C" fn destroy_helios_branch_blind(
     branch_blind: *mut BranchBlind<<Helios as Ciphersuite>::G>,
 ) {
-    free_box(branch_blind);
+    destroy_box(branch_blind);
 }
 
 #[no_mangle]

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -36,18 +36,44 @@ namespace fcmp_pp
 //----------------------------------------------------------------------------------------------------------------------
 // FFI types
 //----------------------------------------------------------------------------------------------------------------------
-#define IMPLEMENT_FCMP_FFI_TYPE(raw_t, gen_fn, destroy_fn)                                    \
-    void raw_t##Deleter::operator()(raw_t##Unsafe *p) const noexcept { ::destroy_fn(p); };    \
-                                                                                              \
-    raw_t raw_t##Gen()                                                                        \
-    {                                                                                         \
-        ::raw_t##Unsafe* raw_ptr;                                                             \
-        CHECK_AND_ASSERT_THROW_MES(::gen_fn(&raw_ptr) == 0, "Failed to generate " << #raw_t); \
-        return raw_t(raw_ptr);                                                                \
+#define IMPLEMENT_FCMP_FFI_TYPE(raw_t, cpp_fn, rust_fn, destroy_fn)                        \
+    void raw_t##Deleter::operator()(raw_t##Unsafe *p) const noexcept { ::destroy_fn(p); }; \
+                                                                                           \
+    raw_t cpp_fn                                                                           \
+    {                                                                                      \
+        ::raw_t##Unsafe* raw_ptr;                                                          \
+        CHECK_AND_ASSERT_THROW_MES(::rust_fn == 0, "Failed to generate " << #raw_t);       \
+        return raw_t(raw_ptr);                                                             \
     };
 
-IMPLEMENT_FCMP_FFI_TYPE(HeliosBranchBlind, generate_helios_branch_blind, destroy_helios_branch_blind);
-IMPLEMENT_FCMP_FFI_TYPE(SeleneBranchBlind, generate_selene_branch_blind, destroy_selene_branch_blind);
+// Branch blinds
+IMPLEMENT_FCMP_FFI_TYPE(HeliosBranchBlind,
+    gen_helios_branch_blind(),
+    generate_helios_branch_blind(&raw_ptr),
+    destroy_helios_branch_blind);
+IMPLEMENT_FCMP_FFI_TYPE(SeleneBranchBlind,
+    gen_selene_branch_blind(),
+    generate_selene_branch_blind(&raw_ptr),
+    destroy_selene_branch_blind);
+
+// Blinded blinds
+IMPLEMENT_FCMP_FFI_TYPE(BlindedOBlind,
+    blind_o_blind(const SeleneScalar &o_blind),
+    blind_o_blind(&o_blind, &raw_ptr),
+    destroy_blinded_o_blind);
+IMPLEMENT_FCMP_FFI_TYPE(BlindedIBlind,
+    blind_i_blind(const SeleneScalar &i_blind),
+    blind_i_blind(&i_blind, &raw_ptr),
+    destroy_blinded_i_blind);
+IMPLEMENT_FCMP_FFI_TYPE(BlindedIBlindBlind,
+    blind_i_blind_blind(const SeleneScalar &i_blind_blind),
+    blind_i_blind_blind(&i_blind_blind, &raw_ptr),
+    destroy_blinded_i_blind_blind);
+IMPLEMENT_FCMP_FFI_TYPE(BlindedCBlind,
+    blind_c_blind(const SeleneScalar &c_blind),
+    blind_c_blind(&c_blind, &raw_ptr),
+    destroy_blinded_c_blind);
+
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 }//namespace fcmp_pp

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -47,6 +47,7 @@ namespace fcmp_pp
     };
 
 IMPLEMENT_FCMP_FFI_TYPE(HeliosBranchBlind, generate_helios_branch_blind, destroy_helios_branch_blind);
+IMPLEMENT_FCMP_FFI_TYPE(SeleneBranchBlind, generate_selene_branch_blind, destroy_selene_branch_blind);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 }//namespace fcmp_pp

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -121,9 +121,9 @@ IMPLEMENT_FCMP_FFI_TYPE(Path,
     destroy_path);
 //----------------------------------------------------------------------------------------------------------------------
 // Implement FCMP++ Prove Input manually because will need temp slices
-void FcmpProveInputDeleter::operator()(FcmpProveInputUnsafe *p) const noexcept { ::destroy_fcmp_prove_input(p); };
+void FcmpPpProveInputDeleter::operator()(FcmpPpProveInputUnsafe *p) const noexcept { ::destroy_fcmp_pp_prove_input(p); };
 
-FcmpProveInput fcmp_prove_input_new(const Path &path,
+FcmpPpProveInput fcmp_pp_prove_input_new(const Path &path,
         const OutputBlinds &output_blinds,
         const std::vector<SeleneBranchBlind> &selene_branch_blinds,
         const std::vector<HeliosBranchBlind> &helios_branch_blinds)
@@ -131,21 +131,21 @@ FcmpProveInput fcmp_prove_input_new(const Path &path,
     MAKE_TEMP_FFI_SLICE(SeleneBranchBlind, selene_branch_blinds, selene_branch_blind_slice);
     MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
-    FcmpProveInputUnsafe *raw_ptr;
-    int r = ::fcmp_prove_input_new(path.get(),
+    FcmpPpProveInputUnsafe *raw_ptr;
+    int r = ::fcmp_pp_prove_input_new(path.get(),
         output_blinds.get(),
         selene_branch_blind_slice,
         helios_branch_blind_slice,
         &raw_ptr);
     CHECK_AND_ASSERT_THROW_MES(r == 0, "Failed to construct FCMP++ prove input");
 
-    return FcmpProveInput(raw_ptr);
+    return FcmpPpProveInput(raw_ptr);
 }
 //----------------------------------------------------------------------------------------------------------------------
 // Implement FCMP++ Verify Input manually because need to type cast
-void FcmpVerifyInputDeleter::operator()(FcmpVerifyInputUnsafe *p) const noexcept { ::destroy_fcmp_verify_input(p); };
+void FcmpPpVerifyInputDeleter::operator()(FcmpPpVerifyInputUnsafe *p) const noexcept { ::destroy_fcmp_pp_verify_input(p); };
 
-FcmpVerifyInput fcmp_verify_input_new(const crypto::hash &signable_tx_hash,
+FcmpPpVerifyInput fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
         const fcmp_pp::FcmpPpProof &fcmp_pp_proof,
         const std::size_t n_tree_layers,
         const fcmp_pp::TreeRoot &tree_root,
@@ -164,7 +164,7 @@ FcmpVerifyInput fcmp_verify_input_new(const crypto::hash &signable_tx_hash,
     for (const auto &ki : key_images)
         key_images_ptrs.emplace_back((const uint8_t *)&ki.data);
 
-    FcmpVerifyInputUnsafe *raw_ptr;
+    FcmpPpVerifyInputUnsafe *raw_ptr;
     int r = ::fcmp_pp_verify_input_new(
             reinterpret_cast<const uint8_t*>(&signable_tx_hash),
             fcmp_pp_proof.data(),
@@ -177,7 +177,7 @@ FcmpVerifyInput fcmp_verify_input_new(const crypto::hash &signable_tx_hash,
         );
     CHECK_AND_ASSERT_THROW_MES(r == 0, "Failed to construct FCMP++ verify input");
 
-    return FcmpVerifyInput(raw_ptr);
+    return FcmpPpVerifyInput(raw_ptr);
 }
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -42,8 +42,23 @@ namespace fcmp_pp
     raw_t cpp_fn                                                                           \
     {                                                                                      \
         ::raw_t##Unsafe* raw_ptr;                                                          \
-        CHECK_AND_ASSERT_THROW_MES(::rust_fn == 0, "Failed to generate " << #raw_t);       \
+        CHECK_AND_ASSERT_THROW_MES(::rust_fn == 0, "Failed " << #rust_fn);                 \
         return raw_t(raw_ptr);                                                             \
+    };
+
+#define IMPLEMENT_FCMP_FFI_SHARED_TYPE(raw_t, cpp_fn1, rust_fn1, cpp_fn2, rust_fn2, destroy_fn) \
+    raw_t cpp_fn1                                                                               \
+    {                                                                                           \
+        ::raw_t##Unsafe* raw_ptr;                                                               \
+        CHECK_AND_ASSERT_THROW_MES(::rust_fn1 == 0, "Failed " << #rust_fn1);                    \
+        return raw_t(raw_ptr, ::destroy_fn);                                                    \
+    };                                                                                          \
+                                                                                                \
+    raw_t cpp_fn2                                                                               \
+    {                                                                                           \
+        ::raw_t##Unsafe* raw_ptr;                                                               \
+        CHECK_AND_ASSERT_THROW_MES(::rust_fn2 == 0, "Failed " << #rust_fn2);                    \
+        return raw_t(raw_ptr, ::destroy_fn);                                                    \
     };
 
 // Branch blinds
@@ -73,6 +88,14 @@ IMPLEMENT_FCMP_FFI_TYPE(BlindedCBlind,
     blind_c_blind(const SeleneScalar &c_blind),
     blind_c_blind(&c_blind, &raw_ptr),
     destroy_blinded_c_blind);
+
+// Tree root
+IMPLEMENT_FCMP_FFI_SHARED_TYPE(TreeRoot,
+    helios_tree_root(const HeliosPoint &helios_point),
+    helios_tree_root(helios_point, &raw_ptr),
+    selene_tree_root(const SelenePoint &selene_point),
+    selene_tree_root(selene_point, &raw_ptr),
+    destroy_tree_root);
 
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -37,13 +37,17 @@ namespace fcmp_pp
 //----------------------------------------------------------------------------------------------------------------------
 // FFI types
 //----------------------------------------------------------------------------------------------------------------------
+#define CHECK_FFI_RES \
+    CHECK_AND_ASSERT_THROW_MES(r == 0, __func__ << " failed with error code " << r);
+
 #define IMPLEMENT_FCMP_FFI_TYPE(raw_t, cpp_fn, rust_fn, destroy_fn)                        \
     void raw_t##Deleter::operator()(raw_t##Unsafe *p) const noexcept { ::destroy_fn(p); }; \
                                                                                            \
     raw_t cpp_fn                                                                           \
     {                                                                                      \
         ::raw_t##Unsafe* raw_ptr;                                                          \
-        CHECK_AND_ASSERT_THROW_MES(::rust_fn == 0, "Failed " << #rust_fn);                 \
+        int r = ::rust_fn;                                                                 \
+        CHECK_FFI_RES;                                                                     \
         return raw_t(raw_ptr);                                                             \
     };
 
@@ -51,14 +55,16 @@ namespace fcmp_pp
     raw_t cpp_fn1                                                                               \
     {                                                                                           \
         ::raw_t##Unsafe* raw_ptr;                                                               \
-        CHECK_AND_ASSERT_THROW_MES(::rust_fn1 == 0, "Failed " << #rust_fn1);                    \
+        int r = ::rust_fn1;                                                                     \
+        CHECK_FFI_RES;                                                                          \
         return raw_t(raw_ptr, ::destroy_fn);                                                    \
     };                                                                                          \
                                                                                                 \
     raw_t cpp_fn2                                                                               \
     {                                                                                           \
         ::raw_t##Unsafe* raw_ptr;                                                               \
-        CHECK_AND_ASSERT_THROW_MES(::rust_fn2 == 0, "Failed " << #rust_fn2);                    \
+        int r = ::rust_fn2;                                                                     \
+        CHECK_FFI_RES;                                                                          \
         return raw_t(raw_ptr, ::destroy_fn);                                                    \
     };
 //----------------------------------------------------------------------------------------------------------------------
@@ -137,7 +143,7 @@ FcmpPpProveInput fcmp_pp_prove_input_new(const Path &path,
         selene_branch_blind_slice,
         helios_branch_blind_slice,
         &raw_ptr);
-    CHECK_AND_ASSERT_THROW_MES(r == 0, "Failed to construct FCMP++ prove input");
+    CHECK_FFI_RES;
 
     return FcmpPpProveInput(raw_ptr);
 }
@@ -175,7 +181,7 @@ FcmpPpVerifyInput fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
             {key_images_ptrs.data(), key_images_ptrs.size()},
             &raw_ptr
         );
-    CHECK_AND_ASSERT_THROW_MES(r == 0, "Failed to construct FCMP++ verify input");
+    CHECK_FFI_RES;
 
     return FcmpPpVerifyInput(raw_ptr);
 }

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -52,20 +52,20 @@ namespace fcmp_pp
     };
 
 #define IMPLEMENT_FCMP_FFI_SHARED_TYPE(raw_t, cpp_fn1, rust_fn1, cpp_fn2, rust_fn2, destroy_fn) \
-    raw_t cpp_fn1                                                                               \
+    raw_t##Shared cpp_fn1                                                                       \
     {                                                                                           \
         ::raw_t##Unsafe* raw_ptr;                                                               \
         int r = ::rust_fn1;                                                                     \
         CHECK_FFI_RES;                                                                          \
-        return raw_t(raw_ptr, ::destroy_fn);                                                    \
+        return raw_t##Shared(raw_ptr, ::destroy_fn);                                            \
     };                                                                                          \
                                                                                                 \
-    raw_t cpp_fn2                                                                               \
+    raw_t##Shared cpp_fn2                                                                       \
     {                                                                                           \
         ::raw_t##Unsafe* raw_ptr;                                                               \
         int r = ::rust_fn2;                                                                     \
         CHECK_FFI_RES;                                                                          \
-        return raw_t(raw_ptr, ::destroy_fn);                                                    \
+        return raw_t##Shared(raw_ptr, ::destroy_fn);                                            \
     };
 //----------------------------------------------------------------------------------------------------------------------
 // Branch blinds
@@ -127,9 +127,12 @@ IMPLEMENT_FCMP_FFI_TYPE(Path,
     destroy_path);
 //----------------------------------------------------------------------------------------------------------------------
 // Implement FCMP++ Prove Input manually because will need temp slices
-void FcmpPpProveInputDeleter::operator()(FcmpPpProveInputUnsafe *p) const noexcept { ::destroy_fcmp_pp_prove_input(p); };
+void FcmpPpProveMembershipInputDeleter::operator()(FcmpPpProveMembershipInputUnsafe *p) const noexcept
+{
+    ::destroy_fcmp_pp_prove_input(p);
+}
 
-FcmpPpProveInput fcmp_pp_prove_input_new(const Path &path,
+FcmpPpProveMembershipInput fcmp_pp_prove_input_new(const Path &path,
         const OutputBlinds &output_blinds,
         const std::vector<SeleneBranchBlind> &selene_branch_blinds,
         const std::vector<HeliosBranchBlind> &helios_branch_blinds)
@@ -137,7 +140,7 @@ FcmpPpProveInput fcmp_pp_prove_input_new(const Path &path,
     MAKE_TEMP_FFI_SLICE(SeleneBranchBlind, selene_branch_blinds, selene_branch_blind_slice);
     MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
-    FcmpPpProveInputUnsafe *raw_ptr;
+    FcmpPpProveMembershipInputUnsafe *raw_ptr;
     int r = ::fcmp_pp_prove_input_new(path.get(),
         output_blinds.get(),
         selene_branch_blind_slice,
@@ -145,16 +148,19 @@ FcmpPpProveInput fcmp_pp_prove_input_new(const Path &path,
         &raw_ptr);
     CHECK_FFI_RES;
 
-    return FcmpPpProveInput(raw_ptr);
+    return FcmpPpProveMembershipInput(raw_ptr);
 }
 //----------------------------------------------------------------------------------------------------------------------
 // Implement FCMP++ Verify Input manually because need to type cast
-void FcmpPpVerifyInputDeleter::operator()(FcmpPpVerifyInputUnsafe *p) const noexcept { ::destroy_fcmp_pp_verify_input(p); };
+void FcmpPpVerifyInputDeleter::operator()(FcmpPpVerifyInputUnsafe *p) const noexcept
+{
+    ::destroy_fcmp_pp_verify_input(p);
+}
 
 FcmpPpVerifyInput fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
         const fcmp_pp::FcmpPpProof &fcmp_pp_proof,
         const std::size_t n_tree_layers,
-        const fcmp_pp::TreeRoot &tree_root,
+        const fcmp_pp::TreeRootShared &tree_root,
         const std::vector<crypto::ec_point> &pseudo_outs,
         const std::vector<crypto::key_image> &key_images)
 {

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -89,6 +89,19 @@ IMPLEMENT_FCMP_FFI_TYPE(BlindedCBlind,
     blind_c_blind(&c_blind, &raw_ptr),
     destroy_blinded_c_blind);
 
+// Output blinds
+IMPLEMENT_FCMP_FFI_TYPE(OutputBlinds,
+    output_blinds_new(const BlindedOBlind &blinded_o_blind,
+        const BlindedIBlind &blinded_i_blind,
+        const BlindedIBlindBlind &blinded_i_blind_blind,
+        const BlindedCBlind &blinded_c_blind),
+    output_blinds_new(blinded_o_blind.get(),
+        blinded_i_blind.get(),
+        blinded_i_blind_blind.get(),
+        blinded_c_blind.get(),
+        &raw_ptr),
+    destroy_output_blinds);
+
 // Tree root
 IMPLEMENT_FCMP_FFI_SHARED_TYPE(TreeRoot,
     helios_tree_root(const HeliosPoint &helios_point),

--- a/src/fcmp_pp/fcmp_pp_types.cpp
+++ b/src/fcmp_pp/fcmp_pp_types.cpp
@@ -97,6 +97,15 @@ IMPLEMENT_FCMP_FFI_SHARED_TYPE(TreeRoot,
     selene_tree_root(selene_point, &raw_ptr),
     destroy_tree_root);
 
+// Path
+IMPLEMENT_FCMP_FFI_TYPE(Path,
+    path_new(const OutputChunk &output_chunk,
+        std::size_t output_idx,
+        const HeliosT::ScalarChunks &helios_layer_chunks,
+        const SeleneT::ScalarChunks &selene_layer_chunks),
+    path_new(output_chunk, output_idx, helios_layer_chunks, selene_layer_chunks, &raw_ptr),
+    destroy_path);
+
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 }//namespace fcmp_pp

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -73,11 +73,10 @@ using OutputChunk = ::OutputSlice;
 //----------------------------------------------------------------------------------------------------------------------
 // FFI types instantiated on the Rust side must be destroyed back on the Rust side. We wrap them in a unique ptr with a
 // custom deleter that calls the respective Rust destroy fn.
-#define DEFINE_FCMP_FFI_TYPE(raw_t)                                                 \
-    struct raw_t##Deleter { void operator()(raw_t##Unsafe *p) const noexcept; };    \
-    using raw_t = std::unique_ptr<raw_t##Unsafe, raw_t##Deleter>;                   \
-    raw_t raw_t##Gen();                                                             \
-    std::vector<const raw_t##Unsafe *> raw_t##Slice(const std::vector<raw_t> &vec);
+#define DEFINE_FCMP_FFI_TYPE(raw_t, cpp_fn)                                      \
+    struct raw_t##Deleter { void operator()(raw_t##Unsafe *p) const noexcept; }; \
+    using raw_t = std::unique_ptr<raw_t##Unsafe, raw_t##Deleter>;                \
+    raw_t cpp_fn;
 
 // Macro to instantiate an FFI-compatible slice from a vector of FCMP FFI type. Instantiates a vector in local scope
 // so it remains in scope while the slice points to it, making sure memory addresses remain contiguous. The slice is
@@ -89,8 +88,14 @@ using OutputChunk = ::OutputSlice;
         raw_t##Vector.push_back(elem.get());                                     \
     ::raw_t##SliceUnsafe slice_name{raw_t##Vector.data(), raw_t##Vector.size()};
 
-DEFINE_FCMP_FFI_TYPE(HeliosBranchBlind);
-DEFINE_FCMP_FFI_TYPE(SeleneBranchBlind);
+DEFINE_FCMP_FFI_TYPE(HeliosBranchBlind, gen_helios_branch_blind());
+DEFINE_FCMP_FFI_TYPE(SeleneBranchBlind, gen_selene_branch_blind());
+
+DEFINE_FCMP_FFI_TYPE(BlindedOBlind, blind_o_blind(const SeleneScalar &));
+DEFINE_FCMP_FFI_TYPE(BlindedIBlind, blind_i_blind(const SeleneScalar &));
+DEFINE_FCMP_FFI_TYPE(BlindedIBlindBlind, blind_i_blind_blind(const SeleneScalar &));
+DEFINE_FCMP_FFI_TYPE(BlindedCBlind, blind_c_blind(const SeleneScalar &));
+
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // C++ types

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -78,6 +78,12 @@ using OutputChunk = ::OutputSlice;
     using raw_t = std::unique_ptr<raw_t##Unsafe, raw_t##Deleter>;                \
     raw_t cpp_fn;
 
+// Sometimes a shared ptr is necessary so that we can reference the same copy of underlying data in multiple places.
+#define DEFINE_FCMP_FFI_SHARED_TYPE(raw_t, cpp_fn1, cpp_fn2) \
+    using raw_t = std::shared_ptr<raw_t##Unsafe>;            \
+    raw_t cpp_fn1;                                           \
+    raw_t cpp_fn2;
+
 // Macro to instantiate an FFI-compatible slice from a vector of FCMP FFI type. Instantiates a vector in local scope
 // so it remains in scope while the slice points to it, making sure memory addresses remain contiguous. The slice is
 // only usable within local scope, hence "TEMP".
@@ -96,6 +102,7 @@ DEFINE_FCMP_FFI_TYPE(BlindedIBlind, blind_i_blind(const SeleneScalar &));
 DEFINE_FCMP_FFI_TYPE(BlindedIBlindBlind, blind_i_blind_blind(const SeleneScalar &));
 DEFINE_FCMP_FFI_TYPE(BlindedCBlind, blind_c_blind(const SeleneScalar &));
 
+DEFINE_FCMP_FFI_SHARED_TYPE(TreeRoot, helios_tree_root(const HeliosPoint &), selene_tree_root(const SelenePoint &));
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // C++ types
@@ -121,7 +128,7 @@ struct ProofParams final
 
 struct FcmpVerifyHelperData final
 {
-    const uint8_t *tree_root; // borrowing, *not* owning
+    TreeRoot tree_root;
     std::vector<crypto::key_image> key_images;
 };
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -103,6 +103,9 @@ DEFINE_FCMP_FFI_TYPE(BlindedIBlindBlind, blind_i_blind_blind(const SeleneScalar 
 DEFINE_FCMP_FFI_TYPE(BlindedCBlind, blind_c_blind(const SeleneScalar &));
 
 DEFINE_FCMP_FFI_SHARED_TYPE(TreeRoot, helios_tree_root(const HeliosPoint &), selene_tree_root(const SelenePoint &));
+
+DEFINE_FCMP_FFI_TYPE(Path,
+    path_new(const OutputChunk &, std::size_t, const HeliosT::ScalarChunks &, const SeleneT::ScalarChunks &));
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // C++ types
@@ -114,7 +117,7 @@ using FcmpPpProof = std::vector<uint8_t>;
 
 struct ProofInput final
 {
-    uint8_t *path;
+    Path path;
     uint8_t *output_blinds;
     std::vector<SeleneBranchBlind> selene_branch_blinds;
     std::vector<HeliosBranchBlind> helios_branch_blinds;

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -80,13 +80,14 @@ using OutputChunk = ::OutputSlice;
     std::vector<const raw_t##Unsafe *> raw_t##Slice(const std::vector<raw_t> &vec);
 
 // Macro to instantiate an FFI-compatible slice from a vector of FCMP FFI type. Instantiates a vector in local scope
-// so it remains in scope while the slice points to it, making sure memory addresses remain contiguous.
-#define MAKE_FFI_SLICE(slice_name, raw_t, vec)                             \
-    std::vector<const raw_t##Unsafe *> raw_t##Vector;                      \
-    raw_t##Vector.reserve(vec.size());                                     \
-    for (const raw_t &elem : vec)                                          \
-        raw_t##Vector.push_back(elem.get());                               \
-    ::raw_t##Slice slice_name{raw_t##Vector.data(), raw_t##Vector.size()};
+// so it remains in scope while the slice points to it, making sure memory addresses remain contiguous. The slice is
+// only usable within local scope, hence "TEMP".
+#define MAKE_TEMP_FFI_SLICE(raw_t, vec, slice_name)                              \
+    std::vector<const raw_t##Unsafe *> raw_t##Vector;                            \
+    raw_t##Vector.reserve(vec.size());                                           \
+    for (const raw_t &elem : vec)                                                \
+        raw_t##Vector.push_back(elem.get());                                     \
+    ::raw_t##SliceUnsafe slice_name{raw_t##Vector.data(), raw_t##Vector.size()};
 
 DEFINE_FCMP_FFI_TYPE(HeliosBranchBlind);
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -113,14 +113,14 @@ DEFINE_FCMP_FFI_SHARED_TYPE(TreeRoot, helios_tree_root(const HeliosPoint &), sel
 DEFINE_FCMP_FFI_TYPE(Path,
     path_new(const OutputChunk &, std::size_t, const HeliosT::ScalarChunks &, const SeleneT::ScalarChunks &));
 
-DEFINE_FCMP_FFI_TYPE(FcmpProveInput,
-    fcmp_prove_input_new(const Path &,
+DEFINE_FCMP_FFI_TYPE(FcmpPpProveInput,
+    fcmp_pp_prove_input_new(const Path &,
         const OutputBlinds &,
         const std::vector<SeleneBranchBlind> &,
         const std::vector<HeliosBranchBlind> &));
 
-DEFINE_FCMP_FFI_TYPE(FcmpVerifyInput,
-    fcmp_verify_input_new(const crypto::hash &signable_tx_hash,
+DEFINE_FCMP_FFI_TYPE(FcmpPpVerifyInput,
+    fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
         const fcmp_pp::FcmpPpProof &fcmp_pp_proof,
         const std::size_t n_tree_layers,
         const fcmp_pp::TreeRoot &tree_root,

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -102,6 +102,9 @@ DEFINE_FCMP_FFI_TYPE(BlindedIBlind, blind_i_blind(const SeleneScalar &));
 DEFINE_FCMP_FFI_TYPE(BlindedIBlindBlind, blind_i_blind_blind(const SeleneScalar &));
 DEFINE_FCMP_FFI_TYPE(BlindedCBlind, blind_c_blind(const SeleneScalar &));
 
+DEFINE_FCMP_FFI_TYPE(OutputBlinds,
+    output_blinds_new(const BlindedOBlind &, const BlindedIBlind &, const BlindedIBlindBlind &, const BlindedCBlind &));
+
 DEFINE_FCMP_FFI_SHARED_TYPE(TreeRoot, helios_tree_root(const HeliosPoint &), selene_tree_root(const SelenePoint &));
 
 DEFINE_FCMP_FFI_TYPE(Path,
@@ -118,7 +121,7 @@ using FcmpPpProof = std::vector<uint8_t>;
 struct ProofInput final
 {
     Path path;
-    uint8_t *output_blinds;
+    OutputBlinds output_blinds;
     std::vector<SeleneBranchBlind> selene_branch_blinds;
     std::vector<HeliosBranchBlind> helios_branch_blinds;
 };

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -137,6 +137,12 @@ struct FcmpVerifyHelperData final
     TreeRoot tree_root;
     std::vector<crypto::key_image> key_images;
 };
+
+// Serialize types into a single byte buffer
+FcmpPpProof fcmp_pp_proof_from_parts_v1(const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
+    const std::vector<FcmpPpSalProof> &sal_proofs,
+    const FcmpMembershipProof &membership_proof,
+    const std::uint8_t n_tree_layers);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 }//namespace fcmp_pp

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -90,6 +90,7 @@ using OutputChunk = ::OutputSlice;
     ::raw_t##SliceUnsafe slice_name{raw_t##Vector.data(), raw_t##Vector.size()};
 
 DEFINE_FCMP_FFI_TYPE(HeliosBranchBlind);
+DEFINE_FCMP_FFI_TYPE(SeleneBranchBlind);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // C++ types
@@ -103,7 +104,7 @@ struct ProofInput final
 {
     uint8_t *path;
     uint8_t *output_blinds;
-    std::vector<const uint8_t *> selene_branch_blinds;
+    std::vector<SeleneBranchBlind> selene_branch_blinds;
     std::vector<HeliosBranchBlind> helios_branch_blinds;
 };
 

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -109,6 +109,12 @@ DEFINE_FCMP_FFI_SHARED_TYPE(TreeRoot, helios_tree_root(const HeliosPoint &), sel
 
 DEFINE_FCMP_FFI_TYPE(Path,
     path_new(const OutputChunk &, std::size_t, const HeliosT::ScalarChunks &, const SeleneT::ScalarChunks &));
+
+DEFINE_FCMP_FFI_TYPE(FcmpProveInput,
+    fcmp_prove_input_new(const Path &,
+        const OutputBlinds &,
+        const std::vector<SeleneBranchBlind> &,
+        const std::vector<HeliosBranchBlind> &));
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // C++ types

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -68,6 +68,9 @@ struct HeliosT final
 using OutputBytes = ::OutputBytes;
 using OutputChunk = ::OutputSlice;
 //----------------------------------------------------------------------------------------------------------------------
+// Define C++ type here so it can be used in FFI types
+using FcmpPpProof = std::vector<uint8_t>;
+//----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // FFI types
 //----------------------------------------------------------------------------------------------------------------------
@@ -115,6 +118,14 @@ DEFINE_FCMP_FFI_TYPE(FcmpProveInput,
         const OutputBlinds &,
         const std::vector<SeleneBranchBlind> &,
         const std::vector<HeliosBranchBlind> &));
+
+DEFINE_FCMP_FFI_TYPE(FcmpVerifyInput,
+    fcmp_verify_input_new(const crypto::hash &signable_tx_hash,
+        const fcmp_pp::FcmpPpProof &fcmp_pp_proof,
+        const std::size_t n_tree_layers,
+        const fcmp_pp::TreeRoot &tree_root,
+        const std::vector<crypto::ec_point> &pseudo_outs,
+        const std::vector<crypto::key_image> &key_images));
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 // C++ types
@@ -122,7 +133,6 @@ DEFINE_FCMP_FFI_TYPE(FcmpProveInput,
 // Byte buffer containing the fcmp++ proof
 using FcmpPpSalProof = std::vector<uint8_t>;
 using FcmpMembershipProof = std::vector<uint8_t>;
-using FcmpPpProof = std::vector<uint8_t>;
 
 struct ProofInput final
 {

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "crypto/crypto.h"
@@ -94,6 +95,18 @@ struct FcmpVerifyHelperData final
     const uint8_t *tree_root; // borrowing, *not* owning
     std::vector<crypto::key_image> key_images;
 };
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+// FFI types
+//----------------------------------------------------------------------------------------------------------------------
+// FFI types instantiated on the Rust side must be destroyed back on the Rust side. We wrap them in a unique ptr with a
+// custom deleter that calls the respective Rust destroy fn.
+#define DEFINE_FCMP_FFI_TYPE(raw_t)                                              \
+    struct raw_t##Deleter { void operator()(raw_t##Unsafe *p) const noexcept; }; \
+    using raw_t = std::unique_ptr<raw_t##Unsafe, raw_t##Deleter>;                \
+    raw_t raw_t##Gen();
+
+DEFINE_FCMP_FFI_TYPE(HeliosBranchBlind);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 }//namespace fcmp_pp

--- a/src/fcmp_pp/ffi_types.h
+++ b/src/fcmp_pp/ffi_types.h
@@ -1,0 +1,79 @@
+// Copyright (c) 2024, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <cstdint>
+
+#include "fcmp_pp_rust/fcmp++.h"
+#include "misc_log_ex.h"
+
+namespace fcmp_pp
+{
+namespace ffi
+{
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+
+class HeliosBranchBlind
+{
+public:
+    HeliosBranchBlind()
+    {
+        CHECK_AND_ASSERT_THROW_MES(::helios_branch_blind2(&ptr) == 0, "Failed to construct helios branch blind");
+    };
+
+    // Disable copying/assigning
+    HeliosBranchBlind(const HeliosBranchBlind&) = delete;
+    HeliosBranchBlind& operator=(const HeliosBranchBlind&) = delete;
+    HeliosBranchBlind& operator=(HeliosBranchBlind&& other) = delete;
+
+    // Move constructor
+    HeliosBranchBlind(HeliosBranchBlind&& other) noexcept
+        : ptr(other.ptr)
+    {
+        // Set blind_ptr to nullptr so destructor doesn't run after move. Let the new owner handle destruction.
+        other.ptr = nullptr;
+    };
+
+    ~HeliosBranchBlind()
+    {
+        if (ptr == nullptr)
+            return;
+        ::free_helios_branch_blind(ptr);
+    };
+
+    const uint8_t *get() const { return const_cast<uint8_t*>(ptr); }
+
+private:
+    uint8_t *ptr;
+};
+
+//----------------------------------------------------------------------------------------------------------------------
+}//namespace ffi
+}//namespace fcmp_pp

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -225,10 +225,10 @@ std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signa
     return {std::move(p), L};
 }
 //----------------------------------------------------------------------------------------------------------------------
-FcmpMembershipProof prove_membership(const std::vector<FcmpPpProveInput> &fcmp_pp_prove_inputs,
+FcmpMembershipProof prove_membership(const std::vector<FcmpPpProveMembershipInput> &fcmp_pp_prove_inputs,
     const std::size_t n_tree_layers)
 {
-    MAKE_TEMP_FFI_SLICE(FcmpPpProveInput, fcmp_pp_prove_inputs, fcmp_pp_prove_inputs_slice);
+    MAKE_TEMP_FFI_SLICE(FcmpPpProveMembershipInput, fcmp_pp_prove_inputs, fcmp_pp_prove_inputs_slice);
 
     FcmpPpSalProof p;
     const std::size_t proof_len = membership_proof_len(fcmp_pp_prove_inputs.size(), n_tree_layers);
@@ -267,7 +267,7 @@ bool verify_sal(const crypto::hash &signable_tx_hash,
 //----------------------------------------------------------------------------------------------------------------------
 bool verify_membership(const FcmpMembershipProof &fcmp_proof,
     const std::size_t n_tree_layers,
-    const fcmp_pp::TreeRoot &tree_root,
+    const fcmp_pp::TreeRootShared &tree_root,
     const std::vector<FcmpInputCompressed> &inputs)
 {
     return ::fcmp_pp_verify_membership(
@@ -287,7 +287,7 @@ bool verify(const std::vector<fcmp_pp::FcmpPpVerifyInput> &fcmp_pp_verify_inputs
 bool verify(const crypto::hash &signable_tx_hash,
     const fcmp_pp::FcmpPpProof &fcmp_pp_proof,
     const std::size_t n_tree_layers,
-    const fcmp_pp::TreeRoot &tree_root,
+    const fcmp_pp::TreeRootShared &tree_root,
     const std::vector<crypto::ec_point> &pseudo_outs,
     const std::vector<crypto::key_image> &key_images)
 {

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -193,35 +193,6 @@ void make_balanced_rerandomized_output_set(
     }
 }
 //----------------------------------------------------------------------------------------------------------------------
-void balance_last_pseudo_out(const uint8_t *sum_input_masks,
-    const uint8_t *sum_output_masks,
-    std::vector<const uint8_t *> &fcmp_prove_inputs_inout)
-{
-    auto res = ::balance_last_pseudo_out(
-        sum_input_masks,
-        sum_output_masks,
-        {fcmp_prove_inputs_inout.data(), fcmp_prove_inputs_inout.size()});
-
-    if (res.err != nullptr)
-    {
-        free(res.err);
-        throw std::runtime_error("failed to update last pseudo out");
-    }
-
-    fcmp_prove_inputs_inout.pop_back();
-    fcmp_prove_inputs_inout.emplace_back((uint8_t *)res.value);
-}
-
-crypto::ec_point read_input_pseudo_out(const uint8_t *fcmp_prove_input)
-{
-    uint8_t * res_ptr = ::read_input_pseudo_out(fcmp_prove_input);
-    crypto::ec_point res;
-    static_assert(sizeof(crypto::ec_point) == 32, "unexpected size of crypto::ec_point");
-    memcpy(&res, res_ptr, sizeof(crypto::ec_point));
-    free(res_ptr);
-    return res;
-}
-//----------------------------------------------------------------------------------------------------------------------
 SeleneScalar o_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output)
 {
     HANDLE_RES_CODE(SeleneScalar, ::o_blind, &rerandomized_output);
@@ -252,28 +223,6 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
     MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
     auto res = ::fcmp_prove_input_new(&rerandomized_output,
-        path.get(),
-        output_blinds.get(),
-        selene_branch_blind_slice,
-        helios_branch_blind_slice);
-
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
-uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
-    const uint8_t *y,
-    const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const fcmp_pp::Path &path,
-    const fcmp_pp::OutputBlinds &output_blinds,
-    const std::vector<SeleneBranchBlind> &selene_branch_blinds,
-    const std::vector<HeliosBranchBlind> &helios_branch_blinds)
-{
-    MAKE_TEMP_FFI_SLICE(SeleneBranchBlind, selene_branch_blinds, selene_branch_blind_slice);
-    MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
-
-    auto res = ::fcmp_pp_prove_input_new(x,
-        y,
-        &rerandomized_output,
         path.get(),
         output_blinds.get(),
         selene_branch_blind_slice,

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -376,7 +376,7 @@ FcmpMembershipProof prove_membership(const std::vector<uint8_t *> &fcmp_prove_in
 uint8_t *fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
     const FcmpPpProof &fcmp_pp_proof,
     const std::size_t n_tree_layers,
-    const uint8_t *tree_root,
+    const fcmp_pp::TreeRoot &tree_root,
     const std::vector<crypto::ec_point> &pseudo_outs,
     const std::vector<crypto::key_image> &key_images)
 {
@@ -395,7 +395,7 @@ uint8_t *fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
             fcmp_pp_proof.data(),
             fcmp_pp_proof.size(),
             n_tree_layers,
-            tree_root,
+            tree_root.get(),
             {pseudo_outs_ptrs.data(), pseudo_outs_ptrs.size()},
             {key_images_ptrs.data(), key_images_ptrs.size()}
         );
@@ -406,7 +406,7 @@ uint8_t *fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
 bool verify(const crypto::hash &signable_tx_hash,
     const FcmpPpProof &fcmp_pp_proof,
     const std::size_t n_tree_layers,
-    const uint8_t *tree_root,
+    const fcmp_pp::TreeRoot &tree_root,
     const std::vector<crypto::ec_point> &pseudo_outs,
     const std::vector<crypto::key_image> &key_images)
 {
@@ -425,7 +425,7 @@ bool verify(const crypto::hash &signable_tx_hash,
             fcmp_pp_proof.data(),
             fcmp_pp_proof.size(),
             n_tree_layers,
-            tree_root,
+            tree_root.get(),
             {pseudo_outs_ptrs.data(), pseudo_outs_ptrs.size()},
             {key_images_ptrs.data(), key_images_ptrs.size()}
         );
@@ -447,12 +447,12 @@ bool verify_sal(const crypto::hash &signable_tx_hash,
 //----------------------------------------------------------------------------------------------------------------------
 bool verify_membership(const FcmpMembershipProof &fcmp_proof,
     const std::size_t n_tree_layers,
-    const uint8_t *tree_root,
+    const fcmp_pp::TreeRoot &tree_root,
     const std::vector<FcmpInputCompressed> &inputs)
 {
     return ::fcmp_pp_verify_membership(
         {inputs.data(), inputs.size()},
-        tree_root,
+        tree_root.get(),
         n_tree_layers,
         fcmp_proof.data(),
         fcmp_proof.size());

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -296,7 +296,7 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
     const std::vector<const uint8_t *> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
-    MAKE_FFI_SLICE(helios_branch_blind_slice, HeliosBranchBlind, helios_branch_blinds);
+    MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
     auto res = ::fcmp_prove_input_new(&rerandomized_output,
         path,
@@ -315,7 +315,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const std::vector<const uint8_t *> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
-    MAKE_FFI_SLICE(helios_branch_blind_slice, HeliosBranchBlind, helios_branch_blinds);
+    MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
     auto res = ::fcmp_pp_prove_input_new(x,
         y,

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -213,8 +213,7 @@ SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
     HANDLE_RES_CODE(SeleneScalar, ::c_blind, &rerandomized_output);
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const fcmp_pp::Path &path,
+uint8_t *fcmp_prove_input_new(const fcmp_pp::Path &path,
     const fcmp_pp::OutputBlinds &output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
@@ -222,40 +221,12 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
     MAKE_TEMP_FFI_SLICE(SeleneBranchBlind, selene_branch_blinds, selene_branch_blind_slice);
     MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
-    auto res = ::fcmp_prove_input_new(&rerandomized_output,
-        path.get(),
+    auto res = ::fcmp_prove_input_new(path.get(),
         output_blinds.get(),
         selene_branch_blind_slice,
         helios_branch_blind_slice);
 
     return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
-FcmpPpProof prove(const crypto::hash &signable_tx_hash,
-    const std::vector<const uint8_t *> &fcmp_prove_inputs,
-    const std::size_t n_tree_layers)
-{
-    auto res = ::prove(reinterpret_cast<const uint8_t*>(&signable_tx_hash),
-        {fcmp_prove_inputs.data(), fcmp_prove_inputs.size()},
-        n_tree_layers);
-
-    if (res.err != nullptr)
-    {
-        free(res.err);
-        throw std::runtime_error("failed to construct FCMP++ proof");
-    }
-
-    // res.value is a void * pointing to a uint8_t *, so cast as a double pointer
-    uint8_t **buf = (uint8_t**) res.value;
-
-    const std::size_t proof_size = fcmp_pp_proof_len(fcmp_prove_inputs.size(), n_tree_layers);
-    const FcmpPpProof proof{*buf, *buf + proof_size};
-
-    // Free both pointers
-    free(*buf);
-    free(res.value);
-
-    return proof;
 }
 //----------------------------------------------------------------------------------------------------------------------
 std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signable_tx_hash,

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -242,30 +242,6 @@ SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
     HANDLE_RES_CODE(SeleneScalar, ::c_blind, &rerandomized_output);
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *blind_o_blind(const SeleneScalar &o_blind)
-{
-    auto res = ::blind_o_blind(&o_blind);
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
-uint8_t *blind_i_blind(const SeleneScalar &i_blind)
-{
-    auto res = ::blind_i_blind(&i_blind);
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
-uint8_t *blind_i_blind_blind(const SeleneScalar &i_blind_blind)
-{
-    auto res = ::blind_i_blind_blind(&i_blind_blind);
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
-uint8_t *blind_c_blind(const SeleneScalar &c_blind)
-{
-    auto res = ::blind_c_blind(&c_blind);
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
 uint8_t *path_new(const OutputChunk &leaves,
     std::size_t output_idx,
     const HeliosT::ScalarChunks &helios_layer_chunks,

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -225,17 +225,17 @@ std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signa
     return {std::move(p), L};
 }
 //----------------------------------------------------------------------------------------------------------------------
-FcmpMembershipProof prove_membership(const std::vector<FcmpProveInput> &fcmp_prove_inputs,
+FcmpMembershipProof prove_membership(const std::vector<FcmpPpProveInput> &fcmp_pp_prove_inputs,
     const std::size_t n_tree_layers)
 {
-    MAKE_TEMP_FFI_SLICE(FcmpProveInput, fcmp_prove_inputs, fcmp_prove_inputs_slice);
+    MAKE_TEMP_FFI_SLICE(FcmpPpProveInput, fcmp_pp_prove_inputs, fcmp_pp_prove_inputs_slice);
 
     FcmpPpSalProof p;
-    const std::size_t proof_len = membership_proof_len(fcmp_prove_inputs.size(), n_tree_layers);
+    const std::size_t proof_len = membership_proof_len(fcmp_pp_prove_inputs.size(), n_tree_layers);
     p.resize(proof_len);
 
     size_t proof_size = p.size();
-    const int r = ::fcmp_pp_prove_membership(fcmp_prove_inputs_slice,
+    const int r = ::fcmp_pp_prove_membership(fcmp_pp_prove_inputs_slice,
         n_tree_layers,
         proof_len,
         &p[0],
@@ -278,10 +278,10 @@ bool verify_membership(const FcmpMembershipProof &fcmp_proof,
         fcmp_proof.size());
 }
 //----------------------------------------------------------------------------------------------------------------------
-bool verify(const std::vector<fcmp_pp::FcmpVerifyInput> &fcmp_pp_verify_inputs)
+bool verify(const std::vector<fcmp_pp::FcmpPpVerifyInput> &fcmp_pp_verify_inputs)
 {
-    MAKE_TEMP_FFI_SLICE(FcmpVerifyInput, fcmp_pp_verify_inputs, fcmp_verify_inputs_slice);
-    return ::fcmp_pp_verify(fcmp_verify_inputs_slice);
+    MAKE_TEMP_FFI_SLICE(FcmpPpVerifyInput, fcmp_pp_verify_inputs, fcmp_pp_verify_inputs_slice);
+    return ::fcmp_pp_verify(fcmp_pp_verify_inputs_slice);
 }
 //----------------------------------------------------------------------------------------------------------------------
 bool verify(const crypto::hash &signable_tx_hash,
@@ -291,7 +291,7 @@ bool verify(const crypto::hash &signable_tx_hash,
     const std::vector<crypto::ec_point> &pseudo_outs,
     const std::vector<crypto::key_image> &key_images)
 {
-    auto fcmp_verify_input = fcmp_pp::fcmp_verify_input_new(
+    auto fcmp_pp_verify_input = fcmp_pp::fcmp_pp_verify_input_new(
             signable_tx_hash,
             fcmp_pp_proof,
             n_tree_layers,
@@ -299,9 +299,9 @@ bool verify(const crypto::hash &signable_tx_hash,
             pseudo_outs,
             key_images
         );
-    std::vector<fcmp_pp::FcmpVerifyInput> fcmp_verify_inputs;
-    fcmp_verify_inputs.emplace_back(std::move(fcmp_verify_input));
-    return verify(fcmp_verify_inputs);
+    std::vector<fcmp_pp::FcmpPpVerifyInput> fcmp_pp_verify_inputs;
+    fcmp_pp_verify_inputs.emplace_back(std::move(fcmp_pp_verify_input));
+    return verify(fcmp_pp_verify_inputs);
 }
 //----------------------------------------------------------------------------------------------------------------------
 }//namespace fcmp_pp

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -290,23 +290,19 @@ uint8_t *selene_branch_blind()
     return handle_res_ptr(__func__, res);
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *helios_branch_blind()
-{
-    const auto res = ::helios_branch_blind();
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const uint8_t *path,
     const uint8_t *output_blinds,
     const std::vector<const uint8_t *> &selene_branch_blinds,
-    const std::vector<const uint8_t *> &helios_branch_blinds)
+    const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
+    MAKE_FFI_SLICE(helios_branch_blind_slice, HeliosBranchBlind, helios_branch_blinds);
+
     auto res = ::fcmp_prove_input_new(&rerandomized_output,
         path,
         output_blinds,
         {selene_branch_blinds.data(), selene_branch_blinds.size()},
-        {helios_branch_blinds.data(), helios_branch_blinds.size()});
+        helios_branch_blind_slice);
 
     return handle_res_ptr(__func__, res);
 }
@@ -317,15 +313,17 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const uint8_t *path,
     const uint8_t *output_blinds,
     const std::vector<const uint8_t *> &selene_branch_blinds,
-    const std::vector<const uint8_t *> &helios_branch_blinds)
+    const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
+    MAKE_FFI_SLICE(helios_branch_blind_slice, HeliosBranchBlind, helios_branch_blinds);
+
     auto res = ::fcmp_pp_prove_input_new(x,
         y,
         &rerandomized_output,
         path,
         output_blinds,
         {selene_branch_blinds.data(), selene_branch_blinds.size()},
-        {helios_branch_blinds.data(), helios_branch_blinds.size()});
+        helios_branch_blind_slice);
 
     return handle_res_ptr(__func__, res);
 }

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -284,24 +284,19 @@ uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
     return handle_res_ptr(__func__, res);
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *selene_branch_blind()
-{
-    const auto res = ::selene_branch_blind();
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const uint8_t *path,
     const uint8_t *output_blinds,
-    const std::vector<const uint8_t *> &selene_branch_blinds,
+    const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
+    MAKE_TEMP_FFI_SLICE(SeleneBranchBlind, selene_branch_blinds, selene_branch_blind_slice);
     MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
     auto res = ::fcmp_prove_input_new(&rerandomized_output,
         path,
         output_blinds,
-        {selene_branch_blinds.data(), selene_branch_blinds.size()},
+        selene_branch_blind_slice,
         helios_branch_blind_slice);
 
     return handle_res_ptr(__func__, res);
@@ -312,9 +307,10 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const uint8_t *path,
     const uint8_t *output_blinds,
-    const std::vector<const uint8_t *> &selene_branch_blinds,
+    const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
+    MAKE_TEMP_FFI_SLICE(SeleneBranchBlind, selene_branch_blinds, selene_branch_blind_slice);
     MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
     auto res = ::fcmp_pp_prove_input_new(x,
@@ -322,7 +318,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
         &rerandomized_output,
         path,
         output_blinds,
-        {selene_branch_blinds.data(), selene_branch_blinds.size()},
+        selene_branch_blind_slice,
         helios_branch_blind_slice);
 
     return handle_res_ptr(__func__, res);

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -242,15 +242,6 @@ SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
     HANDLE_RES_CODE(SeleneScalar, ::c_blind, &rerandomized_output);
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *path_new(const OutputChunk &leaves,
-    std::size_t output_idx,
-    const HeliosT::ScalarChunks &helios_layer_chunks,
-    const SeleneT::ScalarChunks &selene_layer_chunks)
-{
-    auto res = ::path_new(leaves, output_idx, helios_layer_chunks, selene_layer_chunks);
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
 uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
     const uint8_t *blinded_i_blind,
     const uint8_t *blinded_i_blind_blind,
@@ -261,7 +252,7 @@ uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
 }
 //----------------------------------------------------------------------------------------------------------------------
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const uint8_t *path,
+    const fcmp_pp::Path &path,
     const uint8_t *output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
@@ -270,7 +261,7 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
     MAKE_TEMP_FFI_SLICE(HeliosBranchBlind, helios_branch_blinds, helios_branch_blind_slice);
 
     auto res = ::fcmp_prove_input_new(&rerandomized_output,
-        path,
+        path.get(),
         output_blinds,
         selene_branch_blind_slice,
         helios_branch_blind_slice);
@@ -281,7 +272,7 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
 uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const uint8_t *y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const uint8_t *path,
+    const fcmp_pp::Path &path,
     const uint8_t *output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
@@ -292,7 +283,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     auto res = ::fcmp_pp_prove_input_new(x,
         y,
         &rerandomized_output,
-        path,
+        path.get(),
         output_blinds,
         selene_branch_blind_slice,
         helios_branch_blind_slice);

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -242,18 +242,9 @@ SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
     HANDLE_RES_CODE(SeleneScalar, ::c_blind, &rerandomized_output);
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
-    const uint8_t *blinded_i_blind,
-    const uint8_t *blinded_i_blind_blind,
-    const uint8_t *blinded_c_blind)
-{
-    auto res = ::output_blinds_new(blinded_o_blind, blinded_i_blind, blinded_i_blind_blind, blinded_c_blind);
-    return handle_res_ptr(__func__, res);
-}
-//----------------------------------------------------------------------------------------------------------------------
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const fcmp_pp::Path &path,
-    const uint8_t *output_blinds,
+    const fcmp_pp::OutputBlinds &output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
@@ -262,7 +253,7 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
 
     auto res = ::fcmp_prove_input_new(&rerandomized_output,
         path.get(),
-        output_blinds,
+        output_blinds.get(),
         selene_branch_blind_slice,
         helios_branch_blind_slice);
 
@@ -273,7 +264,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const uint8_t *y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const fcmp_pp::Path &path,
-    const uint8_t *output_blinds,
+    const fcmp_pp::OutputBlinds &output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds)
 {
@@ -284,7 +275,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
         y,
         &rerandomized_output,
         path.get(),
-        output_blinds,
+        output_blinds.get(),
         selene_branch_blind_slice,
         helios_branch_blind_slice);
 

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -70,20 +70,6 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);
 
-uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
-    const uint8_t *y,
-    const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const fcmp_pp::Path &path,
-    const fcmp_pp::OutputBlinds &output_blinds,
-    const std::vector<SeleneBranchBlind> &selene_branch_blinds,
-    const std::vector<HeliosBranchBlind> &helios_branch_blinds);
-
-void balance_last_pseudo_out(const uint8_t *sum_input_masks,
-    const uint8_t *sum_output_masks,
-    std::vector<const uint8_t *> &fcmp_prove_inputs_inout);
-
-crypto::ec_point read_input_pseudo_out(const uint8_t *fcmp_prove_input);
-
 FcmpPpProof prove(const crypto::hash &signable_tx_hash,
     const std::vector<const uint8_t *> &fcmp_prove_inputs,
     const std::size_t n_tree_layers);

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -64,17 +64,12 @@ SeleneScalar i_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
 SeleneScalar i_blind_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-uint8_t *fcmp_prove_input_new(const fcmp_pp::Path &path,
-    const fcmp_pp::OutputBlinds &output_blinds,
-    const std::vector<SeleneBranchBlind> &selene_branch_blinds,
-    const std::vector<HeliosBranchBlind> &helios_branch_blinds);
-
 std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signable_tx_hash,
     const crypto::secret_key &x,
     const crypto::secret_key &y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-FcmpMembershipProof prove_membership(const std::vector<uint8_t *> &fcmp_prove_inputs,
+FcmpMembershipProof prove_membership(const std::vector<FcmpProveInput> &fcmp_prove_inputs,
     const std::size_t n_tree_layers);
 
 uint8_t *fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -72,20 +72,6 @@ std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signa
 FcmpMembershipProof prove_membership(const std::vector<FcmpProveInput> &fcmp_prove_inputs,
     const std::size_t n_tree_layers);
 
-uint8_t *fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
-    const FcmpPpProof &fcmp_pp_proof,
-    const std::size_t n_tree_layers,
-    const fcmp_pp::TreeRoot &tree_root,
-    const std::vector<crypto::ec_point> &pseudo_outs,
-    const std::vector<crypto::key_image> &key_images);
-
-bool verify(const crypto::hash &signable_tx_hash,
-    const FcmpPpProof &fcmp_pp_proof,
-    const std::size_t n_tree_layers,
-    const fcmp_pp::TreeRoot &tree_root,
-    const std::vector<crypto::ec_point> &pseudo_outs,
-    const std::vector<crypto::key_image> &key_images);
-
 bool verify_sal(const crypto::hash &signable_tx_hash,
     const FcmpInputCompressed &input,
     const crypto::key_image &key_image,
@@ -96,5 +82,12 @@ bool verify_membership(const FcmpMembershipProof &fcmp_proof,
     const fcmp_pp::TreeRoot &tree_root,
     const std::vector<FcmpInputCompressed> &inputs);
 
-bool batch_verify(const std::vector<const uint8_t *> &fcmp_pp_verify_inputs);
+bool verify(const std::vector<fcmp_pp::FcmpVerifyInput> &fcmp_pp_verify_inputs);
+
+bool verify(const crypto::hash &signable_tx_hash,
+    const fcmp_pp::FcmpPpProof &fcmp_pp_proof,
+    const std::size_t n_tree_layers,
+    const fcmp_pp::TreeRoot &tree_root,
+    const std::vector<crypto::ec_point> &pseudo_outs,
+    const std::vector<crypto::key_image> &key_images);
 }//namespace fcmp_pp

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -80,13 +80,12 @@ uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
     const uint8_t *blinded_c_blind);
 
 uint8_t *selene_branch_blind();
-uint8_t *helios_branch_blind();
 
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const uint8_t *path,
     const uint8_t *output_blinds,
     const std::vector<const uint8_t *> &selene_branch_blinds,
-    const std::vector<const uint8_t *> &helios_branch_blinds);
+    const std::vector<HeliosBranchBlind> &helios_branch_blinds);
 
 uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const uint8_t *y,
@@ -94,7 +93,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const uint8_t *path,
     const uint8_t *output_blinds,
     const std::vector<const uint8_t *> &selene_branch_blinds,
-    const std::vector<const uint8_t *> &helios_branch_blinds);
+    const std::vector<HeliosBranchBlind> &helios_branch_blinds);
 
 void balance_last_pseudo_out(const uint8_t *sum_input_masks,
     const uint8_t *sum_output_masks,

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -69,7 +69,7 @@ std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signa
     const crypto::secret_key &y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-FcmpMembershipProof prove_membership(const std::vector<FcmpPpProveInput> &fcmp_pp_prove_inputs,
+FcmpMembershipProof prove_membership(const std::vector<FcmpPpProveMembershipInput> &fcmp_pp_prove_inputs,
     const std::size_t n_tree_layers);
 
 bool verify_sal(const crypto::hash &signable_tx_hash,
@@ -79,7 +79,7 @@ bool verify_sal(const crypto::hash &signable_tx_hash,
 
 bool verify_membership(const FcmpMembershipProof &fcmp_proof,
     const std::size_t n_tree_layers,
-    const fcmp_pp::TreeRoot &tree_root,
+    const fcmp_pp::TreeRootShared &tree_root,
     const std::vector<FcmpInputCompressed> &inputs);
 
 bool verify(const std::vector<fcmp_pp::FcmpPpVerifyInput> &fcmp_pp_verify_inputs);
@@ -87,7 +87,7 @@ bool verify(const std::vector<fcmp_pp::FcmpPpVerifyInput> &fcmp_pp_verify_inputs
 bool verify(const crypto::hash &signable_tx_hash,
     const fcmp_pp::FcmpPpProof &fcmp_pp_proof,
     const std::size_t n_tree_layers,
-    const fcmp_pp::TreeRoot &tree_root,
+    const fcmp_pp::TreeRootShared &tree_root,
     const std::vector<crypto::ec_point> &pseudo_outs,
     const std::vector<crypto::key_image> &key_images);
 }//namespace fcmp_pp

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -69,7 +69,7 @@ std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signa
     const crypto::secret_key &y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-FcmpMembershipProof prove_membership(const std::vector<FcmpProveInput> &fcmp_prove_inputs,
+FcmpMembershipProof prove_membership(const std::vector<FcmpPpProveInput> &fcmp_pp_prove_inputs,
     const std::size_t n_tree_layers);
 
 bool verify_sal(const crypto::hash &signable_tx_hash,
@@ -82,7 +82,7 @@ bool verify_membership(const FcmpMembershipProof &fcmp_proof,
     const fcmp_pp::TreeRoot &tree_root,
     const std::vector<FcmpInputCompressed> &inputs);
 
-bool verify(const std::vector<fcmp_pp::FcmpVerifyInput> &fcmp_pp_verify_inputs);
+bool verify(const std::vector<fcmp_pp::FcmpPpVerifyInput> &fcmp_pp_verify_inputs);
 
 bool verify(const crypto::hash &signable_tx_hash,
     const fcmp_pp::FcmpPpProof &fcmp_pp_proof,

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -64,11 +64,6 @@ SeleneScalar i_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
 SeleneScalar i_blind_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-uint8_t *blind_o_blind(const SeleneScalar &o_blind);
-uint8_t *blind_i_blind(const SeleneScalar &i_blind);
-uint8_t *blind_i_blind_blind(const SeleneScalar &i_blind_blind);
-uint8_t *blind_c_blind(const SeleneScalar &c_blind);
-
 uint8_t *path_new(const OutputChunk &leaves,
     std::size_t output_idx,
     const HeliosT::ScalarChunks &helios_layer_chunks,

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -64,14 +64,9 @@ SeleneScalar i_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
 SeleneScalar i_blind_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
-    const uint8_t *blinded_i_blind,
-    const uint8_t *blinded_i_blind_blind,
-    const uint8_t *blinded_c_blind);
-
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const fcmp_pp::Path &path,
-    const uint8_t *output_blinds,
+    const fcmp_pp::OutputBlinds &output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);
 
@@ -79,7 +74,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const uint8_t *y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const fcmp_pp::Path &path,
-    const uint8_t *output_blinds,
+    const fcmp_pp::OutputBlinds &output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);
 

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -64,18 +64,13 @@ SeleneScalar i_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
 SeleneScalar i_blind_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-uint8_t *path_new(const OutputChunk &leaves,
-    std::size_t output_idx,
-    const HeliosT::ScalarChunks &helios_layer_chunks,
-    const SeleneT::ScalarChunks &selene_layer_chunks);
-
 uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
     const uint8_t *blinded_i_blind,
     const uint8_t *blinded_i_blind_blind,
     const uint8_t *blinded_c_blind);
 
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const uint8_t *path,
+    const fcmp_pp::Path &path,
     const uint8_t *output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);
@@ -83,7 +78,7 @@ uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomiz
 uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const uint8_t *y,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const uint8_t *path,
+    const fcmp_pp::Path &path,
     const uint8_t *output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -109,14 +109,14 @@ FcmpMembershipProof prove_membership(const std::vector<uint8_t *> &fcmp_prove_in
 uint8_t *fcmp_pp_verify_input_new(const crypto::hash &signable_tx_hash,
     const FcmpPpProof &fcmp_pp_proof,
     const std::size_t n_tree_layers,
-    const uint8_t *tree_root,
+    const fcmp_pp::TreeRoot &tree_root,
     const std::vector<crypto::ec_point> &pseudo_outs,
     const std::vector<crypto::key_image> &key_images);
 
 bool verify(const crypto::hash &signable_tx_hash,
     const FcmpPpProof &fcmp_pp_proof,
     const std::size_t n_tree_layers,
-    const uint8_t *tree_root,
+    const fcmp_pp::TreeRoot &tree_root,
     const std::vector<crypto::ec_point> &pseudo_outs,
     const std::vector<crypto::key_image> &key_images);
 
@@ -127,7 +127,7 @@ bool verify_sal(const crypto::hash &signable_tx_hash,
 
 bool verify_membership(const FcmpMembershipProof &fcmp_proof,
     const std::size_t n_tree_layers,
-    const uint8_t *tree_root,
+    const fcmp_pp::TreeRoot &tree_root,
     const std::vector<FcmpInputCompressed> &inputs);
 
 bool batch_verify(const std::vector<const uint8_t *> &fcmp_pp_verify_inputs);

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -64,15 +64,10 @@ SeleneScalar i_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output
 SeleneScalar i_blind_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 SeleneScalar c_blind(const FcmpRerandomizedOutputCompressed &rerandomized_output);
 
-uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const fcmp_pp::Path &path,
+uint8_t *fcmp_prove_input_new(const fcmp_pp::Path &path,
     const fcmp_pp::OutputBlinds &output_blinds,
     const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);
-
-FcmpPpProof prove(const crypto::hash &signable_tx_hash,
-    const std::vector<const uint8_t *> &fcmp_prove_inputs,
-    const std::size_t n_tree_layers);
 
 std::pair<FcmpPpSalProof, crypto::key_image> prove_sal(const crypto::hash &signable_tx_hash,
     const crypto::secret_key &x,

--- a/src/fcmp_pp/prove.h
+++ b/src/fcmp_pp/prove.h
@@ -79,12 +79,10 @@ uint8_t *output_blinds_new(const uint8_t *blinded_o_blind,
     const uint8_t *blinded_i_blind_blind,
     const uint8_t *blinded_c_blind);
 
-uint8_t *selene_branch_blind();
-
 uint8_t *fcmp_prove_input_new(const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const uint8_t *path,
     const uint8_t *output_blinds,
-    const std::vector<const uint8_t *> &selene_branch_blinds,
+    const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);
 
 uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
@@ -92,7 +90,7 @@ uint8_t *fcmp_pp_prove_input_new(const uint8_t *x,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const uint8_t *path,
     const uint8_t *output_blinds,
-    const std::vector<const uint8_t *> &selene_branch_blinds,
+    const std::vector<SeleneBranchBlind> &selene_branch_blinds,
     const std::vector<HeliosBranchBlind> &helios_branch_blinds);
 
 void balance_last_pseudo_out(const uint8_t *sum_input_masks,

--- a/src/fcmp_pp/tower_cycle.cpp
+++ b/src/fcmp_pp/tower_cycle.cpp
@@ -26,6 +26,7 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include "misc_log_ex.h"
 #include "string_tools.h"
 #include "tower_cycle.h"
 
@@ -61,22 +62,15 @@ Selene::Point Selene::hash_grow(
     const Selene::Scalar &existing_child_at_offset,
     const Selene::Chunk &new_children) const
 {
-    auto result = ::hash_grow_selene(
+    Selene::Point hash;
+    int res = ::hash_grow_selene(
         existing_hash,
         offset,
         existing_child_at_offset,
-        new_children);
-
-    if (result.err != nullptr)
-    {
-        free(result.err);
-        throw std::runtime_error("failed to hash grow");
-    }
-
-    typename Selene::Point res;
-    memcpy(&res, result.value, sizeof(typename Selene::Point));
-    free(result.value);
-    return res;
+        new_children,
+        &hash);
+    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow selene");
+    return hash;
 }
 //----------------------------------------------------------------------------------------------------------------------
 Helios::Point Helios::hash_grow(
@@ -85,22 +79,15 @@ Helios::Point Helios::hash_grow(
     const Helios::Scalar &existing_child_at_offset,
     const Helios::Chunk &new_children) const
 {
-    auto result = ::hash_grow_helios(
+    Helios::Point hash;
+    int res = ::hash_grow_helios(
         existing_hash,
         offset,
         existing_child_at_offset,
-        new_children);
-
-    if (result.err != nullptr)
-    {
-        free(result.err);
-        throw std::runtime_error("failed to hash grow");
-    }
-
-    typename Helios::Point res;
-    memcpy(&res, result.value, sizeof(typename Helios::Point));
-    free(result.value);
-    return res;
+        new_children,
+        &hash);
+    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow helios");
+    return hash;
 }
 //----------------------------------------------------------------------------------------------------------------------
 Selene::Scalar Selene::zero_scalar() const

--- a/src/fcmp_pp/tower_cycle.cpp
+++ b/src/fcmp_pp/tower_cycle.cpp
@@ -69,7 +69,7 @@ Selene::Point Selene::hash_grow(
         existing_child_at_offset,
         new_children,
         &hash);
-    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow selene");
+    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow selene with error code " << res);
     return hash;
 }
 //----------------------------------------------------------------------------------------------------------------------
@@ -86,7 +86,7 @@ Helios::Point Helios::hash_grow(
         existing_child_at_offset,
         new_children,
         &hash);
-    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow helios");
+    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow helios with error code " << res);
     return hash;
 }
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/fcmp_pp/tower_cycle.cpp
+++ b/src/fcmp_pp/tower_cycle.cpp
@@ -229,8 +229,5 @@ template std::vector<HeliosT::Chunk> scalar_chunks_to_chunk_vector<HeliosT>(
 template std::vector<SeleneT::Chunk> scalar_chunks_to_chunk_vector<SeleneT>(
     const std::vector<std::vector<SeleneT::Scalar>> &scalar_chunks);
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *selene_tree_root(const Selene::Point &point) { return ::selene_tree_root(point); }
-uint8_t *helios_tree_root(const Helios::Point &point) { return ::helios_tree_root(point); }
-//----------------------------------------------------------------------------------------------------------------------
 } //namespace tower_cycle
 } //namespace fcmp_pp

--- a/src/fcmp_pp/tower_cycle.h
+++ b/src/fcmp_pp/tower_cycle.h
@@ -148,9 +148,6 @@ void extend_scalars_from_cycle_points(const std::unique_ptr<C_POINTS> &curve,
     const std::vector<typename C_POINTS::Point> &points,
     std::vector<typename C_SCALARS::Scalar> &scalars_out);
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *selene_tree_root(const Selene::Point &point);
-uint8_t *helios_tree_root(const Helios::Point &point);
-//----------------------------------------------------------------------------------------------------------------------
 template<typename C>
 std::vector<typename C::Chunk> scalar_chunks_to_chunk_vector(
     const std::vector<std::vector<typename C::Scalar>> &scalar_chunks);

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -1113,7 +1113,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         "finalize_all_proofs_from_transfer_details: some prove jobs failed");
 
     // collect FCMP Rust API proving structures
-    std::vector<fcmp_pp::FcmpProveInput> membership_proving_inputs;
+    std::vector<fcmp_pp::FcmpPpProveInput> membership_proving_inputs;
     membership_proving_inputs.reserve(n_inputs);
     for (size_t i = 0; i < n_inputs; ++i)
     {
@@ -1138,7 +1138,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
             helios_branch_blinds.emplace_back(std::move(flat_helios_branch_blinds.at(flat_idx)));
         }
 
-        membership_proving_inputs.push_back(fcmp_pp::fcmp_prove_input_new(
+        membership_proving_inputs.push_back(fcmp_pp::fcmp_pp_prove_input_new(
             path_rust,
             output_blinds,
             selene_branch_blinds,

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -1003,7 +1003,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
 
     // Submit blinds calculation jobs
     uint8_t** blinds_obj_ptr = fcmp_blinds_objs.data();
-    std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds(num_c2_blinds * n_inputs);
+    std::vector<fcmp_pp::HeliosBranchBlind> flat_helios_branch_blinds(num_c2_blinds * n_inputs);
     for (size_t i = 0; i < n_inputs; ++i)
     {
         const FcmpRerandomizedOutputCompressed &rerandomized_output = rerandomized_outputs.at(i);
@@ -1032,9 +1032,9 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         }
         for (size_t j = 0; j < num_c2_blinds; ++j)
         {
-            tpool.submit(&pre_membership_waiter, [&helios_branch_blinds, num_c2_blinds, i, j]() {
+            tpool.submit(&pre_membership_waiter, [&flat_helios_branch_blinds, num_c2_blinds, i, j]() {
                 PERF_TIMER(helios_branch_blind);
-                helios_branch_blinds[(i * num_c2_blinds) + j] = fcmp_pp::HeliosBranchBlindGen();});
+                flat_helios_branch_blinds[(i * num_c2_blinds) + j] = fcmp_pp::HeliosBranchBlindGen();});
         }
     }
     CHECK_AND_ASSERT_THROW_MES(blinds_obj_ptr == fcmp_blinds_objs.data() + fcmp_blinds_objs.size(),
@@ -1150,6 +1150,13 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         std::vector<const uint8_t *> selene_branch_blinds(num_c1_blinds);
         memcpy(selene_branch_blinds.data(), blinds_obj_ptr, sizeof(selene_branch_blinds[0])*num_c1_blinds);
         blinds_obj_ptr += num_c1_blinds;
+
+        std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds;
+        for (size_t j = 0; j < num_c2_blinds; ++j)
+        {
+            const size_t flat_idx = (i * num_c2_blinds) + j;
+            helios_branch_blinds.emplace_back(std::move(flat_helios_branch_blinds.at(flat_idx)));
+        }
 
         membership_proving_inputs.push_back(fcmp_pp::fcmp_prove_input_new(
             rerandomized_output,

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -46,6 +46,7 @@
 #include "common/threadpool.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/blockchain.h"
+#include "fcmp_pp/fcmp_pp_types.h"
 #include "fcmp_pp/proof_len.h"
 #include "fcmp_pp/prove.h"
 #include "fcmp_pp/tower_cycle.h"
@@ -1183,22 +1184,20 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     // get FCMP tree root from provided path
     //! @TODO: make this a method of TreeCacheV1
     LOG_PRINT_L3("Making tree root from tree cache");
-    uint8_t *fcmp_tree_root = nullptr;
-    const auto tree_root_freer = epee::misc_utils::create_scope_leave_handler([fcmp_tree_root](){
-        if (fcmp_tree_root) free(fcmp_tree_root);});
+    fcmp_pp::TreeRoot fcmp_tree_root;
     if (n_tree_layers % 2 == 0)
     {
         CHECK_AND_ASSERT_THROW_MES(!first_fcmp_path.c2_layers.empty(), "missing c2 layers");
         const auto &last_layer = first_fcmp_path.c2_layers.back();
         CHECK_AND_ASSERT_THROW_MES(last_layer.size() == 1, "unexpected n elems in c2 root");
-        fcmp_tree_root = fcmp_pp::tower_cycle::helios_tree_root(last_layer.back());
+        fcmp_tree_root = fcmp_pp::helios_tree_root(last_layer.back());
     }
     else
     {
         CHECK_AND_ASSERT_THROW_MES(!first_fcmp_path.c1_layers.empty(), "missing c1 layers");
         const auto &last_layer = first_fcmp_path.c1_layers.back();
         CHECK_AND_ASSERT_THROW_MES(last_layer.size() == 1, "unexpected n elems in c1 root");
-        fcmp_tree_root = fcmp_pp::tower_cycle::selene_tree_root(last_layer.back());
+        fcmp_tree_root = fcmp_pp::selene_tree_root(last_layer.back());
     }
 
     // expand tx

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -1128,7 +1128,6 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     const auto memberin_freer = make_fcmp_obj_freer(membership_proving_inputs);
     for (size_t i = 0; i < n_inputs; ++i)
     {
-        const FcmpRerandomizedOutputCompressed &rerandomized_output = rerandomized_outputs.at(i);
         const fcmp_pp::Path &path_rust = fcmp_paths_rust.at(i);
         const fcmp_pp::OutputBlinds output_blinds = fcmp_pp::output_blinds_new(
             blinded_o_blinds.at(i),
@@ -1151,7 +1150,6 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         }
 
         membership_proving_inputs.push_back(fcmp_pp::fcmp_prove_input_new(
-            rerandomized_output,
             path_rust,
             output_blinds,
             selene_branch_blinds,

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -75,17 +75,7 @@ static constexpr T div_ceil(T dividend, T divisor)
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-static epee::misc_utils::auto_scope_leave_caller make_fcmp_obj_freer(const std::vector<uint8_t*> &objs)
-{
-    return epee::misc_utils::create_scope_leave_handler([&objs](){
-        for (uint8_t *obj : objs)
-            if (nullptr != obj)
-                free(obj);
-    });
-}
-//-------------------------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------------------------
-static bool is_transfer_usable_for_input_selection(const wallet2_basic::transfer_details &td,
+static bool is_transfer_usable_for_input_selection(const wallet2::transfer_details &td,
     const std::uint32_t from_account,
     const std::set<std::uint32_t> from_subaddresses,
     const rct::xmr_amount ignore_above,
@@ -1123,9 +1113,8 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         "finalize_all_proofs_from_transfer_details: some prove jobs failed");
 
     // collect FCMP Rust API proving structures
-    std::vector<uint8_t*> membership_proving_inputs;
+    std::vector<fcmp_pp::FcmpProveInput> membership_proving_inputs;
     membership_proving_inputs.reserve(n_inputs);
-    const auto memberin_freer = make_fcmp_obj_freer(membership_proving_inputs);
     for (size_t i = 0; i < n_inputs; ++i)
     {
         const fcmp_pp::Path &path_rust = fcmp_paths_rust.at(i);

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -1130,14 +1130,11 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     {
         const FcmpRerandomizedOutputCompressed &rerandomized_output = rerandomized_outputs.at(i);
         const fcmp_pp::Path &path_rust = fcmp_paths_rust.at(i);
-        uint8_t *output_blinds = fcmp_pp::output_blinds_new(
-            (uint8_t*)blinded_o_blinds.at(i).get(),
-            (uint8_t*)blinded_i_blinds.at(i).get(),
-            (uint8_t*)blinded_i_blind_blinds.at(i).get(),
-            (uint8_t*)blinded_c_blinds.at(i).get());
-        const auto free_output_blinds =
-            epee::misc_utils::create_scope_leave_handler([output_blinds]()
-                { free(output_blinds); });
+        const fcmp_pp::OutputBlinds output_blinds = fcmp_pp::output_blinds_new(
+            blinded_o_blinds.at(i),
+            blinded_i_blinds.at(i),
+            blinded_i_blind_blinds.at(i),
+            blinded_c_blinds.at(i));
 
         std::vector<fcmp_pp::SeleneBranchBlind> selene_branch_blinds;
         for (size_t j = 0; j < num_c1_blinds; ++j)

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -75,7 +75,7 @@ static constexpr T div_ceil(T dividend, T divisor)
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-static bool is_transfer_usable_for_input_selection(const wallet2::transfer_details &td,
+static bool is_transfer_usable_for_input_selection(const wallet2_basic::transfer_details &td,
     const std::uint32_t from_account,
     const std::set<std::uint32_t> from_subaddresses,
     const rct::xmr_amount ignore_above,
@@ -1113,7 +1113,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         "finalize_all_proofs_from_transfer_details: some prove jobs failed");
 
     // collect FCMP Rust API proving structures
-    std::vector<fcmp_pp::FcmpPpProveInput> membership_proving_inputs;
+    std::vector<fcmp_pp::FcmpPpProveMembershipInput> membership_proving_inputs;
     membership_proving_inputs.reserve(n_inputs);
     for (size_t i = 0; i < n_inputs; ++i)
     {
@@ -1167,7 +1167,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     // get FCMP tree root from provided path
     //! @TODO: make this a method of TreeCacheV1
     LOG_PRINT_L3("Making tree root from tree cache");
-    fcmp_pp::TreeRoot fcmp_tree_root;
+    fcmp_pp::TreeRootShared fcmp_tree_root;
     if (n_tree_layers % 2 == 0)
     {
         CHECK_AND_ASSERT_THROW_MES(!first_fcmp_path.c2_layers.empty(), "missing c2 layers");

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -513,10 +513,10 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
         auto blinded_c_blind = fcmp_pp::blind_c_blind(fcmp_pp::c_blind(rerandomized_output));
 
         // make output blinds
-        proof_input.output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
-            (uint8_t*)blinded_i_blind.get(),
-            (uint8_t*)blinded_i_blind_blind.get(),
-            (uint8_t*)blinded_c_blind.get());
+        proof_input.output_blinds = fcmp_pp::output_blinds_new(blinded_o_blind,
+            blinded_i_blind,
+            blinded_i_blind_blind,
+            blinded_c_blind);
 
         // generate selene blinds
         proof_input.selene_branch_blinds.reserve(expected_num_selene_branch_blinds);
@@ -541,7 +541,6 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
             proof_input.output_blinds,
             proof_input.selene_branch_blinds,
             proof_input.helios_branch_blinds));
-        free(proof_input.output_blinds);
     }
     const fcmp_pp::FcmpMembershipProof membership_proof = fcmp_pp::prove_membership(fcmp_proof_inputs_rust,
         n_tree_layers);

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -507,30 +507,26 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
         const FcmpRerandomizedOutputCompressed &rerandomized_output = rerandomized_outputs.at(i);
 
         // calculate individual blinds
-        uint8_t *blinded_o_blind = fcmp_pp::blind_o_blind(fcmp_pp::o_blind(rerandomized_output));
-        uint8_t *blinded_i_blind = fcmp_pp::blind_i_blind(fcmp_pp::i_blind(rerandomized_output));
-        uint8_t *blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(fcmp_pp::i_blind_blind(rerandomized_output));
-        uint8_t *blinded_c_blind = fcmp_pp::blind_c_blind(fcmp_pp::c_blind(rerandomized_output));
+        auto blinded_o_blind = fcmp_pp::blind_o_blind(fcmp_pp::o_blind(rerandomized_output));
+        auto blinded_i_blind = fcmp_pp::blind_i_blind(fcmp_pp::i_blind(rerandomized_output));
+        auto blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(fcmp_pp::i_blind_blind(rerandomized_output));
+        auto blinded_c_blind = fcmp_pp::blind_c_blind(fcmp_pp::c_blind(rerandomized_output));
 
         // make output blinds
-        proof_input.output_blinds = fcmp_pp::output_blinds_new(
-            blinded_o_blind, blinded_i_blind, blinded_i_blind_blind, blinded_c_blind);
+        proof_input.output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
+            (uint8_t*)blinded_i_blind.get(),
+            (uint8_t*)blinded_i_blind_blind.get(),
+            (uint8_t*)blinded_c_blind.get());
 
         // generate selene blinds
         proof_input.selene_branch_blinds.reserve(expected_num_selene_branch_blinds);
         for (size_t j = 0; j < expected_num_selene_branch_blinds; ++j)
-            proof_input.selene_branch_blinds.push_back(fcmp_pp::SeleneBranchBlindGen());
+            proof_input.selene_branch_blinds.push_back(fcmp_pp::gen_selene_branch_blind());
 
         // generate helios blinds
         proof_input.helios_branch_blinds.reserve(expected_num_helios_branch_blinds);
         for (size_t j = 0; j < expected_num_helios_branch_blinds; ++j)
-            proof_input.helios_branch_blinds.push_back(fcmp_pp::HeliosBranchBlindGen());
-
-        // dealloc individual blinds
-        free(blinded_o_blind);
-        free(blinded_i_blind);
-        free(blinded_i_blind_blind);
-        free(blinded_c_blind);
+            proof_input.helios_branch_blinds.push_back(fcmp_pp::gen_helios_branch_blind());
     }
 
     // Make FCMP membership proof

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -531,7 +531,7 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
 
     // Make FCMP membership proof
     LOG_PRINT_L1("Generating FCMP++ membership proofs");
-    std::vector<fcmp_pp::FcmpPpProveInput> fcmp_proof_inputs_rust;
+    std::vector<fcmp_pp::FcmpPpProveMembershipInput> fcmp_proof_inputs_rust;
     for (size_t i = 0; i < n_inputs; ++i)
     {
         fcmp_pp::ProofInput &proof_input = fcmp_proof_inputs.at(i);

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -519,7 +519,7 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
         // generate selene blinds
         proof_input.selene_branch_blinds.reserve(expected_num_selene_branch_blinds);
         for (size_t j = 0; j < expected_num_selene_branch_blinds; ++j)
-            proof_input.selene_branch_blinds.push_back(fcmp_pp::selene_branch_blind());
+            proof_input.selene_branch_blinds.push_back(fcmp_pp::SeleneBranchBlindGen());
 
         // generate helios blinds
         proof_input.helios_branch_blinds.reserve(expected_num_helios_branch_blinds);
@@ -547,8 +547,6 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
             proof_input.helios_branch_blinds));
         free(proof_input.path);
         free(proof_input.output_blinds);
-        for (const uint8_t *branch_blind : proof_input.selene_branch_blinds)
-            free(const_cast<uint8_t*>(branch_blind));
     }
     const fcmp_pp::FcmpMembershipProof membership_proof = fcmp_pp::prove_membership(fcmp_proof_inputs_rust,
         n_tree_layers);

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -536,7 +536,6 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
     {
         fcmp_pp::ProofInput &proof_input = fcmp_proof_inputs.at(i);
         fcmp_proof_inputs_rust.push_back(fcmp_pp::fcmp_prove_input_new(
-            rerandomized_outputs.at(i),
             proof_input.path,
             proof_input.output_blinds,
             proof_input.selene_branch_blinds,

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -491,12 +491,12 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
         const auto selene_scalar_chunks = fcmp_pp::tower_cycle::scalar_chunks_to_chunk_vector<fcmp_pp::SeleneT>(
             path_for_proof.c1_scalar_chunks);
 
-        const auto path_rust = fcmp_pp::path_new({path_for_proof.leaves.data(), path_for_proof.leaves.size()},
+        auto path_rust = fcmp_pp::path_new({path_for_proof.leaves.data(), path_for_proof.leaves.size()},
             path_for_proof.output_idx,
             {helios_scalar_chunks.data(), helios_scalar_chunks.size()},
             {selene_scalar_chunks.data(), selene_scalar_chunks.size()});
 
-        fcmp_proof_inputs[i].path = path_rust;
+        fcmp_proof_inputs[i].path = std::move(path_rust);
     }
 
     // make FCMP blinds
@@ -541,7 +541,6 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
             proof_input.output_blinds,
             proof_input.selene_branch_blinds,
             proof_input.helios_branch_blinds));
-        free(proof_input.path);
         free(proof_input.output_blinds);
     }
     const fcmp_pp::FcmpMembershipProof membership_proof = fcmp_pp::prove_membership(fcmp_proof_inputs_rust,

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -524,7 +524,7 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
         // generate helios blinds
         proof_input.helios_branch_blinds.reserve(expected_num_helios_branch_blinds);
         for (size_t j = 0; j < expected_num_helios_branch_blinds; ++j)
-            proof_input.helios_branch_blinds.push_back(fcmp_pp::helios_branch_blind());
+            proof_input.helios_branch_blinds.push_back(fcmp_pp::HeliosBranchBlindGen());
 
         // dealloc individual blinds
         free(blinded_o_blind);
@@ -548,8 +548,6 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
         free(proof_input.path);
         free(proof_input.output_blinds);
         for (const uint8_t *branch_blind : proof_input.selene_branch_blinds)
-            free(const_cast<uint8_t*>(branch_blind));
-        for (const uint8_t *branch_blind : proof_input.helios_branch_blinds)
             free(const_cast<uint8_t*>(branch_blind));
     }
     const fcmp_pp::FcmpMembershipProof membership_proof = fcmp_pp::prove_membership(fcmp_proof_inputs_rust,

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -531,7 +531,7 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
 
     // Make FCMP membership proof
     LOG_PRINT_L1("Generating FCMP++ membership proofs");
-    std::vector<uint8_t*> fcmp_proof_inputs_rust;
+    std::vector<fcmp_pp::FcmpProveInput> fcmp_proof_inputs_rust;
     for (size_t i = 0; i < n_inputs; ++i)
     {
         fcmp_pp::ProofInput &proof_input = fcmp_proof_inputs.at(i);
@@ -543,10 +543,6 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
     }
     const fcmp_pp::FcmpMembershipProof membership_proof = fcmp_pp::prove_membership(fcmp_proof_inputs_rust,
         n_tree_layers);
-
-    // Dealloc FCMP proof inputs
-    for (uint8_t *proof_input : fcmp_proof_inputs_rust)
-      free(proof_input);
 
     // Attach rctSigPrunable to tx
     LOG_PRINT_L1("Storing rctSig prunable");

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -619,7 +619,6 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
     // Verify all RingCT non-semantics
     LOG_PRINT_L1("Verify RingCT non-semantics consensus rules");
     ASSERT_TRUE(rct::verRctNonSemanticsSimple(deserialized_tx.rct_signatures));
-    free(tree_root);
 
     // Load carrot from tx
     LOG_PRINT_L1("Parsing carrot info from deserialized transaction");

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -531,11 +531,11 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
 
     // Make FCMP membership proof
     LOG_PRINT_L1("Generating FCMP++ membership proofs");
-    std::vector<fcmp_pp::FcmpProveInput> fcmp_proof_inputs_rust;
+    std::vector<fcmp_pp::FcmpPpProveInput> fcmp_proof_inputs_rust;
     for (size_t i = 0; i < n_inputs; ++i)
     {
         fcmp_pp::ProofInput &proof_input = fcmp_proof_inputs.at(i);
-        fcmp_proof_inputs_rust.push_back(fcmp_pp::fcmp_prove_input_new(
+        fcmp_proof_inputs_rust.push_back(fcmp_pp::fcmp_pp_prove_input_new(
             proof_input.path,
             proof_input.output_blinds,
             proof_input.selene_branch_blinds,

--- a/tests/unit_tests/curve_trees.cpp
+++ b/tests/unit_tests/curve_trees.cpp
@@ -479,7 +479,7 @@ std::set<std::size_t> CurveTreesGlobalTree::get_leaf_idxs_with_output_pair(
     return leaf_idx;
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint8_t *CurveTreesGlobalTree::get_tree_root() const
+fcmp_pp::TreeRoot CurveTreesGlobalTree::get_tree_root() const
 {
     const std::size_t n_layers = m_tree.c1_layers.size() + m_tree.c2_layers.size();
 
@@ -491,14 +491,14 @@ uint8_t *CurveTreesGlobalTree::get_tree_root() const
         CHECK_AND_ASSERT_THROW_MES(!m_tree.c2_layers.empty(), "missing c2 layers");
         const auto &last_layer = m_tree.c2_layers.back();
         CHECK_AND_ASSERT_THROW_MES(last_layer.size() == 1, "unexpected n elems in c2 root");
-        return fcmp_pp::tower_cycle::helios_tree_root(last_layer.back());
+        return fcmp_pp::helios_tree_root(last_layer.back());
     }
     else
     {
         CHECK_AND_ASSERT_THROW_MES(!m_tree.c1_layers.empty(), "missing c1 layers");
         const auto &last_layer = m_tree.c1_layers.back();
         CHECK_AND_ASSERT_THROW_MES(last_layer.size() == 1, "unexpected n elems in c1 root");
-        return fcmp_pp::tower_cycle::selene_tree_root(last_layer.back());
+        return fcmp_pp::selene_tree_root(last_layer.back());
     }
 }
 //----------------------------------------------------------------------------------------------------------------------

--- a/tests/unit_tests/curve_trees.cpp
+++ b/tests/unit_tests/curve_trees.cpp
@@ -479,7 +479,7 @@ std::set<std::size_t> CurveTreesGlobalTree::get_leaf_idxs_with_output_pair(
     return leaf_idx;
 }
 //----------------------------------------------------------------------------------------------------------------------
-fcmp_pp::TreeRoot CurveTreesGlobalTree::get_tree_root() const
+fcmp_pp::TreeRootShared CurveTreesGlobalTree::get_tree_root() const
 {
     const std::size_t n_layers = m_tree.c1_layers.size() + m_tree.c2_layers.size();
 

--- a/tests/unit_tests/curve_trees.h
+++ b/tests/unit_tests/curve_trees.h
@@ -92,7 +92,7 @@ public:
     // get all leaf indices with given output pair
     std::set<std::size_t> get_leaf_idxs_with_output_pair(const fcmp_pp::curve_trees::OutputPair &output_pair) const;
 
-    fcmp_pp::TreeRoot get_tree_root() const;
+    fcmp_pp::TreeRootShared get_tree_root() const;
 
 private:
     // Use the tree extension to extend the in-memory tree

--- a/tests/unit_tests/curve_trees.h
+++ b/tests/unit_tests/curve_trees.h
@@ -92,7 +92,7 @@ public:
     // get all leaf indices with given output pair
     std::set<std::size_t> get_leaf_idxs_with_output_pair(const fcmp_pp::curve_trees::OutputPair &output_pair) const;
 
-    uint8_t *get_tree_root() const;
+    fcmp_pp::TreeRoot get_tree_root() const;
 
 private:
     // Use the tree extension to extend the in-memory tree

--- a/tests/unit_tests/fake_pruned_blockchain.cpp
+++ b/tests/unit_tests/fake_pruned_blockchain.cpp
@@ -359,7 +359,7 @@ void fake_pruned_blockchain::add_block(cryptonote::block &&blk,
     m_num_outputs = running_num_chain_outputs;
     m_block_entries.emplace_back(std::move(blk_entry));
     m_parsed_blocks.emplace_back(std::move(par_blk));
-    m_curve_tree_roots.emplace_back(make_fcmp_generic_object(m_global_curve_tree.get_tree_root()));
+    m_curve_tree_roots.emplace_back(m_global_curve_tree.get_tree_root());
 }
 //----------------------------------------------------------------------------------------------------------------------
 void fake_pruned_blockchain::get_blocks_data(const uint64_t start_block_index,

--- a/tests/unit_tests/fake_pruned_blockchain.h
+++ b/tests/unit_tests/fake_pruned_blockchain.h
@@ -31,14 +31,11 @@
 #define IN_UNIT_TESTS
 
 #include "curve_trees.h"
+#include "fcmp_pp/fcmp_pp_types.h"
 #include "wallet/wallet2.h"
 
 namespace mock
 {
-//----------------------------------------------------------------------------------------------------------------------
-//----------------------------------------------------------------------------------------------------------------------
-using fcmp_generic_object_t = std::unique_ptr<void, decltype(&free)>;
-static inline fcmp_generic_object_t make_fcmp_generic_object(void *p) { return fcmp_generic_object_t(p, &free); }
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 class fake_pruned_blockchain
@@ -111,12 +108,12 @@ public:
         return m_parsed_blocks.at(block_index - this->m_start_block_index);
     }
 
-    const uint8_t *get_fcmp_tree_root_at(const uint64_t block_index) const
+    const fcmp_pp::TreeRoot get_fcmp_tree_root_at(const uint64_t block_index) const
     {
         if (block_index >= this->height() || block_index < this->m_start_block_index)
             throw std::out_of_range("get_fcmp_tree_root_at requested block index");
 
-        return reinterpret_cast<uint8_t*>(m_curve_tree_roots.at(block_index - this->m_start_block_index).get());
+        return m_curve_tree_roots.at(block_index - this->m_start_block_index);
     }
 
 private:
@@ -129,7 +126,7 @@ private:
     uint64_t m_num_outputs;
     std::vector<cryptonote::block_complete_entry> m_block_entries;
     std::vector<tools::wallet2::parsed_block> m_parsed_blocks;
-    std::vector<fcmp_generic_object_t> m_curve_tree_roots;
+    std::vector<fcmp_pp::TreeRoot> m_curve_tree_roots;
 
     CurveTreesGlobalTree m_global_curve_tree;
 };

--- a/tests/unit_tests/fake_pruned_blockchain.h
+++ b/tests/unit_tests/fake_pruned_blockchain.h
@@ -108,7 +108,7 @@ public:
         return m_parsed_blocks.at(block_index - this->m_start_block_index);
     }
 
-    const fcmp_pp::TreeRoot get_fcmp_tree_root_at(const uint64_t block_index) const
+    const fcmp_pp::TreeRootShared get_fcmp_tree_root_at(const uint64_t block_index) const
     {
         if (block_index >= this->height() || block_index < this->m_start_block_index)
             throw std::out_of_range("get_fcmp_tree_root_at requested block index");
@@ -126,7 +126,7 @@ private:
     uint64_t m_num_outputs;
     std::vector<cryptonote::block_complete_entry> m_block_entries;
     std::vector<tools::wallet2::parsed_block> m_parsed_blocks;
-    std::vector<fcmp_pp::TreeRoot> m_curve_tree_roots;
+    std::vector<fcmp_pp::TreeRootShared> m_curve_tree_roots;
 
     CurveTreesGlobalTree m_global_curve_tree;
 };

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -350,13 +350,13 @@ TEST(fcmp_pp, prove)
     {
         std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
         std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
-        std::vector<fcmp_pp::FcmpProveInput> fcmp_prove_inputs;
+        std::vector<fcmp_pp::FcmpPpProveInput> fcmp_pp_prove_inputs;
         std::vector<crypto::key_image> key_images;
         std::vector<crypto::ec_point> pseudo_outs;
 
         std::unordered_set<std::size_t> selected_indices;
 
-        while (fcmp_prove_inputs.size() < n_inputs)
+        while (fcmp_pp_prove_inputs.size() < n_inputs)
         {
             // Generate a random unique leaf tuple index within the tree
             const size_t leaf_idx = crypto::rand_idx(global_tree.get_n_leaf_tuples());
@@ -439,7 +439,7 @@ TEST(fcmp_pp, prove)
                 rerandomized_output);
 
             // Collect input for membership proof
-            auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
+            auto fcmp_pp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
@@ -447,7 +447,7 @@ TEST(fcmp_pp, prove)
 
             rerandomized_outputs.emplace_back(std::move(rerandomized_output));
             sal_proofs.emplace_back(std::move(sal_proof.first));
-            fcmp_prove_inputs.emplace_back(std::move(fcmp_prove_input));
+            fcmp_pp_prove_inputs.emplace_back(std::move(fcmp_pp_prove_input));
         }
 
         LOG_PRINT_L1("Constructing membership proof and verifying (n_inputs=" << n_inputs << ")");
@@ -455,7 +455,7 @@ TEST(fcmp_pp, prove)
 
         // Create membership proof
         LOG_PRINT_L1("Proving " << n_inputs << "-in " << n_layers << "-layer FCMP");
-        const auto membership_proof = fcmp_pp::prove_membership(fcmp_prove_inputs, n_layers);
+        const auto membership_proof = fcmp_pp::prove_membership(fcmp_pp_prove_inputs, n_layers);
 
         // Serialize FCMP++ proof and verify
         const auto fcmp_pp_proof = fcmp_pp::fcmp_pp_proof_from_parts_v1(rerandomized_outputs,
@@ -518,13 +518,13 @@ TEST(fcmp_pp, verify)
     {
         std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
         std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
-        std::vector<fcmp_pp::FcmpProveInput> fcmp_prove_inputs;
+        std::vector<fcmp_pp::FcmpPpProveInput> fcmp_pp_prove_inputs;
         std::vector<crypto::key_image> key_images;
         std::vector<crypto::ec_point> pseudo_outs;
 
         std::unordered_set<std::size_t> selected_indices;
 
-        while (fcmp_prove_inputs.size() < n_inputs)
+        while (fcmp_pp_prove_inputs.size() < n_inputs)
         {
             // Generate a random unique leaf tuple index within the tree
             const size_t leaf_idx = crypto::rand_idx(curve_trees->m_c1_width);
@@ -593,7 +593,7 @@ TEST(fcmp_pp, verify)
                 rerandomized_output);
 
             // Collect input for membership proof
-            auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
+            auto fcmp_pp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
@@ -601,14 +601,14 @@ TEST(fcmp_pp, verify)
 
             rerandomized_outputs.emplace_back(std::move(rerandomized_output));
             sal_proofs.emplace_back(std::move(sal_proof.first));
-            fcmp_prove_inputs.emplace_back(std::move(fcmp_prove_input));
+            fcmp_pp_prove_inputs.emplace_back(std::move(fcmp_pp_prove_input));
         }
 
         LOG_PRINT_L1("Constructing membership proof and verifying (n_inputs=" << n_inputs << ")");
 
         // Create membership proof
         LOG_PRINT_L1("Proving " << n_inputs << "-in " << std::to_string(n_layers) << "-layer FCMP");
-        const auto membership_proof = fcmp_pp::prove_membership(fcmp_prove_inputs, n_layers);
+        const auto membership_proof = fcmp_pp::prove_membership(fcmp_pp_prove_inputs, n_layers);
 
         // Serialize FCMP++ proof and verify
         const auto fcmp_pp_proof = fcmp_pp::fcmp_pp_proof_from_parts_v1(rerandomized_outputs,
@@ -720,7 +720,7 @@ TEST(fcmp_pp, membership_completeness)
         std::set<size_t> selected_indices;
         std::vector<FcmpInputCompressed> fcmp_raw_inputs;
         fcmp_raw_inputs.reserve(num_inputs);
-        std::vector<fcmp_pp::FcmpProveInput> fcmp_provable_inputs;
+        std::vector<fcmp_pp::FcmpPpProveInput> fcmp_provable_inputs;
         fcmp_provable_inputs.reserve(num_inputs);
         while (selected_indices.size() < num_inputs)
         {
@@ -823,7 +823,7 @@ TEST(fcmp_pp, membership_completeness)
                 blinded_c_blind);
             
             // make provable FCMP input
-            fcmp_provable_inputs.push_back(fcmp_pp::fcmp_prove_input_new(
+            fcmp_provable_inputs.push_back(fcmp_pp::fcmp_pp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -413,19 +413,19 @@ TEST(fcmp_pp, prove)
             const auto blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(i_blind_blind);
             const auto blinded_c_blind = fcmp_pp::blind_c_blind(c_blind);
 
-            const auto output_blinds = fcmp_pp::output_blinds_new(blinded_o_blind,
-                blinded_i_blind,
-                blinded_i_blind_blind,
-                blinded_c_blind);
+            const auto output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
+                (uint8_t*)blinded_i_blind.get(),
+                (uint8_t*)blinded_i_blind_blind.get(),
+                (uint8_t*)blinded_c_blind.get());
 
             // Cache branch blinds
             if (selene_branch_blinds.empty())
                 for (std::size_t i = 0; i < helios_scalar_chunks.size(); ++i)
-                    selene_branch_blinds.emplace_back(fcmp_pp::SeleneBranchBlindGen());
+                    selene_branch_blinds.emplace_back(fcmp_pp::gen_selene_branch_blind());
 
             if (helios_branch_blinds.empty())
                 for (std::size_t i = 0; i < selene_scalar_chunks.size(); ++i)
-                    helios_branch_blinds.emplace_back(fcmp_pp::HeliosBranchBlindGen());
+                    helios_branch_blinds.emplace_back(fcmp_pp::gen_helios_branch_blind());
 
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,
@@ -491,13 +491,13 @@ TEST(fcmp_pp, verify)
     LOG_PRINT_L1("Calculating " << expected_num_selene_branch_blinds << " Selene branch blinds");
     std::vector<fcmp_pp::SeleneBranchBlind> selene_branch_blinds;
     for (size_t i = 0; i < expected_num_selene_branch_blinds; ++i)
-        selene_branch_blinds.emplace_back(fcmp_pp::SeleneBranchBlindGen());
+        selene_branch_blinds.emplace_back(fcmp_pp::gen_selene_branch_blind());
 
     const size_t expected_num_helios_branch_blinds = (n_layers - 1) / 2;
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");
     std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds;
     for (size_t i = 0; i < expected_num_helios_branch_blinds; ++i)
-        helios_branch_blinds.emplace_back(fcmp_pp::HeliosBranchBlindGen());
+        helios_branch_blinds.emplace_back(fcmp_pp::gen_helios_branch_blind());
 
     // Create proofs with random leaf idxs for txs with [1..FCMP_PLUS_PLUS_MAX_INPUTS] inputs
     for (std::size_t n_inputs = 1; n_inputs <= FCMP_PLUS_PLUS_MAX_INPUTS; ++n_inputs)
@@ -564,10 +564,10 @@ TEST(fcmp_pp, verify)
             const auto blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(i_blind_blind);
             const auto blinded_c_blind = fcmp_pp::blind_c_blind(c_blind);
 
-            const auto output_blinds = fcmp_pp::output_blinds_new(blinded_o_blind,
-                blinded_i_blind,
-                blinded_i_blind_blind,
-                blinded_c_blind);
+            const auto output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
+                (uint8_t*)blinded_i_blind.get(),
+                (uint8_t*)blinded_i_blind_blind.get(),
+                (uint8_t*)blinded_c_blind.get());
 
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,
@@ -674,13 +674,13 @@ TEST(fcmp_pp, membership_completeness)
     LOG_PRINT_L1("Calculating " << expected_num_selene_branch_blinds << " Selene branch blinds");
     std::vector<fcmp_pp::SeleneBranchBlind> selene_branch_blinds;
     for (size_t i = 0; i < expected_num_selene_branch_blinds; ++i)
-        selene_branch_blinds.emplace_back(fcmp_pp::SeleneBranchBlindGen());
+        selene_branch_blinds.emplace_back(fcmp_pp::gen_selene_branch_blind());
 
     const size_t expected_num_helios_branch_blinds = tree_depth / 2;
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");
     std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds;
     for (size_t i = 0; i < expected_num_helios_branch_blinds; ++i)
-        helios_branch_blinds.emplace_back(fcmp_pp::HeliosBranchBlindGen());
+        helios_branch_blinds.emplace_back(fcmp_pp::gen_helios_branch_blind());
 
     // For every supported input size...
     for (size_t num_inputs = 1; num_inputs <= MAX_NUM_INPUTS; ++num_inputs)
@@ -789,10 +789,10 @@ TEST(fcmp_pp, membership_completeness)
             const auto blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(i_blind_blind);
             const auto blinded_c_blind = fcmp_pp::blind_c_blind(c_blind);
 
-            const auto output_blinds = fcmp_pp::output_blinds_new(blinded_o_blind,
-                blinded_i_blind,
-                blinded_i_blind_blind,
-                blinded_c_blind);
+            const auto output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
+                (uint8_t*)blinded_i_blind.get(),
+                (uint8_t*)blinded_i_blind_blind.get(),
+                (uint8_t*)blinded_c_blind.get());
             
             // make provable FCMP input
             fcmp_provable_inputs.push_back(fcmp_pp::fcmp_prove_input_new(rerandomized_output,
@@ -805,10 +805,6 @@ TEST(fcmp_pp, membership_completeness)
             fcmp_raw_inputs.push_back(rerandomized_output.input);
 
             // Dealloc
-            free(blinded_o_blind);
-            free(blinded_i_blind);
-            free(blinded_i_blind_blind);
-            free(blinded_c_blind);
             free(output_blinds);
         }
 

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -497,7 +497,7 @@ TEST(fcmp_pp, verify)
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");
     std::vector<fcmp_pp::ffi::HeliosBranchBlind> helios_branch_blinds;
     for (size_t i = 0; i < expected_num_helios_branch_blinds; ++i)
-        helios_branch_blinds.emplace_back(fcmp_pp::ffi::HeliosBranchBlind());
+        helios_branch_blinds.emplace_back(fcmp_pp::ffi::HeliosBranchBlindNew());
 
     // Create proofs with random leaf idxs for txs with [1..FCMP_PLUS_PLUS_MAX_INPUTS] inputs
     for (std::size_t n_inputs = 1; n_inputs <= FCMP_PLUS_PLUS_MAX_INPUTS; ++n_inputs)
@@ -576,7 +576,7 @@ TEST(fcmp_pp, verify)
 
             std::vector<const uint8_t*> helios_blinds;
             for (const auto &hbb : helios_branch_blinds)
-                helios_blinds.push_back(hbb.get());
+                helios_blinds.push_back((uint8_t*)hbb.get());
 
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -350,7 +350,7 @@ TEST(fcmp_pp, prove)
     {
         std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
         std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
-        std::vector<uint8_t *> fcmp_prove_inputs;
+        std::vector<fcmp_pp::FcmpProveInput> fcmp_prove_inputs;
         std::vector<crypto::key_image> key_images;
         std::vector<crypto::ec_point> pseudo_outs;
 
@@ -439,7 +439,7 @@ TEST(fcmp_pp, prove)
                 rerandomized_output);
 
             // Collect input for membership proof
-            const auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
+            auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
@@ -518,7 +518,7 @@ TEST(fcmp_pp, verify)
     {
         std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
         std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
-        std::vector<uint8_t *> fcmp_prove_inputs;
+        std::vector<fcmp_pp::FcmpProveInput> fcmp_prove_inputs;
         std::vector<crypto::key_image> key_images;
         std::vector<crypto::ec_point> pseudo_outs;
 
@@ -593,7 +593,7 @@ TEST(fcmp_pp, verify)
                 rerandomized_output);
 
             // Collect input for membership proof
-            const auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
+            auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
@@ -720,7 +720,7 @@ TEST(fcmp_pp, membership_completeness)
         std::set<size_t> selected_indices;
         std::vector<FcmpInputCompressed> fcmp_raw_inputs;
         fcmp_raw_inputs.reserve(num_inputs);
-        std::vector<uint8_t*> fcmp_provable_inputs;
+        std::vector<fcmp_pp::FcmpProveInput> fcmp_provable_inputs;
         fcmp_provable_inputs.reserve(num_inputs);
         while (selected_indices.size() < num_inputs)
         {
@@ -843,10 +843,6 @@ TEST(fcmp_pp, membership_completeness)
         // Verify
         LOG_PRINT_L1("Verifying " << num_inputs << "-in " << n_layers << "-layer FCMP");
         EXPECT_TRUE(fcmp_pp::verify_membership(proof, n_layers, global_tree.get_tree_root(), fcmp_raw_inputs));
-
-        // Dealloc
-        for (uint8_t *input : fcmp_provable_inputs)
-            free(input);
     }
 }
 //----------------------------------------------------------------------------------------------------------------------

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -350,7 +350,7 @@ TEST(fcmp_pp, prove)
     {
         std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
         std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
-        std::vector<fcmp_pp::FcmpPpProveInput> fcmp_pp_prove_inputs;
+        std::vector<fcmp_pp::FcmpPpProveMembershipInput> fcmp_pp_prove_inputs;
         std::vector<crypto::key_image> key_images;
         std::vector<crypto::ec_point> pseudo_outs;
 
@@ -518,7 +518,7 @@ TEST(fcmp_pp, verify)
     {
         std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
         std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
-        std::vector<fcmp_pp::FcmpPpProveInput> fcmp_pp_prove_inputs;
+        std::vector<fcmp_pp::FcmpPpProveMembershipInput> fcmp_pp_prove_inputs;
         std::vector<crypto::key_image> key_images;
         std::vector<crypto::ec_point> pseudo_outs;
 
@@ -720,7 +720,7 @@ TEST(fcmp_pp, membership_completeness)
         std::set<size_t> selected_indices;
         std::vector<FcmpInputCompressed> fcmp_raw_inputs;
         fcmp_raw_inputs.reserve(num_inputs);
-        std::vector<fcmp_pp::FcmpPpProveInput> fcmp_provable_inputs;
+        std::vector<fcmp_pp::FcmpPpProveMembershipInput> fcmp_provable_inputs;
         fcmp_provable_inputs.reserve(num_inputs);
         while (selected_indices.size() < num_inputs)
         {

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -439,7 +439,7 @@ TEST(fcmp_pp, prove)
                 rerandomized_output);
 
             // Collect input for membership proof
-            const auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(rerandomized_output,
+            const auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
@@ -593,7 +593,7 @@ TEST(fcmp_pp, verify)
                 rerandomized_output);
 
             // Collect input for membership proof
-            const auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(rerandomized_output,
+            const auto fcmp_prove_input = fcmp_pp::fcmp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
@@ -823,7 +823,7 @@ TEST(fcmp_pp, membership_completeness)
                 blinded_c_blind);
             
             // make provable FCMP input
-            fcmp_provable_inputs.push_back(fcmp_pp::fcmp_prove_input_new(rerandomized_output,
+            fcmp_provable_inputs.push_back(fcmp_pp::fcmp_prove_input_new(
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -339,7 +339,7 @@ TEST(fcmp_pp, prove)
 
     // Keep them cached across runs
     std::vector<const uint8_t *> selene_branch_blinds;
-    std::vector<const uint8_t *> helios_branch_blinds;
+    std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds;
 
     CHECK_AND_ASSERT_THROW_MES(global_tree.get_n_leaf_tuples() >= FCMP_PLUS_PLUS_MAX_INPUTS, "too few leaves");
 
@@ -425,7 +425,7 @@ TEST(fcmp_pp, prove)
 
             if (helios_branch_blinds.empty())
                 for (std::size_t i = 0; i < selene_scalar_chunks.size(); ++i)
-                    helios_branch_blinds.emplace_back(fcmp_pp::helios_branch_blind());
+                    helios_branch_blinds.emplace_back(fcmp_pp::HeliosBranchBlindGen());
 
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,
@@ -574,17 +574,13 @@ TEST(fcmp_pp, verify)
                 for (std::size_t i = 0; i < helios_scalar_chunks.size(); ++i)
                     selene_branch_blinds.emplace_back(fcmp_pp::selene_branch_blind());
 
-            std::vector<const uint8_t*> helios_blinds;
-            for (const auto &hbb : helios_branch_blinds)
-                helios_blinds.push_back((uint8_t*)hbb.get());
-
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,
                 rerandomized_output,
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
-                helios_blinds);
+                helios_branch_blinds);
 
             fcmp_prove_inputs.emplace_back(std::move(fcmp_prove_input));
         }
@@ -687,9 +683,9 @@ TEST(fcmp_pp, membership_completeness)
 
     const size_t expected_num_helios_branch_blinds = tree_depth / 2;
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");
-    std::vector<const uint8_t *> helios_branch_blinds;
+    std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds;
     for (size_t i = 0; i < expected_num_helios_branch_blinds; ++i)
-        helios_branch_blinds.emplace_back(fcmp_pp::helios_branch_blind());
+        helios_branch_blinds.emplace_back(fcmp_pp::HeliosBranchBlindGen());
 
     // For every supported input size...
     for (size_t num_inputs = 1; num_inputs <= MAX_NUM_INPUTS; ++num_inputs)

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -33,6 +33,7 @@
 #include "common/threadpool.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "curve_trees.h"
+#include "fcmp_pp/ffi_types.h"
 #include "fcmp_pp/proof_len.h"
 #include "fcmp_pp/prove.h"
 #include "fcmp_pp/tower_cycle.h"
@@ -494,9 +495,9 @@ TEST(fcmp_pp, verify)
 
     const size_t expected_num_helios_branch_blinds = (n_layers - 1) / 2;
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");
-    std::vector<const uint8_t *> helios_branch_blinds;
+    std::vector<fcmp_pp::ffi::HeliosBranchBlind> helios_branch_blinds;
     for (size_t i = 0; i < expected_num_helios_branch_blinds; ++i)
-        helios_branch_blinds.emplace_back(fcmp_pp::helios_branch_blind());
+        helios_branch_blinds.emplace_back(fcmp_pp::ffi::HeliosBranchBlind());
 
     // Create proofs with random leaf idxs for txs with [1..FCMP_PLUS_PLUS_MAX_INPUTS] inputs
     for (std::size_t n_inputs = 1; n_inputs <= FCMP_PLUS_PLUS_MAX_INPUTS; ++n_inputs)
@@ -573,9 +574,9 @@ TEST(fcmp_pp, verify)
                 for (std::size_t i = 0; i < helios_scalar_chunks.size(); ++i)
                     selene_branch_blinds.emplace_back(fcmp_pp::selene_branch_blind());
 
-            if (helios_branch_blinds.empty())
-                for (std::size_t i = 0; i < selene_scalar_chunks.size(); ++i)
-                    helios_branch_blinds.emplace_back(fcmp_pp::helios_branch_blind());
+            std::vector<const uint8_t*> helios_blinds;
+            for (const auto &hbb : helios_branch_blinds)
+                helios_blinds.push_back(hbb.get());
 
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,
@@ -583,7 +584,7 @@ TEST(fcmp_pp, verify)
                 path_rust,
                 output_blinds,
                 selene_branch_blinds,
-                helios_branch_blinds);
+                helios_blinds);
 
             fcmp_prove_inputs.emplace_back(std::move(fcmp_prove_input));
         }

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -483,8 +483,8 @@ TEST(fcmp_pp, verify)
     ASSERT_TRUE(curve_trees->audit_path(path, new_outputs.outputs.front().output_pair, expected_n_leaves));
 
     const auto tree_root = n_layers % 2 == 0
-        ? fcmp_pp::tower_cycle::helios_tree_root(path.c2_layers.back().back())
-        : fcmp_pp::tower_cycle::selene_tree_root(path.c1_layers.back().back());
+        ? fcmp_pp::helios_tree_root(path.c2_layers.back().back())
+        : fcmp_pp::selene_tree_root(path.c1_layers.back().back());
 
     // Make branch blinds once purely for performance reasons (DO NOT DO THIS IN PRODUCTION)
     const size_t expected_num_selene_branch_blinds = n_layers / 2;

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -33,7 +33,7 @@
 #include "common/threadpool.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "curve_trees.h"
-#include "fcmp_pp/ffi_types.h"
+#include "fcmp_pp/fcmp_pp_types.h"
 #include "fcmp_pp/proof_len.h"
 #include "fcmp_pp/prove.h"
 #include "fcmp_pp/tower_cycle.h"
@@ -495,9 +495,9 @@ TEST(fcmp_pp, verify)
 
     const size_t expected_num_helios_branch_blinds = (n_layers - 1) / 2;
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");
-    std::vector<fcmp_pp::ffi::HeliosBranchBlind> helios_branch_blinds;
+    std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds;
     for (size_t i = 0; i < expected_num_helios_branch_blinds; ++i)
-        helios_branch_blinds.emplace_back(fcmp_pp::ffi::HeliosBranchBlindNew());
+        helios_branch_blinds.emplace_back(fcmp_pp::HeliosBranchBlindGen());
 
     // Create proofs with random leaf idxs for txs with [1..FCMP_PLUS_PLUS_MAX_INPUTS] inputs
     for (std::size_t n_inputs = 1; n_inputs <= FCMP_PLUS_PLUS_MAX_INPUTS; ++n_inputs)

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -413,10 +413,10 @@ TEST(fcmp_pp, prove)
             const auto blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(i_blind_blind);
             const auto blinded_c_blind = fcmp_pp::blind_c_blind(c_blind);
 
-            const auto output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
-                (uint8_t*)blinded_i_blind.get(),
-                (uint8_t*)blinded_i_blind_blind.get(),
-                (uint8_t*)blinded_c_blind.get());
+            const auto output_blinds = fcmp_pp::output_blinds_new(blinded_o_blind,
+                blinded_i_blind,
+                blinded_i_blind_blind,
+                blinded_c_blind);
 
             // Cache branch blinds
             if (selene_branch_blinds.empty())
@@ -564,10 +564,10 @@ TEST(fcmp_pp, verify)
             const auto blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(i_blind_blind);
             const auto blinded_c_blind = fcmp_pp::blind_c_blind(c_blind);
 
-            const auto output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
-                (uint8_t*)blinded_i_blind.get(),
-                (uint8_t*)blinded_i_blind_blind.get(),
-                (uint8_t*)blinded_c_blind.get());
+            const auto output_blinds = fcmp_pp::output_blinds_new(blinded_o_blind,
+                blinded_i_blind,
+                blinded_i_blind_blind,
+                blinded_c_blind);
 
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,
@@ -789,10 +789,10 @@ TEST(fcmp_pp, membership_completeness)
             const auto blinded_i_blind_blind = fcmp_pp::blind_i_blind_blind(i_blind_blind);
             const auto blinded_c_blind = fcmp_pp::blind_c_blind(c_blind);
 
-            const auto output_blinds = fcmp_pp::output_blinds_new((uint8_t*)blinded_o_blind.get(),
-                (uint8_t*)blinded_i_blind.get(),
-                (uint8_t*)blinded_i_blind_blind.get(),
-                (uint8_t*)blinded_c_blind.get());
+            const auto output_blinds = fcmp_pp::output_blinds_new(blinded_o_blind,
+                blinded_i_blind,
+                blinded_i_blind_blind,
+                blinded_c_blind);
             
             // make provable FCMP input
             fcmp_provable_inputs.push_back(fcmp_pp::fcmp_prove_input_new(rerandomized_output,
@@ -803,9 +803,6 @@ TEST(fcmp_pp, membership_completeness)
 
             // get FCMP input
             fcmp_raw_inputs.push_back(rerandomized_output.input);
-
-            // Dealloc
-            free(output_blinds);
         }
 
         ASSERT_EQ(fcmp_raw_inputs.size(), fcmp_provable_inputs.size());

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -338,7 +338,7 @@ TEST(fcmp_pp, prove)
     const auto tree_root = global_tree.get_tree_root();
 
     // Keep them cached across runs
-    std::vector<const uint8_t *> selene_branch_blinds;
+    std::vector<fcmp_pp::SeleneBranchBlind> selene_branch_blinds;
     std::vector<fcmp_pp::HeliosBranchBlind> helios_branch_blinds;
 
     CHECK_AND_ASSERT_THROW_MES(global_tree.get_n_leaf_tuples() >= FCMP_PLUS_PLUS_MAX_INPUTS, "too few leaves");
@@ -421,7 +421,7 @@ TEST(fcmp_pp, prove)
             // Cache branch blinds
             if (selene_branch_blinds.empty())
                 for (std::size_t i = 0; i < helios_scalar_chunks.size(); ++i)
-                    selene_branch_blinds.emplace_back(fcmp_pp::selene_branch_blind());
+                    selene_branch_blinds.emplace_back(fcmp_pp::SeleneBranchBlindGen());
 
             if (helios_branch_blinds.empty())
                 for (std::size_t i = 0; i < selene_scalar_chunks.size(); ++i)
@@ -489,9 +489,9 @@ TEST(fcmp_pp, verify)
     // Make branch blinds once purely for performance reasons (DO NOT DO THIS IN PRODUCTION)
     const size_t expected_num_selene_branch_blinds = n_layers / 2;
     LOG_PRINT_L1("Calculating " << expected_num_selene_branch_blinds << " Selene branch blinds");
-    std::vector<const uint8_t *> selene_branch_blinds;
+    std::vector<fcmp_pp::SeleneBranchBlind> selene_branch_blinds;
     for (size_t i = 0; i < expected_num_selene_branch_blinds; ++i)
-        selene_branch_blinds.emplace_back(fcmp_pp::selene_branch_blind());
+        selene_branch_blinds.emplace_back(fcmp_pp::SeleneBranchBlindGen());
 
     const size_t expected_num_helios_branch_blinds = (n_layers - 1) / 2;
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");
@@ -568,11 +568,6 @@ TEST(fcmp_pp, verify)
                 blinded_i_blind,
                 blinded_i_blind_blind,
                 blinded_c_blind);
-
-            // Cache branch blinds
-            if (selene_branch_blinds.empty())
-                for (std::size_t i = 0; i < helios_scalar_chunks.size(); ++i)
-                    selene_branch_blinds.emplace_back(fcmp_pp::selene_branch_blind());
 
             auto fcmp_prove_input = fcmp_pp::fcmp_pp_prove_input_new(x,
                 y,
@@ -677,9 +672,9 @@ TEST(fcmp_pp, membership_completeness)
     // Make branch blinds once purely for performance reasons (DO NOT DO THIS IN PRODUCTION)
     const size_t expected_num_selene_branch_blinds = (tree_depth + 1) / 2;
     LOG_PRINT_L1("Calculating " << expected_num_selene_branch_blinds << " Selene branch blinds");
-    std::vector<const uint8_t *> selene_branch_blinds;
+    std::vector<fcmp_pp::SeleneBranchBlind> selene_branch_blinds;
     for (size_t i = 0; i < expected_num_selene_branch_blinds; ++i)
-        selene_branch_blinds.emplace_back(fcmp_pp::selene_branch_blind());
+        selene_branch_blinds.emplace_back(fcmp_pp::SeleneBranchBlindGen());
 
     const size_t expected_num_helios_branch_blinds = tree_depth / 2;
     LOG_PRINT_L1("Calculating " << expected_num_helios_branch_blinds << " Helios branch blinds");

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -768,7 +768,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
 
     // 11.
     LOG_PRINT_L2("'Perhaps this is valid money that belongs to another chain', Bob postulates");
-    const uint8_t *tree_root = bc.get_fcmp_tree_root_at(bc.height() - 1);
+    const auto tree_root = bc.get_fcmp_tree_root_at(bc.height() - 1);
     ASSERT_TRUE(cryptonote::Blockchain::expand_transaction_2(alicebob_tx,
         cryptonote::get_transaction_prefix_hash(alicebob_tx),
         /*pubkeys=*/{},


### PR DESCRIPTION
From Rust docs [`into_raw`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.into_raw):

> After calling this function, the caller is responsible for the memory previously managed by the Box. In particular, the caller should properly destroy T and release the memory, taking into account the [memory layout](https://doc.rust-lang.org/std/boxed/index.html#memory-layout) used by Box. The easiest way to do this is to convert the raw pointer back into a Box with the [Box::from_raw](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.from_raw) function, allowing the Box destructor to perform the cleanup.

As such, I don't believe calling `free()` on the C side is guaranteed to properly release the memory previously managed by the Box. So this PR's solution is to free the raw pointer by sending the pointer back over the FFI and destroying via Rust's [`from_raw`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.from_raw).

This PR also brings stronger type protection on the C++ side, since it wouldn't just be `const uint8_t *` for tons of different types.

Would be good to get the crustaceans to take a look at this too probably.