### PR TITLE
fcmp++: don't prefer powers of 2 inputs

### DIFF
--- a/src/carrot_impl/input_selection.cpp
+++ b/src/carrot_impl/input_selection.cpp
@@ -316,7 +316,6 @@ std::vector<std::set<std::size_t>> form_preferred_input_candidate_subsets(
 std::vector<std::size_t> get_input_counts_in_preferred_order()
 {
     // 1 or 2 randomly, then
-    // other ascending powers of 2, then
     // other ascending positive numbers
 
     //! @TODO: MRL discussion about 2 vs 1 default input count when 1 input can pay. If we default
@@ -331,10 +330,16 @@ std::vector<std::size_t> get_input_counts_in_preferred_order()
         "refactor this function for different input count limits");
 
     const bool random_bit = 0 == (crypto::rand<uint8_t>() & 0x01);
-    if (random_bit)
-        return {2, 1, 4, 8, 3, 5, 6, 7};
-    else
-        return {1, 2, 4, 8, 3, 5, 6, 7};
+    std::vector<std::size_t> res = random_bit ? std::vector<std::size_t>{2, 1} : std::vector<std::size_t>{1, 2};
+
+    res.reserve(CARROT_MAX_TX_INPUTS);
+    for (std::size_t input_count = 3; input_count <= CARROT_MAX_TX_INPUTS; ++input_count)
+        res.emplace_back(input_count);
+
+    CHECK_AND_ASSERT_THROW_MES(res.size() == CARROT_MAX_TX_INPUTS,
+        "get_input_counts_in_preferred_order: incorrect res size");
+
+    return res;
 }
 //-------------------------------------------------------------------------------------------------------------------
 select_inputs_func_t make_single_transfer_input_selector(


### PR DESCRIPTION
Since it takes more time to verify [as n inputs increase](https://github.com/seraphis-migration/monero/pull/26#discussion_r2057203539) (e.g. 5-input takes 142ms and 8-input takes 181ms for a 7-layer tree), I figure it actually does make sense to use as few inputs as possible.

There is perhaps an argument to be made that since the gap between 3 and 4 is so small (and 6 and 8), that it would make sense to still try to prefer the higher power of 2, since it would be more expensive on the chain to spend those outputs in a 1-input or 2-input tx in the future. I would be open to that argument too, but it seems like added complexity for not too significant a benefit to me.

I think the "1 or 2 randomly" rule is ok