### PR TITLE
fcmp++: remove input copy and result allocate for to_bytes API functions

### DIFF
--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -153,13 +153,13 @@ struct HeliosPoint helios_hash_init_point(void);
 
 struct SelenePoint selene_hash_init_point(void);
 
-uint8_t *helios_scalar_to_bytes(struct HeliosScalar helios_scalar);
+void helios_scalar_to_bytes(const struct HeliosScalar *helios_scalar, uint8_t bytes_out[32]);
 
-uint8_t *selene_scalar_to_bytes(struct SeleneScalar selene_scalar);
+void selene_scalar_to_bytes(const struct SeleneScalar *selene_scalar, uint8_t bytes_out[32]);
 
-uint8_t *helios_point_to_bytes(struct HeliosPoint helios_point);
+void helios_point_to_bytes(const struct HeliosPoint *helios_point, uint8_t bytes_out[32]);
 
-uint8_t *selene_point_to_bytes(struct SelenePoint selene_point);
+void selene_point_to_bytes(const struct SelenePoint *selene_point, uint8_t bytes_out[32]);
 
 struct HeliosPoint helios_point_from_bytes(const uint8_t *helios_point_bytes);
 

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -58,23 +58,27 @@ fn c_u8_32(bytes: [u8; 32]) -> *const u8 {
 }
 
 #[no_mangle]
-pub extern "C" fn helios_scalar_to_bytes(helios_scalar: HeliosScalar) -> *const u8 {
-    c_u8_32(helios_scalar.to_repr())
+pub unsafe extern "C" fn helios_scalar_to_bytes(helios_scalar: *const HeliosScalar, bytes_out: *mut u8) {
+    let bytes_out = core::slice::from_raw_parts_mut(bytes_out, 32);
+    bytes_out.clone_from_slice(&(&*helios_scalar).to_repr());
 }
 
 #[no_mangle]
-pub extern "C" fn selene_scalar_to_bytes(selene_scalar: SeleneScalar) -> *const u8 {
-    c_u8_32(selene_scalar.to_repr())
+pub unsafe extern "C" fn selene_scalar_to_bytes(selene_scalar: *const SeleneScalar, bytes_out: *mut u8) {
+    let bytes_out = core::slice::from_raw_parts_mut(bytes_out, 32);
+    bytes_out.clone_from_slice(&(&*selene_scalar).to_repr());
 }
 
 #[no_mangle]
-pub extern "C" fn helios_point_to_bytes(helios_point: HeliosPoint) -> *const u8 {
-    c_u8_32(helios_point.to_bytes())
+pub unsafe extern "C" fn helios_point_to_bytes(helios_point: *const HeliosPoint, bytes_out: *mut u8) {
+    let bytes_out = core::slice::from_raw_parts_mut(bytes_out, 32);
+    bytes_out.clone_from_slice(&(&*helios_point).to_bytes());
 }
 
 #[no_mangle]
-pub extern "C" fn selene_point_to_bytes(selene_point: SelenePoint) -> *const u8 {
-    c_u8_32(selene_point.to_bytes())
+pub unsafe extern "C" fn selene_point_to_bytes(selene_point: *const SelenePoint, bytes_out: *mut u8) {
+    let bytes_out = core::slice::from_raw_parts_mut(bytes_out, 32);
+    bytes_out.clone_from_slice(&(&*selene_point).to_bytes());
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]

--- a/src/fcmp_pp/tower_cycle.cpp
+++ b/src/fcmp_pp/tower_cycle.cpp
@@ -115,37 +115,29 @@ Helios::Scalar Helios::zero_scalar() const
 //----------------------------------------------------------------------------------------------------------------------
 crypto::ec_scalar Selene::to_bytes(const Selene::Scalar &scalar) const
 {
-    auto bytes = ::selene_scalar_to_bytes(scalar);
     crypto::ec_scalar res;
-    memcpy(&res, bytes, 32);
-    free(bytes);
+    ::selene_scalar_to_bytes(&scalar, ::to_bytes(res));
     return res;
 }
 //----------------------------------------------------------------------------------------------------------------------
 crypto::ec_scalar Helios::to_bytes(const Helios::Scalar &scalar) const
 {
-    auto bytes = ::helios_scalar_to_bytes(scalar);
     crypto::ec_scalar res;
-    memcpy(&res, bytes, 32);
-    free(bytes);
+    ::helios_scalar_to_bytes(&scalar, ::to_bytes(res));
     return res;
 }
 //----------------------------------------------------------------------------------------------------------------------
 crypto::ec_point Selene::to_bytes(const Selene::Point &point) const
 {
-    auto bytes = ::selene_point_to_bytes(point);
     crypto::ec_point res;
-    memcpy(&res, bytes, 32);
-    free(bytes);
+    ::selene_point_to_bytes(&point, ::to_bytes(res));
     return res;
 }
 //----------------------------------------------------------------------------------------------------------------------
 crypto::ec_point Helios::to_bytes(const Helios::Point &point) const
 {
-    auto bytes = ::helios_point_to_bytes(point);
     crypto::ec_point res;
-    memcpy(&res, bytes, 32);
-    free(bytes);
+    ::helios_point_to_bytes(&point, ::to_bytes(res));
     return res;
 }
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Prevents copying of semi-heavy uncompressed point/scalar structs, and prevents heap allocation of a fixed 32 byte array. Also has better type safety since output buffer size has C type info (`bytes_out [32]`). 