### PR TITLE
fcmp++: scan_tx & RPC for path by global output id

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -115,22 +115,12 @@ public: \
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, val_name) \
   epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(this_ref.varialble, stg, hparent_section, val_name);
 
-#define KV_SERIALIZE_CONTAINER_POD_AS_BLOB_OPT_N(variable, val_name, default_value) \
-  do { \
-    if (is_store && variable.empty() && default_value.empty()) \
-      break; \
-    bool ret = KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(variable, val_name) \
-    if (!ret) \
-      epee::serialize_default(this_ref.variable, default_value); \
-  } while(0);
-
 #define END_KV_SERIALIZE_MAP() return true;}
 
 #define KV_SERIALIZE(varialble)                           KV_SERIALIZE_N(varialble, #varialble)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB(varialble)           KV_SERIALIZE_VAL_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(varialble, def)  KV_SERIALIZE_VAL_POD_AS_BLOB_OPT_N(varialble, #varialble, def)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(varialble)     KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, #varialble) //skip is_trivially_copyable and is_standard_layout compile time check
-#define KV_SERIALIZE_CONTAINER_POD_AS_BLOB_OPT(varialble, def) KV_SERIALIZE_CONTAINER_POD_AS_BLOB_OPT_N(varialble, #varialble, def)
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value)
 

--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -115,12 +115,22 @@ public: \
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, val_name) \
   epee::serialization::selector<is_store>::serialize_stl_container_pod_val_as_blob(this_ref.varialble, stg, hparent_section, val_name);
 
+#define KV_SERIALIZE_CONTAINER_POD_AS_BLOB_OPT_N(variable, val_name, default_value) \
+  do { \
+    if (is_store && variable.empty() && default_value.empty()) \
+      break; \
+    bool ret = KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(variable, val_name) \
+    if (!ret) \
+      epee::serialize_default(this_ref.variable, default_value); \
+  } while(0);
+
 #define END_KV_SERIALIZE_MAP() return true;}
 
 #define KV_SERIALIZE(varialble)                           KV_SERIALIZE_N(varialble, #varialble)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB(varialble)           KV_SERIALIZE_VAL_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(varialble, def)  KV_SERIALIZE_VAL_POD_AS_BLOB_OPT_N(varialble, #varialble, def)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(varialble)     KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, #varialble) //skip is_trivially_copyable and is_standard_layout compile time check
+#define KV_SERIALIZE_CONTAINER_POD_AS_BLOB_OPT(varialble, def) KV_SERIALIZE_CONTAINER_POD_AS_BLOB_OPT_N(varialble, #varialble, def)
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
 #define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value)
 

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -43,7 +43,6 @@
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_protocol/enums.h"
 #include "fcmp_pp/curve_trees.h"
-#include "rpc/core_rpc_server_commands_defs.h"
 
 /** \file
  * Cryptonote Blockchain Database Interface

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1884,7 +1884,7 @@ public:
 
   // TODO: description
   virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
-    const crypto::hash &as_of_top_block_hash,
+    const uint64_t as_of_n_blocks,
     std::vector<uint64_t> &leaf_idxs_out,
     std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const = 0;
 

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1883,7 +1883,10 @@ public:
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const = 0;
 
   // TODO: description
-  virtual std::vector<fcmp_pp::curve_trees::PathBytes> get_path_by_amount_output_id(const std::vector<get_outputs_out> &amount_output_ids) const = 0;
+  virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
+    const uint64_t as_of_n_blocks,
+    std::vector<uint64_t> &leaf_idxs_out,
+    std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const = 0;
 
   //
   // Hard fork related storage

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -43,6 +43,7 @@
 #include "cryptonote_basic/hardfork.h"
 #include "cryptonote_protocol/enums.h"
 #include "fcmp_pp/curve_trees.h"
+#include "rpc/core_rpc_server_commands_defs.h"
 
 /** \file
  * Cryptonote Blockchain Database Interface
@@ -1880,6 +1881,9 @@ public:
    * @return custom timelocked outputs grouped by last locked block
    */
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const = 0;
+
+  // TODO: description
+  virtual std::vector<fcmp_pp::curve_trees::PathBytes> get_path_by_amount_output_id(const std::vector<get_outputs_out> &amount_output_ids) const = 0;
 
   //
   // Hard fork related storage

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1884,7 +1884,7 @@ public:
 
   // TODO: description
   virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
-    const uint64_t as_of_n_blocks,
+    const crypto::hash &as_of_top_block_hash,
     std::vector<uint64_t> &leaf_idxs_out,
     std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const = 0;
 

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1831,7 +1831,7 @@ fcmp_pp::curve_trees::PathBytes BlockchainLMDB::get_path(const fcmp_pp::curve_tr
 }
 
 uint64_t BlockchainLMDB::get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
-  const uint64_t as_of_n_blocks,
+  const crypto::hash &as_of_top_block_hash,
   std::vector<uint64_t> &leaf_idxs_out,
   std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const
 {
@@ -1851,10 +1851,11 @@ uint64_t BlockchainLMDB::get_path_by_global_output_id(const std::vector<uint64_t
   const uint64_t cur_n_blocks = this->height();
   if (cur_n_blocks == 0)
     return 0;
-  CHECK_AND_ASSERT_THROW_MES(cur_n_blocks >= as_of_n_blocks, "get_path_by_global_output_id: as_of_n_blocks higher than n blocks in chain");
 
   // We're getting path data assuming chain tip is as_of_block_idx
-  const uint64_t as_of_block_idx = as_of_n_blocks ? (as_of_n_blocks - 1) : (cur_n_blocks - 1);
+  const uint64_t as_of_block_idx = (as_of_top_block_hash != crypto::null_hash)
+    ? this->get_block_height(as_of_top_block_hash)
+    : (cur_n_blocks - 1);
 
   // TODO: de-duplicate db reads where possible (steps 1, 2, 3, 5, 6 can all be de-dup'd especially 6)
   // TODO: return consolidated path

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1851,10 +1851,11 @@ uint64_t BlockchainLMDB::get_path_by_global_output_id(const std::vector<uint64_t
   const uint64_t cur_n_blocks = this->height();
   if (cur_n_blocks == 0)
     return 0;
-  CHECK_AND_ASSERT_THROW_MES(cur_n_blocks >= as_of_n_blocks, "get_path_by_global_output_id: as_of_n_blocks higher than n blocks in chain");
 
   // We're getting path data assuming chain tip is as_of_block_idx
   const uint64_t as_of_block_idx = as_of_n_blocks ? (as_of_n_blocks - 1) : (cur_n_blocks - 1);
+
+  CHECK_AND_ASSERT_THROW_MES(as_of_block_idx <= this->get_tree_block_idx(), "get_path_by_global_output_id: as_of_block_idx is higher than highest tree block idx");
 
   // TODO: de-duplicate db reads where possible (steps 1, 2, 3, 5, 6 can all be de-dup'd especially 6)
   // TODO: return consolidated path

--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1831,7 +1831,7 @@ fcmp_pp::curve_trees::PathBytes BlockchainLMDB::get_path(const fcmp_pp::curve_tr
 }
 
 uint64_t BlockchainLMDB::get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
-  const crypto::hash &as_of_top_block_hash,
+  const uint64_t as_of_n_blocks,
   std::vector<uint64_t> &leaf_idxs_out,
   std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const
 {
@@ -1851,11 +1851,10 @@ uint64_t BlockchainLMDB::get_path_by_global_output_id(const std::vector<uint64_t
   const uint64_t cur_n_blocks = this->height();
   if (cur_n_blocks == 0)
     return 0;
+  CHECK_AND_ASSERT_THROW_MES(cur_n_blocks >= as_of_n_blocks, "get_path_by_global_output_id: as_of_n_blocks higher than n blocks in chain");
 
   // We're getting path data assuming chain tip is as_of_block_idx
-  const uint64_t as_of_block_idx = (as_of_top_block_hash != crypto::null_hash)
-    ? this->get_block_height(as_of_top_block_hash)
-    : (cur_n_blocks - 1);
+  const uint64_t as_of_block_idx = as_of_n_blocks ? (as_of_n_blocks - 1) : (cur_n_blocks - 1);
 
   // TODO: de-duplicate db reads where possible (steps 1, 2, 3, 5, 6 can all be de-dup'd especially 6)
   // TODO: return consolidated path

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -32,7 +32,6 @@
 #include "cryptonote_basic/blobdatatype.h" // for type blobdata
 #include "fcmp_pp/curve_trees.h"
 #include "ringct/rctTypes.h"
-#include "rpc/core_rpc_server_commands_defs.h"
 #include <boost/thread/tss.hpp>
 
 #include <lmdb.h>

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -380,7 +380,7 @@ public:
   bool get_output_distribution(uint64_t amount, uint64_t from_height, uint64_t to_height, std::vector<uint64_t> &distribution, uint64_t &base) const;
 
   virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
-    const crypto::hash &as_of_top_block_hash,
+    const uint64_t as_of_n_blocks,
     std::vector<uint64_t> &leaf_idxs_out,
     std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const;
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -32,6 +32,7 @@
 #include "cryptonote_basic/blobdatatype.h" // for type blobdata
 #include "fcmp_pp/curve_trees.h"
 #include "ringct/rctTypes.h"
+#include "rpc/core_rpc_server_commands_defs.h"
 #include <boost/thread/tss.hpp>
 
 #include <lmdb.h>
@@ -378,6 +379,8 @@ public:
 
   bool get_output_distribution(uint64_t amount, uint64_t from_height, uint64_t to_height, std::vector<uint64_t> &distribution, uint64_t &base) const;
 
+  virtual std::vector<fcmp_pp::curve_trees::PathBytes> get_path_by_amount_output_id(const std::vector<get_outputs_out> &amount_output_ids) const;
+
   // helper functions
   static int compare_uint64(const MDB_val *a, const MDB_val *b);
   static int compare_uint8(const MDB_val *a, const MDB_val *b);
@@ -475,6 +478,8 @@ private:
   uint64_t get_tree_block_idx() const;
 
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const;
+
+  uint64_t find_leaf_idx_by_output_id(uint64_t output_id, uint64_t leaf_idx_start, uint64_t leaf_idx_end) const;
 
   // Hard fork
   virtual void set_hard_fork_version(uint64_t height, uint8_t version);

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -380,7 +380,7 @@ public:
   bool get_output_distribution(uint64_t amount, uint64_t from_height, uint64_t to_height, std::vector<uint64_t> &distribution, uint64_t &base) const;
 
   virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
-    const uint64_t as_of_n_blocks,
+    const crypto::hash &as_of_top_block_hash,
     std::vector<uint64_t> &leaf_idxs_out,
     std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const;
 

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -379,7 +379,10 @@ public:
 
   bool get_output_distribution(uint64_t amount, uint64_t from_height, uint64_t to_height, std::vector<uint64_t> &distribution, uint64_t &base) const;
 
-  virtual std::vector<fcmp_pp::curve_trees::PathBytes> get_path_by_amount_output_id(const std::vector<get_outputs_out> &amount_output_ids) const;
+  virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
+    const uint64_t as_of_n_blocks,
+    std::vector<uint64_t> &leaf_idxs_out,
+    std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const;
 
   // helper functions
   static int compare_uint64(const MDB_val *a, const MDB_val *b);

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -128,7 +128,7 @@ public:
   virtual uint64_t get_n_leaf_tuples() const override { return 0; };
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const override { return 0; };
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const override { return {{}}; };
-  virtual std::vector<fcmp_pp::curve_trees::PathBytes> get_path_by_amount_output_id(const std::vector<get_outputs_out> &amount_output_ids) const override { return {}; };
+  virtual uint64_t get_path_by_global_output_id( const std::vector<uint64_t> &global_output_ids, const uint64_t as_of_n_blocks, std::vector<uint64_t> &leaf_idxs_out, std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const override { return 0; };
 
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const override { return true; }
   virtual bool for_blocks_range(const uint64_t&, const uint64_t&, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const override { return true; }

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -128,6 +128,7 @@ public:
   virtual uint64_t get_n_leaf_tuples() const override { return 0; };
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const override { return 0; };
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const override { return {{}}; };
+  virtual std::vector<fcmp_pp::curve_trees::PathBytes> get_path_by_amount_output_id(const std::vector<get_outputs_out> &amount_output_ids) const override { return {}; };
 
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const override { return true; }
   virtual bool for_blocks_range(const uint64_t&, const uint64_t&, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const override { return true; }

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -128,7 +128,7 @@ public:
   virtual uint64_t get_n_leaf_tuples() const override { return 0; };
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const override { return 0; };
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const override { return {{}}; };
-  virtual uint64_t get_path_by_global_output_id( const std::vector<uint64_t> &global_output_ids, const uint64_t as_of_n_blocks, std::vector<uint64_t> &leaf_idxs_out, std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const override { return 0; };
+  virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids, const crypto::hash &as_of_top_block_hash, std::vector<uint64_t> &leaf_idxs_out, std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const override { return 0; };
 
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const override { return true; }
   virtual bool for_blocks_range(const uint64_t&, const uint64_t&, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const override { return true; }

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -128,7 +128,7 @@ public:
   virtual uint64_t get_n_leaf_tuples() const override { return 0; };
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const override { return 0; };
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const override { return {{}}; };
-  virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids, const crypto::hash &as_of_top_block_hash, std::vector<uint64_t> &leaf_idxs_out, std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const override { return 0; };
+  virtual uint64_t get_path_by_global_output_id( const std::vector<uint64_t> &global_output_ids, const uint64_t as_of_n_blocks, std::vector<uint64_t> &leaf_idxs_out, std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const override { return 0; };
 
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const override { return true; }
   virtual bool for_blocks_range(const uint64_t&, const uint64_t&, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const override { return true; }

--- a/src/fcmp_pp/curve_trees.h
+++ b/src/fcmp_pp/curve_trees.h
@@ -182,6 +182,8 @@ struct ChunkBytes final
 {
     std::vector<crypto::ec_point> chunk_bytes;
 
+    bool operator==(const ChunkBytes &other) const { return chunk_bytes == other.chunk_bytes; }
+
     BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(chunk_bytes)
     END_KV_SERIALIZE_MAP()
@@ -191,6 +193,8 @@ struct PathBytes final
 {
     std::vector<OutputContext> leaves;
     std::vector<ChunkBytes> layer_chunks;
+
+    bool operator==(const PathBytes &other) const {return leaves == other.leaves && layer_chunks == other.layer_chunks;}
 
     BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_CONTAINER_POD_AS_BLOB(leaves)
@@ -358,11 +362,15 @@ public:
 
     TreeRootShared get_tree_root_from_bytes(const std::size_t n_layers, const crypto::ec_point &tree_root) const;
 
+    Path path_bytes_to_path(const PathBytes &path_bytes) const;
+
     PathForProof path_for_proof(const Path &path, const OutputTuple &output_tuple) const;
 
     std::vector<crypto::ec_point> calc_hashes_from_path(const Path &path, const bool replace_last_hash = false) const;
 
     Path get_dummy_path(const std::vector<fcmp_pp::curve_trees::OutputContext> &outputs, uint8_t n_layers) const;
+
+    TreeExtension path_to_tree_extension(const PathBytes &path_bytes, const PathIndexes &path_idxs) const;
 private:
     // Multithreaded helper function to convert outputs to leaf tuples and set leaves on tree extension
     void set_valid_leaves(

--- a/src/fcmp_pp/tree_cache.cpp
+++ b/src/fcmp_pp/tree_cache.cpp
@@ -1242,16 +1242,17 @@ void TreeCache<C1, C2>::force_add_output_path(const OutputPair &output,
 {
     MDEBUG("Force adding output " << output.output_pubkey << " , commitment " << output.commitment);
 
-    // This function expects the output to be registered already.
-    CHECK_AND_ASSERT_THROW_MES(m_registered_outputs.find(get_output_ref(output)) != m_registered_outputs.end(),
-        "force_add_output_path: output is not already registered");
-
     // If an empty path is passed in here, this function is not sufficiently capable of handling it. The output must
     // be added to the locked outputs cache in this case, which would require the output's last locked block.
     CHECK_AND_ASSERT_THROW_MES(path_bytes.leaves.size() && path_bytes.layer_chunks.size(),
         "force_add_output_path: unexpected empty path");
 
-    // TODO: if output's path is already known, make sure all elems are equal and return. Don't bump ref count.
+    // This function expects the output to be registered already, but not yet assigned.
+    const auto registered_output_it = m_registered_outputs.find(get_output_ref(output));
+    CHECK_AND_ASSERT_THROW_MES(registered_output_it != m_registered_outputs.end(),
+        "force_add_output_path: output is not already registered");
+    CHECK_AND_ASSERT_THROW_MES(!registered_output_it->second.assigned_leaf_idx,
+        "force_add_output_path: output is already assigned");
 
     // Assign the output's leaf tuple
     assign_new_output(output, leaf_idx, m_registered_outputs);

--- a/src/fcmp_pp/tree_cache.h
+++ b/src/fcmp_pp/tree_cache.h
@@ -191,7 +191,7 @@ public:
             TreeSync<C1, C2>(curve_trees, max_reorg_depth)
     {};
 
-    bool register_output(const OutputPair &output, const uint64_t last_locked_block_idx) override;
+    bool register_output(const OutputPair &output) override;
 
     // TODO: bool cancel_output_registration
 
@@ -206,6 +206,8 @@ public:
 
 // Public functions not part of TreeSync interface
 public:
+    // Note: it's possible that the cache already contains force added paths from force_add_output_path. Calling init
+    // does not get rid of those already added paths.
     void init(const uint64_t start_block_idx,
         const crypto::hash &start_block_hash,
         const uint64_t n_leaf_tuples,
@@ -249,6 +251,12 @@ public:
 
     // Clear all state
     void clear();
+
+    // Force add a path to the cache without re-constructing it via sync
+    void force_add_output_path(const OutputPair &output,
+        const LeafIdx leaf_idx,
+        const PathBytes &path_bytes,
+        const uint64_t n_leaf_tuples);
 
 // Internal helper functions
 private:

--- a/src/fcmp_pp/tree_sync.h
+++ b/src/fcmp_pp/tree_sync.h
@@ -60,11 +60,8 @@ public:
 
     // Registers an output with the TreeSync object so that syncing will keep track of the output's path in the tree
     // - Returns true on successful new insertion
-    // - Returns false:
-    //    - if the output is already registered.
-    //    - if the TreeSync object has already synced the block in which the output unlocks. The scanner would not
-    //      be able to determine the output's position in the tree in this case.
-    virtual bool register_output(const OutputPair &output, const uint64_t last_locked_block_idx) = 0;
+    // - Returns false if the output is already registered.
+    virtual bool register_output(const OutputPair &output) = 0;
 
     // TODO: bool cancel_output_registration
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1146,7 +1146,7 @@ namespace cryptonote
     {
       std::vector<uint64_t> leaf_idxs;
       std::vector<fcmp_pp::curve_trees::PathBytes> paths;
-      res.n_leaf_tuples = m_core.get_blockchain_storage().get_db().get_path_by_global_output_id(req.global_output_ids, req.as_of_n_blocks, leaf_idxs, paths);
+      res.n_leaf_tuples = m_core.get_blockchain_storage().get_db().get_path_by_global_output_id(req.global_output_ids, req.top_block_hash, leaf_idxs, paths);
       res.paths.reserve(leaf_idxs.size());
       for (std::size_t i = 0; i < leaf_idxs.size(); ++i)
         res.paths.emplace_back(COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response::path_entry{ leaf_idxs.at(i), std::move(paths.at(i)) });

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -1146,7 +1146,7 @@ namespace cryptonote
     {
       std::vector<uint64_t> leaf_idxs;
       std::vector<fcmp_pp::curve_trees::PathBytes> paths;
-      res.n_leaf_tuples = m_core.get_blockchain_storage().get_db().get_path_by_global_output_id(req.global_output_ids, req.top_block_hash, leaf_idxs, paths);
+      res.n_leaf_tuples = m_core.get_blockchain_storage().get_db().get_path_by_global_output_id(req.global_output_ids, req.as_of_n_blocks, leaf_idxs, paths);
       res.paths.reserve(leaf_idxs.size());
       for (std::size_t i = 0; i < leaf_idxs.size(); ++i)
         res.paths.emplace_back(COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response::path_entry{ leaf_idxs.at(i), std::move(paths.at(i)) });

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -108,7 +108,7 @@ namespace cryptonote
       MAP_URI_AUTO_BIN2("/gethashes.bin", on_get_hashes, COMMAND_RPC_GET_HASHES_FAST)
       MAP_URI_AUTO_BIN2("/get_o_indexes.bin", on_get_indexes, COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES)      
       MAP_URI_AUTO_BIN2("/get_outs.bin", on_get_outs_bin, COMMAND_RPC_GET_OUTPUTS_BIN)
-      MAP_URI_AUTO_BIN2("/get_path_by_amount_output_id.bin", on_get_path_by_amount_output_id_bin, COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN)
+      MAP_URI_AUTO_BIN2("/get_path_by_global_output_id.bin", on_get_path_by_global_output_id_bin, COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN)
       MAP_URI_AUTO_JON2("/get_transactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/gettransactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/get_alt_blocks_hashes", on_get_alt_blocks_hashes, COMMAND_RPC_GET_ALT_BLOCKS_HASHES)
@@ -206,7 +206,7 @@ namespace cryptonote
     bool on_mining_status(const COMMAND_RPC_MINING_STATUS::request& req, COMMAND_RPC_MINING_STATUS::response& res, const connection_context *ctx = NULL);
     bool on_get_outs_bin(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMAND_RPC_GET_OUTPUTS_BIN::response& res, const connection_context *ctx = NULL);
     bool on_get_outs(const COMMAND_RPC_GET_OUTPUTS::request& req, COMMAND_RPC_GET_OUTPUTS::response& res, const connection_context *ctx = NULL);
-    bool on_get_path_by_amount_output_id_bin(const COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::request& req, COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::response& res, const connection_context *ctx = NULL);
+    bool on_get_path_by_global_output_id_bin(const COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::request& req, COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response& res, const connection_context *ctx = NULL);
     bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, const connection_context *ctx = NULL);
     bool on_get_net_stats(const COMMAND_RPC_GET_NET_STATS::request& req, COMMAND_RPC_GET_NET_STATS::response& res, const connection_context *ctx = NULL);
     bool on_save_bc(const COMMAND_RPC_SAVE_BC::request& req, COMMAND_RPC_SAVE_BC::response& res, const connection_context *ctx = NULL);

--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -108,6 +108,7 @@ namespace cryptonote
       MAP_URI_AUTO_BIN2("/gethashes.bin", on_get_hashes, COMMAND_RPC_GET_HASHES_FAST)
       MAP_URI_AUTO_BIN2("/get_o_indexes.bin", on_get_indexes, COMMAND_RPC_GET_TX_GLOBAL_OUTPUTS_INDEXES)      
       MAP_URI_AUTO_BIN2("/get_outs.bin", on_get_outs_bin, COMMAND_RPC_GET_OUTPUTS_BIN)
+      MAP_URI_AUTO_BIN2("/get_path_by_amount_output_id.bin", on_get_path_by_amount_output_id_bin, COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN)
       MAP_URI_AUTO_JON2("/get_transactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/gettransactions", on_get_transactions, COMMAND_RPC_GET_TRANSACTIONS)
       MAP_URI_AUTO_JON2("/get_alt_blocks_hashes", on_get_alt_blocks_hashes, COMMAND_RPC_GET_ALT_BLOCKS_HASHES)
@@ -205,6 +206,7 @@ namespace cryptonote
     bool on_mining_status(const COMMAND_RPC_MINING_STATUS::request& req, COMMAND_RPC_MINING_STATUS::response& res, const connection_context *ctx = NULL);
     bool on_get_outs_bin(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMAND_RPC_GET_OUTPUTS_BIN::response& res, const connection_context *ctx = NULL);
     bool on_get_outs(const COMMAND_RPC_GET_OUTPUTS::request& req, COMMAND_RPC_GET_OUTPUTS::response& res, const connection_context *ctx = NULL);
+    bool on_get_path_by_amount_output_id_bin(const COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::request& req, COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::response& res, const connection_context *ctx = NULL);
     bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res, const connection_context *ctx = NULL);
     bool on_get_net_stats(const COMMAND_RPC_GET_NET_STATS::request& req, COMMAND_RPC_GET_NET_STATS::response& res, const connection_context *ctx = NULL);
     bool on_save_bc(const COMMAND_RPC_SAVE_BC::request& req, COMMAND_RPC_SAVE_BC::response& res, const connection_context *ctx = NULL);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -684,12 +684,12 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
   {
     struct request_t: public rpc_access_request_base
     {
-      crypto::hash top_block_hash;
+      uint64_t as_of_n_blocks;
       std::vector<uint64_t> global_output_ids;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_request_base)
-        KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(top_block_hash, crypto::null_hash)
+        KV_SERIALIZE_OPT(as_of_n_blocks, (uint64_t)0)
         KV_SERIALIZE(global_output_ids)
       END_KV_SERIALIZE_MAP()
     };

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -684,12 +684,12 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
   {
     struct request_t: public rpc_access_request_base
     {
-      uint64_t as_of_n_blocks;
+      crypto::hash top_block_hash;
       std::vector<uint64_t> global_output_ids;
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_request_base)
-        KV_SERIALIZE_OPT(as_of_n_blocks, (uint64_t)0)
+        KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(top_block_hash, crypto::null_hash)
         KV_SERIALIZE(global_output_ids)
       END_KV_SERIALIZE_MAP()
     };

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -669,6 +669,31 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
     typedef epee::misc_utils::struct_init<response_t> response;
   };
   //-----------------------------------------------
+  struct COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN
+  {
+    struct request_t: public rpc_access_request_base
+    {
+      std::vector<get_outputs_out> outputs;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_request_base)
+        KV_SERIALIZE(outputs)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<request_t> request;
+
+    struct response_t: public rpc_access_response_base
+    {
+      std::vector<fcmp_pp::curve_trees::PathBytes> paths;
+
+      BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_PARENT(rpc_access_response_base)
+        KV_SERIALIZE(paths)
+      END_KV_SERIALIZE_MAP()
+    };
+    typedef epee::misc_utils::struct_init<response_t> response;
+  };
+  //-----------------------------------------------
   struct COMMAND_RPC_SEND_RAW_TX
   {
     struct request_t: public rpc_access_request_base

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -489,13 +489,13 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
           KV_SERIALIZE(confirmations)
           KV_SERIALIZE(block_timestamp)
           KV_SERIALIZE(output_indices)
+          KV_SERIALIZE(global_output_ids)
         }
         else
         {
           KV_SERIALIZE(relayed)
           KV_SERIALIZE(received_timestamp)
         }
-        KV_SERIALIZE_CONTAINER_POD_AS_BLOB_OPT(global_output_ids, std::vector<uint64_t>{})
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3167,7 +3167,7 @@ bool simple_wallet::scan_tx(const std::vector<std::string> &args)
   m_in_manual_refresh.store(true);
   try {
     m_wallet->scan_tx(txids);
-  } catch (const tools::error::wont_reprocess_recent_txs_via_untrusted_daemon &e) {
+  } catch (const tools::error::wont_reprocess_txs_via_untrusted_daemon &e) {
     fail_msg_writer() << e.what() << ". Either connect to a trusted daemon by passing --trusted-daemon when starting the wallet, or use rescan_bc to rescan the chain.";
   } catch (const std::exception &e) {
     fail_msg_writer() << e.what();

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -3169,6 +3169,8 @@ bool simple_wallet::scan_tx(const std::vector<std::string> &args)
     m_wallet->scan_tx(txids);
   } catch (const tools::error::wont_reprocess_txs_via_untrusted_daemon &e) {
     fail_msg_writer() << e.what() << ". Either connect to a trusted daemon by passing --trusted-daemon when starting the wallet, or use rescan_bc to rescan the chain.";
+  } catch (const tools::error::wont_scan_future_tx &e) {
+    fail_msg_writer() << e.what() << ". Either refresh the wallet, or restore the wallet from the current chain height and then scan.";
   } catch (const std::exception &e) {
     fail_msg_writer() << e.what();
   }

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1299,7 +1299,7 @@ bool WalletImpl::scanTransactions(const std::vector<std::string> &txids)
     {
         m_wallet->scan_tx(txids_u);
     }
-    catch (const tools::error::wont_reprocess_recent_txs_via_untrusted_daemon &e)
+    catch (const tools::error::wont_reprocess_txs_via_untrusted_daemon &e)
     {
         setStatusError(e.what());
         return false;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1198,7 +1198,6 @@ wallet2::wallet2(network_type nettype, uint64_t kdf_rounds, bool unattended, std
   m_first_refresh_done(false),
   m_refresh_from_block_height(0),
   m_explicit_refresh_from_block_height(true),
-  m_skip_to_height(0),
   m_ask_password(AskPasswordToDecrypt),
   m_max_reorg_depth(ORPHANED_BLOCKS_MAX_COUNT),
   m_min_output_count(0),
@@ -1854,17 +1853,14 @@ bool has_nonrequested_tx_at_height_or_above_requested(uint64_t height, const std
   return false;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint64_t skip_to_height, const bool skipping_forwards,
+void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced,
   const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
   const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries)
 {
-  // If the wallet has unlocked receives it has already processed, we need to
-  // be sure to request its paths too. We get the output's global output id
-  // from the daemon, and then use global output id to request path data.
-  const auto need_path_data = [n_blocks_synced, skip_to_height](const transfer_details &td) -> bool
+  // Only need path data for unlocked outputs aka outputs already in the tree
+  const auto need_path_data = [n_blocks_synced](const transfer_details &td) -> bool
   {
-    // Only need path data for unlocked outputs aka outputs already in the tree
-    return cryptonote::get_last_locked_block_index(td.m_tx.unlock_time, td.m_block_height) < std::max(n_blocks_synced, skip_to_height);
+    return cryptonote::get_last_locked_block_index(td.m_tx.unlock_time, td.m_block_height) < n_blocks_synced;
   };
 
   const auto td_to_output_pair = [](const transfer_details &td) -> fcmp_pp::curve_trees::OutputPair
@@ -1874,33 +1870,6 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
       .commitment    = td.is_rct() ? rct::commit(td.amount(), td.m_mask) : rct::zeroCommitVartime(td.amount())
     };
   };
-
-  // We need path data for *all* prior receives that we have not already scanned
-  std::unordered_set<crypto::hash> extra_tx_hashes_we_need_path_data_for;
-  tx_entry_data extra_txs_we_need_path_data_for;
-  if (skipping_forwards)
-  {
-    for (const auto &td : m_transfers)
-    {
-      // Check if we've scanned the tx already
-      if (txids.count(td.m_txid))
-        continue;
-      if (tx_hashes_to_reprocess.count(td.m_txid))
-        continue;
-
-      // We have not already scanned this tx, and we cleared the cache.
-      // So re-register the output with the tree cache.
-      m_tree_cache.register_output(td_to_output_pair(td));
-
-      // If the output is not in the tree, we don't need its path data
-      if (!need_path_data(td))
-        continue;
-      extra_tx_hashes_we_need_path_data_for.insert(td.m_txid);
-    }
-
-    if (extra_tx_hashes_we_need_path_data_for.size())
-      extra_txs_we_need_path_data_for = this->get_tx_entries(extra_tx_hashes_we_need_path_data_for);
-  }
 
   // Collect global output id's for outputs we need path data for
   std::vector<uint64_t> global_output_ids;
@@ -1914,8 +1883,7 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
     // Find the output's global output id among the requested txs
     const bool in_txids = txids.count(td.m_txid);
     const bool in_tx_hashes_to_reprocess = tx_hashes_to_reprocess.count(td.m_txid);
-    const bool in_extra_tx_hashes_we_need_path_data_for = extra_tx_hashes_we_need_path_data_for.count(td.m_txid);
-    THROW_WALLET_EXCEPTION_IF(!in_txids && !in_tx_hashes_to_reprocess && !in_extra_tx_hashes_we_need_path_data_for,
+    THROW_WALLET_EXCEPTION_IF(!in_txids && !in_tx_hashes_to_reprocess,
       error::wallet_internal_error, "Missing tx we need path data for");
 
     const auto find_global_output_id = [&td](const std::vector<process_tx_entry_t> &entries) -> uint64_t
@@ -1932,36 +1900,21 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
     {
       global_output_ids.push_back(find_global_output_id(scan_tx_entries));
     }
-    else if (in_tx_hashes_to_reprocess)
+    else // if (in_tx_hashes_to_reprocess)
     {
       global_output_ids.push_back(find_global_output_id(rescan_tx_entries));
-    }
-    else
-    {
-      global_output_ids.push_back(find_global_output_id(extra_txs_we_need_path_data_for.tx_entries));
     }
 
     output_pairs.emplace_back(td_to_output_pair(td));
   };
 
-  // Collect global output id's for outputs we need paths for
-  if (skipping_forwards)
-  {
-    // Collect *all* the received global output id's and request their paths
-    global_output_ids.reserve(m_transfers.size());
-    output_pairs.reserve(m_transfers.size());
-    for (const auto &td : m_transfers)
+  // Collect received global output id's for *newly* identified receives
+  global_output_ids.reserve(txids.size());
+  output_pairs.reserve(txids.size());
+  for (const auto &td : m_transfers)
+    if (txids.count(td.m_txid) && !detached_tx_hashes.count(td.m_txid))
       push_if_unlocked(td);
-  }
-  else
-  {
-    // Collect received global output id's for *newly* identified receives
-    global_output_ids.reserve(txids.size());
-    output_pairs.reserve(txids.size());
-    for (const auto &td : m_transfers)
-      if (txids.count(td.m_txid) && !detached_tx_hashes.count(td.m_txid))
-        push_if_unlocked(td);
-  }
+
   THROW_WALLET_EXCEPTION_IF(output_pairs.size() != global_output_ids.size(), error::wallet_internal_error, "Mismatched number of output pairs to global output id's");
 
   // Get all the paths from daemon using collected global output id's
@@ -1975,7 +1928,7 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
     cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::request req = AUTO_VAL_INIT(req);
     cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response res = AUTO_VAL_INIT(res);
 
-    req.as_of_n_blocks = std::max(n_blocks_synced, skip_to_height);
+    req.as_of_n_blocks = n_blocks_synced;
 
     req.global_output_ids.reserve(N_PATHS_PER_REQ);
     const std::size_t end_j = std::min(i + N_PATHS_PER_REQ, global_output_ids.size());
@@ -2048,33 +2001,11 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   }
 
   // If the highest scan_tx height exceeds the wallet's known scan height, then
-  // the wallet will skip ahead to the scan_tx's height in order to service
-  // the request in a timely manner. Skipping unrequested transactions avoids
-  // generating sequences of calls to process_new_transaction which process
-  // transactions out-of-order, relative to their order in the blockchain, as
-  // the process_new_transaction implementation requires transactions to be
-  // processed in blockchain order. If a user misses a tx, they should either
-  // use rescan_bc, or manually scan missed txs with scan_tx.
-  const uint64_t skip_to_height = std::max(txs_to_scan.highest_height + 1, m_skip_to_height);
+  // we throw. Users/callers are expected to refresh the wallet in this case,
+  // or restore their wallet from the higher height.
+  // See discussion for why: https://github.com/seraphis-migration/monero/pull/49#issuecomment-3043274275
   const uint64_t n_blocks_synced = m_blockchain.size();
-  const bool skipping_forwards = skip_to_height > n_blocks_synced;
-  if (skipping_forwards)
-  {
-    // With FCMP++, if we skip scanning forwards, then we're going to need path
-    // data for all the wallet's existing received outputs. When connected to
-    // an untrusted daemon, if we need path data for 1 or more tx that the user
-    // did not request to scan, then we fail out because re-requesting the
-    // unexpected from the daemon poses a more severe and unintuitive privacy
-    // risk to the user.
-    THROW_WALLET_EXCEPTION_IF(!is_trusted_daemon() &&
-      has_nonrequested_tx_at_height_or_above_requested(0, txids, m_transfers, m_payments, m_confirmed_txs),
-      error::wont_reprocess_txs_via_untrusted_daemon
-    );
-
-    // We clear the tree cache here before processing scan txs. We'll restore
-    // all the wallet's received paths after processing scan txs.
-    m_tree_cache.clear();
-  }
+  THROW_WALLET_EXCEPTION_IF(txs_to_scan.highest_height >= n_blocks_synced, error::wont_scan_future_tx);
 
   // Detach the blockchain in preparation to re-process txs
   detached_blockchain_data dbd;
@@ -2100,35 +2031,11 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   reattach_blockchain(m_blockchain, dbd);
 
   // Assume the wallet has scanned this portion of chain   [.tx1..]
-  // scan_tx is called with tx0 and tx2                [tx0..tx1....tx2]
-  // All of tx0, tx1, and tx2 have unlocked and are in the tree
-  // We need to be sure to request paths for tx0, tx1, and tx2
-  // It's obvious why we would need tx0 and tx2 since the wallet has not seen
-  // them before. Not as obvious for tx1. We need tx1's path because we're
-  // skipping the scanner forwards (since tx2 is ahead of where we had prior
-  // scanned), and therefore we need to get tx1's latest path.
-  this->handle_needed_path_data(n_blocks_synced, skip_to_height, skipping_forwards, txids, tx_hashes_to_reprocess,
+  // scan_tx is called with tx0                        [tx0..tx1..]
+  // Both tx0 and tx1 have unlocked and are in the tree
+  // We need to be sure to request tx0's path
+  this->handle_needed_path_data(n_blocks_synced, txids, tx_hashes_to_reprocess,
     dbd.detached_tx_hashes, txs_to_scan.tx_entries, txs_to_reprocess.tx_entries);
-
-  // Set all data necessary to skip the scanner forwards on next refresh loop
-  if (skipping_forwards)
-  {
-    m_skip_to_height = skip_to_height;
-    LOG_PRINT_L0("Next refresh will skip to height " << skip_to_height);
-
-    // update last block reward here because the refresh loop won't necessarily set it
-    try
-    {
-      cryptonote::block_header_response block_header;
-      if (m_node_rpc_proxy.get_block_header_by_height(txs_to_scan.highest_height, block_header))
-        throw std::runtime_error("Failed to request block header by height");
-      m_last_block_reward = block_header.reward;
-    }
-    catch (...) { MERROR("Failed getting block header at height " << txs_to_scan.highest_height); }
-
-    // The wallet's blockchain state will now sync from the expected height correctly on next refresh loop
-    // The tree cache will re-initialize from skip_to_height on next refresh loop
-  }
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::set_subaddress_label(const cryptonote::subaddress_index& index, const std::string &label)
@@ -2800,7 +2707,7 @@ void wallet2::process_outgoing(const crypto::hash &txid, const cryptonote::trans
 bool wallet2::should_skip_block(const cryptonote::block &b, uint64_t height) const
 {
   // seeking only for blocks that are not older then the wallet creation time plus 1 day. 1 day is for possible user incorrect time setup
-  return !(b.timestamp + 60*60*24 > m_account.get_createtime() && height >= m_refresh_from_block_height && height >= m_skip_to_height);
+  return !(b.timestamp + 60*60*24 > m_account.get_createtime() && height >= m_refresh_from_block_height);
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::process_new_blockchain_entry(const cryptonote::block& b,
@@ -4135,9 +4042,9 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
   // pull the first set of blocks
   get_short_chain_history(short_chain_history, (m_first_refresh_done || trusted_daemon) ? 1 : FIRST_REFRESH_GRANULARITY);
   m_run.store(true, std::memory_order_relaxed);
-  if (start_height > m_blockchain.size() || m_refresh_from_block_height > m_blockchain.size() || m_skip_to_height > m_blockchain.size()) {
+  if (start_height > m_blockchain.size() || m_refresh_from_block_height > m_blockchain.size()) {
     if (!start_height)
-      start_height = std::max(m_refresh_from_block_height, m_skip_to_height);;
+      start_height = m_refresh_from_block_height;
     // we can shortcut by only pulling hashes up to the start_height
     fast_refresh(start_height, blocks_start_height, short_chain_history);
     // regenerate the history now that we've got a full set of hashes
@@ -4526,7 +4433,6 @@ bool wallet2::clear()
   m_multisig_rounds_passed = 0;
   m_device_last_key_image_sync = 0;
   m_pool_info_query_time = 0;
-  m_skip_to_height = 0;
   m_background_sync_data = background_sync_data_t{};
   m_tree_cache.clear();
   return true;
@@ -4546,7 +4452,6 @@ void wallet2::clear_soft(bool keep_key_images)
   m_scanned_pool_txs[0].clear();
   m_scanned_pool_txs[1].clear();
   m_pool_info_query_time = 0;
-  m_skip_to_height = 0;
   m_background_sync_data = background_sync_data_t{};
 
   cryptonote::block b;
@@ -4719,7 +4624,7 @@ boost::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const crypt
   value2.SetUint64(m_refresh_from_block_height);
   json.AddMember("refresh_height", value2, json.GetAllocator());
 
-  value2.SetUint64(m_skip_to_height);
+  value2.SetUint64(1); // exists for deserialization backwards compatibility
   json.AddMember("skip_to_height", value2, json.GetAllocator());
 
   value2.SetInt(1); // exists for deserialization backwards compatibility
@@ -5043,7 +4948,6 @@ bool wallet2::load_keys_buf(const std::string& keys_buf, const epee::wipeable_st
     m_auto_refresh = true;
     m_refresh_type = RefreshType::RefreshDefault;
     m_refresh_from_block_height = 0;
-    m_skip_to_height = 0;
     m_ask_password = AskPasswordToDecrypt;
     cryptonote::set_default_decimal_point(CRYPTONOTE_DISPLAY_DECIMAL_POINT);
     m_max_reorg_depth = ORPHANED_BLOCKS_MAX_COUNT;
@@ -5195,8 +5099,6 @@ bool wallet2::load_keys_buf(const std::string& keys_buf, const epee::wipeable_st
     }
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, refresh_height, uint64_t, Uint64, false, 0);
     m_refresh_from_block_height = field_refresh_height;
-    GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, skip_to_height, uint64_t, Uint64, false, 0);
-    m_skip_to_height = field_skip_to_height;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, ask_password, AskPasswordType, Int, false, AskPasswordToDecrypt);
     m_ask_password = field_ask_password;
     GET_FIELD_FROM_JSON_RETURN_ON_ERROR(json, default_decimal_point, int, Int, false, CRYPTONOTE_DISPLAY_DECIMAL_POINT);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3028,8 +3028,8 @@ void wallet2::pull_blocks(bool first, bool try_incremental, uint64_t start_heigh
     THROW_WALLET_EXCEPTION_IF(res.blocks.size() != res.output_indices.size(), error::wallet_internal_error,
         "mismatched blocks (" + boost::lexical_cast<std::string>(res.blocks.size()) + ") and output_indices (" +
         boost::lexical_cast<std::string>(res.output_indices.size()) + ") sizes from daemon");
-    THROW_WALLET_EXCEPTION_IF(req.init_tree_sync && !res.included_init_tree_sync_data, error::wallet_internal_error,
-        "daemon did not include requested init tree sync data");
+    THROW_WALLET_EXCEPTION_IF(req.init_tree_sync && res.init_tree_sync_data.init_block_hash == crypto::null_hash,
+        error::wallet_internal_error, "daemon did not include requested init tree sync data");
   }
 
   blocks_start_height = res.start_height;
@@ -6418,15 +6418,7 @@ bool wallet2::check_version(uint32_t *version, bool *wallet_is_outdated, bool *d
     return false;
   }
 
-<<<<<<< HEAD
-||||||| parent of e22a72cf0 (fcmp++: scan_tx & RPC for path by global output id)
   // check wallet compatibility with daemon's hard fork version
-=======
-  // FIXME: FCMP++ compatible wallets must point to FCMP++ compatible daemons in order to sync init_tree_sync_data to
-  // start building the tree correctly. scan_tx also expects to use new endpoints.
-
-  // check wallet compatibility with daemon's hard fork version
->>>>>>> e22a72cf0 (fcmp++: scan_tx & RPC for path by global output id)
   if (!m_allow_mismatched_daemon_version)
   {
     if (rpc_version < MAKE_CORE_RPC_VERSION(3, 17))

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1646,6 +1646,32 @@ std::string wallet2::get_subaddress_label(const cryptonote::subaddress_index& in
   return m_subaddress_labels[index.major][index.minor];
 }
 //----------------------------------------------------------------------------------------------------
+static void assert_top_block_match(const hashchain &blockchain, const tools::wallet2::TreeCacheV1 &tree_sync)
+{
+  if (blockchain.empty())
+  {
+    THROW_WALLET_EXCEPTION_IF(tree_sync.get_output_count() != 0, tools::error::wallet_internal_error,
+      "unexpected non-zero output count in tree sync");
+    return;
+  }
+
+  const uint64_t m_blockchain_top_block_idx = blockchain.size() - 1;
+  THROW_WALLET_EXCEPTION_IF(!blockchain.is_in_bounds(m_blockchain_top_block_idx), tools::error::wallet_internal_error,
+    "top block not in bounds");
+
+  fcmp_pp::curve_trees::BlockMeta top_synced_block;
+  THROW_WALLET_EXCEPTION_IF(!tree_sync.get_top_block(top_synced_block), tools::error::wallet_internal_error,
+    "empty tree sync cache");
+
+  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_idx != m_blockchain_top_block_idx,
+    tools::error::wallet_internal_error, "m_blockchain <> m_tree_cache top block idx mismatch (m_blockchain_top_block_idx: "
+    + std::to_string(m_blockchain_top_block_idx) + " vs tree top idx: " + std::to_string(top_synced_block.blk_idx) + ")");
+  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_hash != blockchain[m_blockchain_top_block_idx],
+    tools::error::wallet_internal_error,
+    "m_blockchain <> m_tree_cache top block hash mismatch (m_blockchain: " + string_tools::pod_to_hex(blockchain[m_blockchain_top_block_idx]) +
+    " vs tree top hash: " + string_tools::pod_to_hex(top_synced_block.blk_hash) + ")");
+}
+//----------------------------------------------------------------------------------------------------
 wallet2::tx_entry_data wallet2::get_tx_entries(const std::unordered_set<crypto::hash> &txids)
 {
   tx_entry_data tx_entries;
@@ -1853,7 +1879,7 @@ bool has_nonrequested_tx_at_height_or_above_requested(uint64_t height, const std
   return false;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced,
+void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const crypto::hash &top_block_hash,
   const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
   const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries)
 {
@@ -1928,7 +1954,7 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced,
     cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::request req = AUTO_VAL_INIT(req);
     cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response res = AUTO_VAL_INIT(res);
 
-    req.as_of_n_blocks = n_blocks_synced;
+    req.top_block_hash = top_block_hash;
 
     req.global_output_ids.reserve(N_PATHS_PER_REQ);
     const std::size_t end_j = std::min(i + N_PATHS_PER_REQ, global_output_ids.size());
@@ -2006,6 +2032,7 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   // See discussion for why: https://github.com/seraphis-migration/monero/pull/49#issuecomment-3043274275
   const uint64_t n_blocks_synced = m_blockchain.size();
   THROW_WALLET_EXCEPTION_IF(txs_to_scan.highest_height >= n_blocks_synced, error::wont_scan_future_tx);
+  assert_top_block_match(m_blockchain, m_tree_cache);
 
   // Detach the blockchain in preparation to re-process txs
   detached_blockchain_data dbd;
@@ -2030,11 +2057,15 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   process_scan_txs(txs_to_scan, txs_to_reprocess, tx_hashes_to_reprocess, dbd);
   reattach_blockchain(m_blockchain, dbd);
 
+  if (n_blocks_synced == 0)
+    return;
+  const crypto::hash &top_block_hash = m_blockchain[n_blocks_synced - 1];
+
   // Assume the wallet has scanned this portion of chain   [.tx1..]
   // scan_tx is called with tx0                        [tx0..tx1..]
   // Both tx0 and tx1 have unlocked and are in the tree
   // We need to be sure to request tx0's path
-  this->handle_needed_path_data(n_blocks_synced, txids, tx_hashes_to_reprocess,
+  this->handle_needed_path_data(n_blocks_synced, top_block_hash, txids, tx_hashes_to_reprocess,
     dbd.detached_tx_hashes, txs_to_scan.tx_entries, txs_to_reprocess.tx_entries);
 }
 //----------------------------------------------------------------------------------------------------
@@ -2993,32 +3024,6 @@ struct TreeSyncStartParams
   uint64_t start_parsed_block_i{0};
   crypto::hash prev_block_hash;
 };
-
-static void assert_top_block_match(const hashchain &blockchain, const tools::wallet2::TreeCacheV1 &tree_sync)
-{
-  if (blockchain.empty())
-  {
-    THROW_WALLET_EXCEPTION_IF(tree_sync.get_output_count() != 0, tools::error::wallet_internal_error,
-      "unexpected non-zero output count in tree sync");
-    return;
-  }
-
-  const uint64_t m_blockchain_top_block_idx = blockchain.size() - 1;
-  THROW_WALLET_EXCEPTION_IF(!blockchain.is_in_bounds(m_blockchain_top_block_idx), tools::error::wallet_internal_error,
-    "top block not in bounds");
-
-  fcmp_pp::curve_trees::BlockMeta top_synced_block;
-  THROW_WALLET_EXCEPTION_IF(!tree_sync.get_top_block(top_synced_block), tools::error::wallet_internal_error,
-    "empty tree sync cache");
-
-  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_idx != m_blockchain_top_block_idx,
-    tools::error::wallet_internal_error, "m_blockchain <> m_tree_cache top block idx mismatch (m_blockchain_top_block_idx: "
-    + std::to_string(m_blockchain_top_block_idx) + " vs tree top idx: " + std::to_string(top_synced_block.blk_idx) + ")");
-  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_hash != blockchain[m_blockchain_top_block_idx],
-    tools::error::wallet_internal_error,
-    "m_blockchain <> m_tree_cache top block hash mismatch (m_blockchain: " + string_tools::pod_to_hex(blockchain[m_blockchain_top_block_idx]) +
-    " vs tree top hash: " + string_tools::pod_to_hex(top_synced_block.blk_hash) + ")");
-}
 
 static void reorg_depth_check(const uint64_t reorg_blk_idx, const uint64_t start_block_idx, const crypto::hash &first_parsed_hash, const hashchain &blockchain, const uint64_t max_reorg_depth)
 {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1691,6 +1691,32 @@ wallet2::tx_entry_data wallet2::get_tx_entries(const std::unordered_set<crypto::
   return tx_entries;
 }
 //----------------------------------------------------------------------------------------------------
+static void assert_top_block_match(const hashchain &blockchain, const tools::wallet2::TreeCacheV1 &tree_cache)
+{
+  if (blockchain.empty())
+  {
+    THROW_WALLET_EXCEPTION_IF(tree_cache.get_output_count() != 0, tools::error::wallet_internal_error,
+      "unexpected non-zero output count in tree sync");
+    return;
+  }
+
+  const uint64_t m_blockchain_top_block_idx = blockchain.size() - 1;
+  THROW_WALLET_EXCEPTION_IF(!blockchain.is_in_bounds(m_blockchain_top_block_idx), tools::error::wallet_internal_error,
+    "top block not in bounds");
+
+  fcmp_pp::curve_trees::BlockMeta top_synced_block;
+  THROW_WALLET_EXCEPTION_IF(!tree_cache.get_top_block(top_synced_block), tools::error::wallet_internal_error,
+    "empty tree sync cache");
+
+  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_idx != m_blockchain_top_block_idx,
+    tools::error::wallet_internal_error, "m_blockchain <> m_tree_cache top block idx mismatch (m_blockchain_top_block_idx: "
+    + std::to_string(m_blockchain_top_block_idx) + " vs tree top idx: " + std::to_string(top_synced_block.blk_idx) + ")");
+  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_hash != blockchain[m_blockchain_top_block_idx],
+    tools::error::wallet_internal_error,
+    "m_blockchain <> m_tree_cache top block hash mismatch (m_blockchain: " + string_tools::pod_to_hex(blockchain[m_blockchain_top_block_idx]) +
+    " vs tree top hash: " + string_tools::pod_to_hex(top_synced_block.blk_hash) + ")");
+}
+//----------------------------------------------------------------------------------------------------
 void wallet2::sort_scan_tx_entries(std::vector<process_tx_entry_t> &unsorted_tx_entries)
 {
   // If any txs we're scanning have the same height, then we need to request the
@@ -2006,6 +2032,7 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   // See discussion for why: https://github.com/seraphis-migration/monero/pull/49#issuecomment-3043274275
   const uint64_t n_blocks_synced = m_blockchain.size();
   THROW_WALLET_EXCEPTION_IF(txs_to_scan.highest_height >= n_blocks_synced, error::wont_scan_future_tx);
+  assert_top_block_match(m_blockchain, m_tree_cache);
 
   // Detach the blockchain in preparation to re-process txs
   detached_blockchain_data dbd;
@@ -2993,32 +3020,6 @@ struct TreeSyncStartParams
   uint64_t start_parsed_block_i{0};
   crypto::hash prev_block_hash;
 };
-
-static void assert_top_block_match(const hashchain &blockchain, const tools::wallet2::TreeCacheV1 &tree_sync)
-{
-  if (blockchain.empty())
-  {
-    THROW_WALLET_EXCEPTION_IF(tree_sync.get_output_count() != 0, tools::error::wallet_internal_error,
-      "unexpected non-zero output count in tree sync");
-    return;
-  }
-
-  const uint64_t m_blockchain_top_block_idx = blockchain.size() - 1;
-  THROW_WALLET_EXCEPTION_IF(!blockchain.is_in_bounds(m_blockchain_top_block_idx), tools::error::wallet_internal_error,
-    "top block not in bounds");
-
-  fcmp_pp::curve_trees::BlockMeta top_synced_block;
-  THROW_WALLET_EXCEPTION_IF(!tree_sync.get_top_block(top_synced_block), tools::error::wallet_internal_error,
-    "empty tree sync cache");
-
-  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_idx != m_blockchain_top_block_idx,
-    tools::error::wallet_internal_error, "m_blockchain <> m_tree_cache top block idx mismatch (m_blockchain_top_block_idx: "
-    + std::to_string(m_blockchain_top_block_idx) + " vs tree top idx: " + std::to_string(top_synced_block.blk_idx) + ")");
-  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_hash != blockchain[m_blockchain_top_block_idx],
-    tools::error::wallet_internal_error,
-    "m_blockchain <> m_tree_cache top block hash mismatch (m_blockchain: " + string_tools::pod_to_hex(blockchain[m_blockchain_top_block_idx]) +
-    " vs tree top hash: " + string_tools::pod_to_hex(top_synced_block.blk_hash) + ")");
-}
 
 static void reorg_depth_check(const uint64_t reorg_blk_idx, const uint64_t start_block_idx, const crypto::hash &first_parsed_hash, const hashchain &blockchain, const uint64_t max_reorg_depth)
 {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1854,12 +1854,173 @@ bool has_nonrequested_tx_at_height_or_above_requested(uint64_t height, const std
   return false;
 }
 //----------------------------------------------------------------------------------------------------
+void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint64_t skip_to_height, const bool skipping_forwards,
+  const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
+  const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries)
+{
+  // If the wallet has unlocked receives it has already processed, we need to
+  // be sure to request its paths too. We get the output's global output id
+  // from the daemon, and then use global output id to request path data.
+  const auto need_path_data = [n_blocks_synced, skip_to_height](const transfer_details &td) -> bool
+  {
+    // Only need path data for unlocked outputs aka outputs already in the tree
+    return cryptonote::get_last_locked_block_index(td.m_tx.unlock_time, td.m_block_height) < std::max(n_blocks_synced, skip_to_height);
+  };
+
+  const auto td_to_output_pair = [](const transfer_details &td) -> fcmp_pp::curve_trees::OutputPair
+  {
+    return fcmp_pp::curve_trees::OutputPair{
+      .output_pubkey = td.get_public_key(),
+      .commitment    = td.is_rct() ? rct::commit(td.amount(), td.m_mask) : rct::zeroCommitVartime(td.amount())
+    };
+  };
+
+  // We need path data for *all* prior receives that we have not already scanned
+  std::unordered_set<crypto::hash> extra_tx_hashes_we_need_path_data_for;
+  tx_entry_data extra_txs_we_need_path_data_for;
+  if (skipping_forwards)
+  {
+    for (const auto &td : m_transfers)
+    {
+      // Check if we've scanned the tx already
+      if (txids.find(td.m_txid) != txids.end())
+        continue;
+      if (tx_hashes_to_reprocess.find(td.m_txid) != tx_hashes_to_reprocess.end())
+        continue;
+
+      // We have not already scanned this tx, and we cleared the cache.
+      // So re-register the output with the tree cache.
+      m_tree_cache.register_output(td_to_output_pair(td));
+
+      // If the output is not in the tree, we don't need its path data
+      if (!need_path_data(td))
+        continue;
+      extra_tx_hashes_we_need_path_data_for.insert(td.m_txid);
+    }
+
+    if (extra_tx_hashes_we_need_path_data_for.size())
+      extra_txs_we_need_path_data_for = this->get_tx_entries(extra_tx_hashes_we_need_path_data_for);
+  }
+
+  // Collect global output id's for outputs we need path data for
+  std::vector<uint64_t> global_output_ids;
+  std::vector<fcmp_pp::curve_trees::OutputPair> output_pairs;
+  const auto push_if_unlocked = [&](const transfer_details &td)
+  {
+    // Need paths for outputs that are spendable (i.e. unlocked)
+    if (!need_path_data(td))
+      return;
+
+    // Find the output's global output id among the requested txs
+    const auto tx_it = txids.find(td.m_txid);
+    const auto tx_hashes_to_reprocess_it = tx_hashes_to_reprocess.find(td.m_txid);
+    const auto extra_tx_hashes_we_need_path_data_for_it = extra_tx_hashes_we_need_path_data_for.find(td.m_txid);
+    THROW_WALLET_EXCEPTION_IF(tx_it == txids.end()
+      && tx_hashes_to_reprocess_it == tx_hashes_to_reprocess.end()
+      && extra_tx_hashes_we_need_path_data_for_it == extra_tx_hashes_we_need_path_data_for.end(),
+      error::wallet_internal_error, "Missing tx we need path data for");
+
+    const auto find_global_output_id = [&td](const std::vector<process_tx_entry_t> &entries) -> uint64_t
+    {
+      for (const auto &entry : entries)
+      {
+        if (entry.tx_hash == td.m_txid)
+          return entry.tx_entry.global_output_ids.at(td.m_internal_output_index);
+      }
+      THROW_WALLET_EXCEPTION(error::wallet_internal_error, "tx entries missing expected tx");
+    };
+
+    if (tx_it != txids.end())
+    {
+      global_output_ids.push_back(find_global_output_id(scan_tx_entries));
+    }
+    else if (tx_hashes_to_reprocess_it != extra_tx_hashes_we_need_path_data_for.end())
+    {
+      global_output_ids.push_back(find_global_output_id(rescan_tx_entries));
+    }
+    else
+    {
+      global_output_ids.push_back(find_global_output_id(extra_txs_we_need_path_data_for.tx_entries));
+    }
+
+    output_pairs.emplace_back(td_to_output_pair(td));
+  };
+
+  // Collect global output id's for outputs we need paths for
+  if (skipping_forwards)
+  {
+    // Collect *all* the received global output id's and request their paths
+    global_output_ids.reserve(m_transfers.size());
+    output_pairs.reserve(m_transfers.size());
+    for (const auto &td : m_transfers)
+      push_if_unlocked(td);
+  }
+  else
+  {
+    // Collect received global output id's for *newly* identified receives
+    global_output_ids.reserve(txids.size());
+    output_pairs.reserve(txids.size());
+    for (const auto &td : m_transfers)
+      if (txids.find(td.m_txid) != txids.end() && detached_tx_hashes.find(td.m_txid) == detached_tx_hashes.end())
+        push_if_unlocked(td);
+  }
+  THROW_WALLET_EXCEPTION_IF(output_pairs.size() != global_output_ids.size(), error::wallet_internal_error, "Mismatched number of output pairs to global output id's");
+
+  // Get all the paths from daemon using collected global output id's
+  // TODO: get consolidated paths
+  std::vector<cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response::path_entry> paths;
+  paths.reserve(global_output_ids.size());
+  static constexpr std::size_t N_PATHS_PER_REQ = 50; // MAX_RESTRICTED_PATHS_COUNT
+  uint64_t n_leaf_tuples = 0;
+  for (std::size_t i = 0; i < global_output_ids.size(); i += N_PATHS_PER_REQ)
+  {
+    cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::request req = AUTO_VAL_INIT(req);
+    cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response res = AUTO_VAL_INIT(res);
+
+    req.as_of_n_blocks = std::max(n_blocks_synced, skip_to_height);
+
+    req.global_output_ids.reserve(N_PATHS_PER_REQ);
+    const std::size_t end_j = std::min(i + N_PATHS_PER_REQ, global_output_ids.size());
+    for (std::size_t j = i; j < end_j; ++j)
+    {
+      req.global_output_ids.push_back(std::move(global_output_ids.at(j)));
+    }
+
+    {
+      const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
+      bool r = net_utils::invoke_http_bin("/get_path_by_global_output_id.bin", req, res, *m_http_client, rpc_timeout);
+      THROW_WALLET_EXCEPTION_IF(!r || res.status != CORE_RPC_STATUS_OK, error::wallet_internal_error, "Failed to get paths by global output id from daemon");
+      THROW_WALLET_EXCEPTION_IF(res.paths.size() != req.global_output_ids.size(), error::wallet_internal_error, "Mismatched number of paths in request for paths by global output id");
+      THROW_WALLET_EXCEPTION_IF(n_leaf_tuples > 0 && n_leaf_tuples != res.n_leaf_tuples, error::wallet_internal_error, "Unexpected different n_leaf_tuples across responses");
+      n_leaf_tuples = res.n_leaf_tuples;
+    }
+
+    for (auto &path_entry : res.paths)
+    {
+      // Since all requested paths should be for outputs that are unlocked, we expect non-empty paths in the resp
+      THROW_WALLET_EXCEPTION_IF(path_entry.path.leaves.empty() || path_entry.path.layer_chunks.empty(), error::wallet_internal_error, "Unexpected empty path");
+      paths.emplace_back(std::move(path_entry));
+    }
+  }
+  THROW_WALLET_EXCEPTION_IF(paths.size() != global_output_ids.size(), error::wallet_internal_error, "Mismatched number of paths to global output id's");
+
+  // Now process paths returned above
+  for (std::size_t i = 0; i < paths.size(); ++i)
+  {
+    // Audit each path returned by daemon
+    const auto path = m_curve_trees->path_bytes_to_path(paths.at(i).path);
+    THROW_WALLET_EXCEPTION_IF(!m_curve_trees->audit_path(path, output_pairs.at(i), n_leaf_tuples),
+      error::wallet_internal_error, "Path returned by daemon failed audit");
+
+    // Add the output's path to the tree cache
+    m_tree_cache.force_add_output_path(output_pairs.at(i), paths.at(i).leaf_idx, paths.at(i).path, n_leaf_tuples);
+  }
+}
+//----------------------------------------------------------------------------------------------------
 void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
 {
   THROW_WALLET_EXCEPTION_IF(m_background_syncing || m_is_background_wallet, error::wallet_internal_error,
     "cannot scan tx from background wallet");
-
-  // FIXME: check m_rpc_version and fail if version is too low
 
   // Get the transactions from daemon in batches sorted lowest height to highest
   tx_entry_data txs_to_scan = get_tx_entries(txids);
@@ -1896,8 +2057,9 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   // the process_new_transaction implementation requires transactions to be
   // processed in blockchain order. If a user misses a tx, they should either
   // use rescan_bc, or manually scan missed txs with scan_tx.
-  const uint64_t skip_to_height = txs_to_scan.highest_height + 1;
-  const bool skipping_forwards = skip_to_height > m_blockchain.size();
+  const uint64_t skip_to_height = std::max(txs_to_scan.highest_height + 1, m_skip_to_height);
+  const uint64_t n_blocks_synced = m_blockchain.size();
+  const bool skipping_forwards = skip_to_height > n_blocks_synced;
   if (skipping_forwards)
   {
     // With FCMP++, if we skip scanning forwards, then we're going to need path
@@ -1910,11 +2072,15 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
       has_nonrequested_tx_at_height_or_above_requested(0, txids, m_transfers, m_payments, m_confirmed_txs),
       error::wont_reprocess_txs_via_untrusted_daemon
     );
+
+    // We clear the tree cache here before processing scan txs. We'll restore
+    // all the wallet's received paths after processing scan txs.
+    m_tree_cache.clear();
   }
 
   // Detach the blockchain in preparation to re-process txs
   detached_blockchain_data dbd;
-  dbd.original_chain_size = m_blockchain.size();
+  dbd.original_chain_size = n_blocks_synced;
   if (txs_to_scan.highest_height > 0)
   {
     LOG_PRINT_L0("Re-processing wallet's existing txs (if any) starting from height " << txs_to_scan.lowest_height);
@@ -1935,87 +2101,16 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   process_scan_txs(txs_to_scan, txs_to_reprocess, tx_hashes_to_reprocess, dbd);
   reattach_blockchain(m_blockchain, dbd);
 
-  // TODO: new function sync_tree_cache_for_scan_tx
-  // Assume the wallet has scanned this portion of chain   [....]
-  // scan_tx is called with a, b, and c                  [a..b....c..]
-  // All of a, b, and c have unlocked and are in the tree
-  // We need to be sure to request paths for a, b, and c and register respective outputs with tree cache
-  std::vector<get_outputs_out> amount_output_ids;
-  std::vector<fcmp_pp::curve_trees::OutputPair> output_pairs;
-  const auto push_if_unlocked = [skip_to_height, &amount_output_ids, &output_pairs](const transfer_details &td, const uint64_t n_blocks)
-  {
-    // Only need to get paths of outputs that are spendable (i.e. unlocked)
-    if (cryptonote::get_last_locked_block_index(td.m_tx.unlock_time, td.m_block_height) >= std::max(n_blocks, skip_to_height))
-      return;
-    amount_output_ids.push_back({td.is_rct() ? 0 : td.amount(), td.m_global_output_index});
-
-    fcmp_pp::curve_trees::OutputPair output_pair{
-      .output_pubkey = td.get_public_key(),
-      .commitment = td.is_rct() ? rct::commit(td.amount(), td.m_mask) : rct::zeroCommitVartime(td.amount())
-    };
-    output_pairs.emplace_back(std::move(output_pair));
-  };
-
-  // Collect amount output id's for outputs we need paths for
-  if (skipping_forwards)
-  {
-    // Collect *all* the received amount output id's and request their paths
-    amount_output_ids.reserve(m_transfers.size());
-    output_pairs.reserve(m_transfers.size());
-    for (const auto &td : m_transfers)
-      push_if_unlocked(td, m_blockchain.size());
-  }
-  else
-  {
-    // Place all newly scanned txs in an unordered set for quick lookup
-    std::unordered_set<crypto::hash> new_txs;
-    for (const auto &tx_entry : txs_to_scan.tx_entries)
-      new_txs.insert(tx_entry.tx_hash);
-
-    // Collect received amount output id's of newly scanned txs
-    amount_output_ids.reserve(new_txs.size());
-    output_pairs.reserve(new_txs.size());
-    for (const auto &td : m_transfers)
-      if (new_txs.find(td.m_txid) != new_txs.end())
-        push_if_unlocked(td, m_blockchain.size());
-  }
-
-  // Get all the paths with collected amount output id's
-  // FIXME: Request should include height at which path is good for so we're certain the paths are tied to expected height
-  // in the tree cache
-  std::vector<fcmp_pp::curve_trees::PathBytes> paths;
-  paths.reserve(amount_output_ids.size());
-  static constexpr std::size_t N_PATHS_PER_REQ = 50; // MAX_RESTRICTED_PATHS_COUNT
-  for (std::size_t i = 0; i < amount_output_ids.size(); i += N_PATHS_PER_REQ)
-  {
-    cryptonote::COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::request req = AUTO_VAL_INIT(req);
-    cryptonote::COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::response res = AUTO_VAL_INIT(res);
-    req.outputs.reserve(N_PATHS_PER_REQ);
-
-    const std::size_t end_j = std::min(i + N_PATHS_PER_REQ, amount_output_ids.size());
-    for (std::size_t j = i; j < end_j; ++j)
-    {
-      req.outputs.push_back(std::move(amount_output_ids[j]));
-    }
-
-    {
-      const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
-      bool r = net_utils::invoke_http_bin("/get_path_by_amount_output_id.bin", req, res, *m_http_client, rpc_timeout);
-      THROW_WALLET_EXCEPTION_IF(!r || res.status != CORE_RPC_STATUS_OK, error::wallet_internal_error, "Failed to get paths by amount output id from daemon");
-      THROW_WALLET_EXCEPTION_IF(res.paths.size() != req.outputs.size(), error::wallet_internal_error, "Mismatched number of paths in request for paths by amount output id");
-    }
-
-    for (auto &path : res.paths)
-      paths.emplace_back(std::move(path));
-  }
-  THROW_WALLET_EXCEPTION_IF(paths.size() != amount_output_ids.size(), error::wallet_internal_error, "Mismatched number of paths to amount output id");
-
-  // TODO: make sure every output pair is present in each path, and make sure each path is correct
-  // TODO: Set paths in the tree cache, being sure to register each output
-  for (std::size_t i = 0; paths.size(); ++i)
-  {
-    // m_tree_cache.sync_path(output_pairs[i], paths[i]);
-  }
+  // Assume the wallet has scanned this portion of chain   [.tx1..]
+  // scan_tx is called with tx0 and tx2                [tx0..tx1....tx2]
+  // All of tx0, tx1, and tx2 have unlocked and are in the tree
+  // We need to be sure to request paths for tx0, tx1, and tx2
+  // It's obvious why we would need tx0 and tx2 since the wallet has not seen
+  // them before. Not as obvious for tx1. We need tx1's path because we're
+  // skipping the scanner forwards (since tx2 is ahead of where we had prior
+  // scanned), and therefore we need to get tx1's latest path.
+  this->handle_needed_path_data(n_blocks_synced, skip_to_height, skipping_forwards, txids, tx_hashes_to_reprocess,
+    dbd.detached_tx_hashes, txs_to_scan.tx_entries, txs_to_reprocess.tx_entries);
 
   // Set all data necessary to skip the scanner forwards on next refresh loop
   if (skipping_forwards)
@@ -2034,9 +2129,7 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
     catch (...) { MERROR("Failed getting block header at height " << txs_to_scan.highest_height); }
 
     // The wallet's blockchain state will now sync from the expected height correctly on next refresh loop
-
-    // TODO: be sure to set the right-edge of the tree at skip_to_height while maintaining known paths
-    // TODO: we can purge refs for non-owned paths, since they'll never get purged otherwise
+    // The tree cache will re-initialize from skip_to_height on next refresh loop
   }
 }
 //----------------------------------------------------------------------------------------------------
@@ -2464,7 +2557,7 @@ void wallet2::process_new_scanned_transaction(
       .output_pubkey = onetime_address,
       .commitment = rct::commit(enote_scan_info->amount, enote_scan_info->amount_blinding_factor)
     };
-    m_tree_cache.register_output(output_pair, cryptonote::get_last_locked_block_index(tx.unlock_time, height));
+    m_tree_cache.register_output(output_pair);
 
     // money received callbacks
     LOG_PRINT_L0("Received money: " << print_money(td.amount()) << ", with tx: " << txid);
@@ -3183,6 +3276,7 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const std::vect
 
   THROW_WALLET_EXCEPTION_IF(blocks.size() != parsed_blocks.size(), error::wallet_internal_error, "size mismatch");
   THROW_WALLET_EXCEPTION_IF(!m_blockchain.is_in_bounds(start_height), error::out_of_hashchain_bounds_error);
+  assert_top_block_match(m_blockchain, m_tree_cache);
 
   tools::threadpool& tpool = tools::threadpool::getInstanceForCompute();
 
@@ -6326,6 +6420,15 @@ bool wallet2::check_version(uint32_t *version, bool *wallet_is_outdated, bool *d
     return false;
   }
 
+<<<<<<< HEAD
+||||||| parent of e22a72cf0 (fcmp++: scan_tx & RPC for path by global output id)
+  // check wallet compatibility with daemon's hard fork version
+=======
+  // FIXME: FCMP++ compatible wallets must point to FCMP++ compatible daemons in order to sync init_tree_sync_data to
+  // start building the tree correctly. scan_tx also expects to use new endpoints.
+
+  // check wallet compatibility with daemon's hard fork version
+>>>>>>> e22a72cf0 (fcmp++: scan_tx & RPC for path by global output id)
   if (!m_allow_mismatched_daemon_version)
   {
     if (rpc_version < MAKE_CORE_RPC_VERSION(3, 17))

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1646,32 +1646,6 @@ std::string wallet2::get_subaddress_label(const cryptonote::subaddress_index& in
   return m_subaddress_labels[index.major][index.minor];
 }
 //----------------------------------------------------------------------------------------------------
-static void assert_top_block_match(const hashchain &blockchain, const tools::wallet2::TreeCacheV1 &tree_sync)
-{
-  if (blockchain.empty())
-  {
-    THROW_WALLET_EXCEPTION_IF(tree_sync.get_output_count() != 0, tools::error::wallet_internal_error,
-      "unexpected non-zero output count in tree sync");
-    return;
-  }
-
-  const uint64_t m_blockchain_top_block_idx = blockchain.size() - 1;
-  THROW_WALLET_EXCEPTION_IF(!blockchain.is_in_bounds(m_blockchain_top_block_idx), tools::error::wallet_internal_error,
-    "top block not in bounds");
-
-  fcmp_pp::curve_trees::BlockMeta top_synced_block;
-  THROW_WALLET_EXCEPTION_IF(!tree_sync.get_top_block(top_synced_block), tools::error::wallet_internal_error,
-    "empty tree sync cache");
-
-  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_idx != m_blockchain_top_block_idx,
-    tools::error::wallet_internal_error, "m_blockchain <> m_tree_cache top block idx mismatch (m_blockchain_top_block_idx: "
-    + std::to_string(m_blockchain_top_block_idx) + " vs tree top idx: " + std::to_string(top_synced_block.blk_idx) + ")");
-  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_hash != blockchain[m_blockchain_top_block_idx],
-    tools::error::wallet_internal_error,
-    "m_blockchain <> m_tree_cache top block hash mismatch (m_blockchain: " + string_tools::pod_to_hex(blockchain[m_blockchain_top_block_idx]) +
-    " vs tree top hash: " + string_tools::pod_to_hex(top_synced_block.blk_hash) + ")");
-}
-//----------------------------------------------------------------------------------------------------
 wallet2::tx_entry_data wallet2::get_tx_entries(const std::unordered_set<crypto::hash> &txids)
 {
   tx_entry_data tx_entries;
@@ -1879,7 +1853,7 @@ bool has_nonrequested_tx_at_height_or_above_requested(uint64_t height, const std
   return false;
 }
 //----------------------------------------------------------------------------------------------------
-void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const crypto::hash &top_block_hash,
+void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced,
   const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
   const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries)
 {
@@ -1954,7 +1928,7 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const cryp
     cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::request req = AUTO_VAL_INIT(req);
     cryptonote::COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN::response res = AUTO_VAL_INIT(res);
 
-    req.top_block_hash = top_block_hash;
+    req.as_of_n_blocks = n_blocks_synced;
 
     req.global_output_ids.reserve(N_PATHS_PER_REQ);
     const std::size_t end_j = std::min(i + N_PATHS_PER_REQ, global_output_ids.size());
@@ -2032,7 +2006,6 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   // See discussion for why: https://github.com/seraphis-migration/monero/pull/49#issuecomment-3043274275
   const uint64_t n_blocks_synced = m_blockchain.size();
   THROW_WALLET_EXCEPTION_IF(txs_to_scan.highest_height >= n_blocks_synced, error::wont_scan_future_tx);
-  assert_top_block_match(m_blockchain, m_tree_cache);
 
   // Detach the blockchain in preparation to re-process txs
   detached_blockchain_data dbd;
@@ -2057,15 +2030,11 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   process_scan_txs(txs_to_scan, txs_to_reprocess, tx_hashes_to_reprocess, dbd);
   reattach_blockchain(m_blockchain, dbd);
 
-  if (n_blocks_synced == 0)
-    return;
-  const crypto::hash &top_block_hash = m_blockchain[n_blocks_synced - 1];
-
   // Assume the wallet has scanned this portion of chain   [.tx1..]
   // scan_tx is called with tx0                        [tx0..tx1..]
   // Both tx0 and tx1 have unlocked and are in the tree
   // We need to be sure to request tx0's path
-  this->handle_needed_path_data(n_blocks_synced, top_block_hash, txids, tx_hashes_to_reprocess,
+  this->handle_needed_path_data(n_blocks_synced, txids, tx_hashes_to_reprocess,
     dbd.detached_tx_hashes, txs_to_scan.tx_entries, txs_to_reprocess.tx_entries);
 }
 //----------------------------------------------------------------------------------------------------
@@ -3024,6 +2993,32 @@ struct TreeSyncStartParams
   uint64_t start_parsed_block_i{0};
   crypto::hash prev_block_hash;
 };
+
+static void assert_top_block_match(const hashchain &blockchain, const tools::wallet2::TreeCacheV1 &tree_sync)
+{
+  if (blockchain.empty())
+  {
+    THROW_WALLET_EXCEPTION_IF(tree_sync.get_output_count() != 0, tools::error::wallet_internal_error,
+      "unexpected non-zero output count in tree sync");
+    return;
+  }
+
+  const uint64_t m_blockchain_top_block_idx = blockchain.size() - 1;
+  THROW_WALLET_EXCEPTION_IF(!blockchain.is_in_bounds(m_blockchain_top_block_idx), tools::error::wallet_internal_error,
+    "top block not in bounds");
+
+  fcmp_pp::curve_trees::BlockMeta top_synced_block;
+  THROW_WALLET_EXCEPTION_IF(!tree_sync.get_top_block(top_synced_block), tools::error::wallet_internal_error,
+    "empty tree sync cache");
+
+  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_idx != m_blockchain_top_block_idx,
+    tools::error::wallet_internal_error, "m_blockchain <> m_tree_cache top block idx mismatch (m_blockchain_top_block_idx: "
+    + std::to_string(m_blockchain_top_block_idx) + " vs tree top idx: " + std::to_string(top_synced_block.blk_idx) + ")");
+  THROW_WALLET_EXCEPTION_IF(top_synced_block.blk_hash != blockchain[m_blockchain_top_block_idx],
+    tools::error::wallet_internal_error,
+    "m_blockchain <> m_tree_cache top block hash mismatch (m_blockchain: " + string_tools::pod_to_hex(blockchain[m_blockchain_top_block_idx]) +
+    " vs tree top hash: " + string_tools::pod_to_hex(top_synced_block.blk_hash) + ")");
+}
 
 static void reorg_depth_check(const uint64_t reorg_blk_idx, const uint64_t start_block_idx, const crypto::hash &first_parsed_hash, const hashchain &blockchain, const uint64_t max_reorg_depth)
 {

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1883,9 +1883,9 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
     for (const auto &td : m_transfers)
     {
       // Check if we've scanned the tx already
-      if (txids.find(td.m_txid) != txids.end())
+      if (txids.count(td.m_txid))
         continue;
-      if (tx_hashes_to_reprocess.find(td.m_txid) != tx_hashes_to_reprocess.end())
+      if (tx_hashes_to_reprocess.count(td.m_txid))
         continue;
 
       // We have not already scanned this tx, and we cleared the cache.
@@ -1912,12 +1912,10 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
       return;
 
     // Find the output's global output id among the requested txs
-    const auto tx_it = txids.find(td.m_txid);
-    const auto tx_hashes_to_reprocess_it = tx_hashes_to_reprocess.find(td.m_txid);
-    const auto extra_tx_hashes_we_need_path_data_for_it = extra_tx_hashes_we_need_path_data_for.find(td.m_txid);
-    THROW_WALLET_EXCEPTION_IF(tx_it == txids.end()
-      && tx_hashes_to_reprocess_it == tx_hashes_to_reprocess.end()
-      && extra_tx_hashes_we_need_path_data_for_it == extra_tx_hashes_we_need_path_data_for.end(),
+    const bool in_txids = txids.count(td.m_txid);
+    const bool in_tx_hashes_to_reprocess = tx_hashes_to_reprocess.count(td.m_txid);
+    const bool in_extra_tx_hashes_we_need_path_data_for = extra_tx_hashes_we_need_path_data_for.count(td.m_txid);
+    THROW_WALLET_EXCEPTION_IF(!in_txids && !in_tx_hashes_to_reprocess && !in_extra_tx_hashes_we_need_path_data_for,
       error::wallet_internal_error, "Missing tx we need path data for");
 
     const auto find_global_output_id = [&td](const std::vector<process_tx_entry_t> &entries) -> uint64_t
@@ -1930,11 +1928,11 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
       THROW_WALLET_EXCEPTION(error::wallet_internal_error, "tx entries missing expected tx");
     };
 
-    if (tx_it != txids.end())
+    if (in_txids)
     {
       global_output_ids.push_back(find_global_output_id(scan_tx_entries));
     }
-    else if (tx_hashes_to_reprocess_it != extra_tx_hashes_we_need_path_data_for.end())
+    else if (in_tx_hashes_to_reprocess)
     {
       global_output_ids.push_back(find_global_output_id(rescan_tx_entries));
     }
@@ -1961,7 +1959,7 @@ void wallet2::handle_needed_path_data(const uint64_t n_blocks_synced, const uint
     global_output_ids.reserve(txids.size());
     output_pairs.reserve(txids.size());
     for (const auto &td : m_transfers)
-      if (txids.find(td.m_txid) != txids.end() && detached_tx_hashes.find(td.m_txid) == detached_tx_hashes.end())
+      if (txids.count(td.m_txid) && !detached_tx_hashes.count(td.m_txid))
         push_if_unlocked(td);
   }
   THROW_WALLET_EXCEPTION_IF(output_pairs.size() != global_output_ids.size(), error::wallet_internal_error, "Mismatched number of output pairs to global output id's");

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -1859,6 +1859,8 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   THROW_WALLET_EXCEPTION_IF(m_background_syncing || m_is_background_wallet, error::wallet_internal_error,
     "cannot scan tx from background wallet");
 
+  // FIXME: check m_rpc_version and fail if version is too low
+
   // Get the transactions from daemon in batches sorted lowest height to highest
   tx_entry_data txs_to_scan = get_tx_entries(txids);
   if (txs_to_scan.tx_entries.empty())
@@ -1874,8 +1876,6 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   // a sweep to a different wallet's address, the wallet will not be able to
   // detect tx2. The wallet would need to scan tx1 first in that case.
   // TODO: handle this sweep case
-  detached_blockchain_data dbd;
-  dbd.original_chain_size = m_blockchain.size();
   if (txs_to_scan.highest_height > 0)
   {
     // When connected to an untrusted daemon, if we will need to re-process 1+
@@ -1884,13 +1884,44 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
     // and unintuitive privacy risk to the user
     THROW_WALLET_EXCEPTION_IF(!is_trusted_daemon() &&
       has_nonrequested_tx_at_height_or_above_requested(txs_to_scan.lowest_height, txids, m_transfers, m_payments, m_confirmed_txs),
-      error::wont_reprocess_recent_txs_via_untrusted_daemon
+      error::wont_reprocess_txs_via_untrusted_daemon
     );
+  }
 
+  // If the highest scan_tx height exceeds the wallet's known scan height, then
+  // the wallet will skip ahead to the scan_tx's height in order to service
+  // the request in a timely manner. Skipping unrequested transactions avoids
+  // generating sequences of calls to process_new_transaction which process
+  // transactions out-of-order, relative to their order in the blockchain, as
+  // the process_new_transaction implementation requires transactions to be
+  // processed in blockchain order. If a user misses a tx, they should either
+  // use rescan_bc, or manually scan missed txs with scan_tx.
+  const uint64_t skip_to_height = txs_to_scan.highest_height + 1;
+  const bool skipping_forwards = skip_to_height > m_blockchain.size();
+  if (skipping_forwards)
+  {
+    // With FCMP++, if we skip scanning forwards, then we're going to need path
+    // data for all the wallet's existing received outputs. When connected to
+    // an untrusted daemon, if we need path data for 1 or more tx that the user
+    // did not request to scan, then we fail out because re-requesting the
+    // unexpected from the daemon poses a more severe and unintuitive privacy
+    // risk to the user.
+    THROW_WALLET_EXCEPTION_IF(!is_trusted_daemon() &&
+      has_nonrequested_tx_at_height_or_above_requested(0, txids, m_transfers, m_payments, m_confirmed_txs),
+      error::wont_reprocess_txs_via_untrusted_daemon
+    );
+  }
+
+  // Detach the blockchain in preparation to re-process txs
+  detached_blockchain_data dbd;
+  dbd.original_chain_size = m_blockchain.size();
+  if (txs_to_scan.highest_height > 0)
+  {
     LOG_PRINT_L0("Re-processing wallet's existing txs (if any) starting from height " << txs_to_scan.lowest_height);
     auto output_tracker_cache = create_output_tracker_cache();
     dbd = detach_blockchain(txs_to_scan.lowest_height, output_tracker_cache);
   }
+
   std::unordered_set<crypto::hash> tx_hashes_to_reprocess;
   tx_hashes_to_reprocess.reserve(dbd.detached_tx_hashes.size());
   for (const auto &tx_hash : dbd.detached_tx_hashes)
@@ -1901,21 +1932,93 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
   // re-request txs from daemon to re-process with all tx data needed
   tx_entry_data txs_to_reprocess = get_tx_entries(tx_hashes_to_reprocess);
 
-  // TODO: request output paths in tree for all outputs in requested txs, add the received output paths to the cache
-
   process_scan_txs(txs_to_scan, txs_to_reprocess, tx_hashes_to_reprocess, dbd);
   reattach_blockchain(m_blockchain, dbd);
 
-  // If the highest scan_tx height exceeds the wallet's known scan height, then
-  // the wallet should skip ahead to the scan_tx's height in order to service
-  // the request in a timely manner. Skipping unrequested transactions avoids
-  // generating sequences of calls to process_new_transaction which process
-  // transactions out-of-order, relative to their order in the blockchain, as
-  // the process_new_transaction implementation requires transactions to be
-  // processed in blockchain order. If a user misses a tx, they should either
-  // use rescan_bc, or manually scan missed txs with scan_tx.
-  uint64_t skip_to_height = txs_to_scan.highest_height + 1;
-  if (skip_to_height > m_blockchain.size())
+  // TODO: new function sync_tree_cache_for_scan_tx
+  // Assume the wallet has scanned this portion of chain   [....]
+  // scan_tx is called with a, b, and c                  [a..b....c..]
+  // All of a, b, and c have unlocked and are in the tree
+  // We need to be sure to request paths for a, b, and c and register respective outputs with tree cache
+  std::vector<get_outputs_out> amount_output_ids;
+  std::vector<fcmp_pp::curve_trees::OutputPair> output_pairs;
+  const auto push_if_unlocked = [skip_to_height, &amount_output_ids, &output_pairs](const transfer_details &td, const uint64_t n_blocks)
+  {
+    // Only need to get paths of outputs that are spendable (i.e. unlocked)
+    if (cryptonote::get_last_locked_block_index(td.m_tx.unlock_time, td.m_block_height) >= std::max(n_blocks, skip_to_height))
+      return;
+    amount_output_ids.push_back({td.is_rct() ? 0 : td.amount(), td.m_global_output_index});
+
+    fcmp_pp::curve_trees::OutputPair output_pair{
+      .output_pubkey = td.get_public_key(),
+      .commitment = td.is_rct() ? rct::commit(td.amount(), td.m_mask) : rct::zeroCommitVartime(td.amount())
+    };
+    output_pairs.emplace_back(std::move(output_pair));
+  };
+
+  // Collect amount output id's for outputs we need paths for
+  if (skipping_forwards)
+  {
+    // Collect *all* the received amount output id's and request their paths
+    amount_output_ids.reserve(m_transfers.size());
+    output_pairs.reserve(m_transfers.size());
+    for (const auto &td : m_transfers)
+      push_if_unlocked(td, m_blockchain.size());
+  }
+  else
+  {
+    // Place all newly scanned txs in an unordered set for quick lookup
+    std::unordered_set<crypto::hash> new_txs;
+    for (const auto &tx_entry : txs_to_scan.tx_entries)
+      new_txs.insert(tx_entry.tx_hash);
+
+    // Collect received amount output id's of newly scanned txs
+    amount_output_ids.reserve(new_txs.size());
+    output_pairs.reserve(new_txs.size());
+    for (const auto &td : m_transfers)
+      if (new_txs.find(td.m_txid) != new_txs.end())
+        push_if_unlocked(td, m_blockchain.size());
+  }
+
+  // Get all the paths with collected amount output id's
+  // FIXME: Request should include height at which path is good for so we're certain the paths are tied to expected height
+  // in the tree cache
+  std::vector<fcmp_pp::curve_trees::PathBytes> paths;
+  paths.reserve(amount_output_ids.size());
+  static constexpr std::size_t N_PATHS_PER_REQ = 50; // MAX_RESTRICTED_PATHS_COUNT
+  for (std::size_t i = 0; i < amount_output_ids.size(); i += N_PATHS_PER_REQ)
+  {
+    cryptonote::COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::request req = AUTO_VAL_INIT(req);
+    cryptonote::COMMAND_RPC_GET_PATH_BY_AMOUNT_OUTPUT_ID_BIN::response res = AUTO_VAL_INIT(res);
+    req.outputs.reserve(N_PATHS_PER_REQ);
+
+    const std::size_t end_j = std::min(i + N_PATHS_PER_REQ, amount_output_ids.size());
+    for (std::size_t j = i; j < end_j; ++j)
+    {
+      req.outputs.push_back(std::move(amount_output_ids[j]));
+    }
+
+    {
+      const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
+      bool r = net_utils::invoke_http_bin("/get_path_by_amount_output_id.bin", req, res, *m_http_client, rpc_timeout);
+      THROW_WALLET_EXCEPTION_IF(!r || res.status != CORE_RPC_STATUS_OK, error::wallet_internal_error, "Failed to get paths by amount output id from daemon");
+      THROW_WALLET_EXCEPTION_IF(res.paths.size() != req.outputs.size(), error::wallet_internal_error, "Mismatched number of paths in request for paths by amount output id");
+    }
+
+    for (auto &path : res.paths)
+      paths.emplace_back(std::move(path));
+  }
+  THROW_WALLET_EXCEPTION_IF(paths.size() != amount_output_ids.size(), error::wallet_internal_error, "Mismatched number of paths to amount output id");
+
+  // TODO: make sure every output pair is present in each path, and make sure each path is correct
+  // TODO: Set paths in the tree cache, being sure to register each output
+  for (std::size_t i = 0; paths.size(); ++i)
+  {
+    // m_tree_cache.sync_path(output_pairs[i], paths[i]);
+  }
+
+  // Set all data necessary to skip the scanner forwards on next refresh loop
+  if (skipping_forwards)
   {
     m_skip_to_height = skip_to_height;
     LOG_PRINT_L0("Next refresh will skip to height " << skip_to_height);
@@ -1932,7 +2035,8 @@ void wallet2::scan_tx(const std::unordered_set<crypto::hash> &txids)
 
     // The wallet's blockchain state will now sync from the expected height correctly on next refresh loop
 
-    // TODO: be sure to initialize the right-edge of the tree at skip_to_height
+    // TODO: be sure to set the right-edge of the tree at skip_to_height while maintaining known paths
+    // TODO: we can purge refs for non-owned paths, since they'll never get purged otherwise
   }
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1524,7 +1524,7 @@ private:
     tx_entry_data get_tx_entries(const std::unordered_set<crypto::hash> &txids);
     void sort_scan_tx_entries(std::vector<process_tx_entry_t> &unsorted_tx_entries);
     void process_scan_txs(const tx_entry_data &txs_to_scan, const tx_entry_data &txs_to_reprocess, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, detached_blockchain_data &dbd);
-    void handle_needed_path_data(const uint64_t n_blocks_synced, const uint64_t skip_to_height, const bool skipping_forwards,
+    void handle_needed_path_data(const uint64_t n_blocks_synced,
       const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
       const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries);
     void write_background_sync_wallet(const epee::wipeable_string &wallet_password, const epee::wipeable_string &background_cache_password);
@@ -1627,9 +1627,6 @@ private:
     // m_refresh_from_block_height was defaulted to zero.*/
     bool m_explicit_refresh_from_block_height;
     uint64_t m_pool_info_query_time;
-    uint64_t m_skip_to_height;
-    // m_skip_to_height is useful when we don't want to modify the wallet's restore height.
-    // m_refresh_from_block_height is also a wallet's restore height which should remain constant unless explicitly modified by the user.
     bool m_confirm_non_default_ring_size;
     AskPasswordType m_ask_password;
     uint64_t m_max_reorg_depth;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1524,7 +1524,7 @@ private:
     tx_entry_data get_tx_entries(const std::unordered_set<crypto::hash> &txids);
     void sort_scan_tx_entries(std::vector<process_tx_entry_t> &unsorted_tx_entries);
     void process_scan_txs(const tx_entry_data &txs_to_scan, const tx_entry_data &txs_to_reprocess, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, detached_blockchain_data &dbd);
-    void handle_needed_path_data(const uint64_t n_blocks_synced, const crypto::hash &top_block_hash,
+    void handle_needed_path_data(const uint64_t n_blocks_synced,
       const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
       const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries);
     void write_background_sync_wallet(const epee::wipeable_string &wallet_password, const epee::wipeable_string &background_cache_password);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1524,6 +1524,9 @@ private:
     tx_entry_data get_tx_entries(const std::unordered_set<crypto::hash> &txids);
     void sort_scan_tx_entries(std::vector<process_tx_entry_t> &unsorted_tx_entries);
     void process_scan_txs(const tx_entry_data &txs_to_scan, const tx_entry_data &txs_to_reprocess, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, detached_blockchain_data &dbd);
+    void handle_needed_path_data(const uint64_t n_blocks_synced, const uint64_t skip_to_height, const bool skipping_forwards,
+      const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
+      const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries);
     void write_background_sync_wallet(const epee::wipeable_string &wallet_password, const epee::wipeable_string &background_cache_password);
     void process_background_cache_on_open();
     void process_background_cache(const background_sync_data_t &background_sync_data, const hashchain &background_chain, uint64_t last_block_reward, const TreeCacheV1 &tree_cache);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1524,7 +1524,7 @@ private:
     tx_entry_data get_tx_entries(const std::unordered_set<crypto::hash> &txids);
     void sort_scan_tx_entries(std::vector<process_tx_entry_t> &unsorted_tx_entries);
     void process_scan_txs(const tx_entry_data &txs_to_scan, const tx_entry_data &txs_to_reprocess, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, detached_blockchain_data &dbd);
-    void handle_needed_path_data(const uint64_t n_blocks_synced,
+    void handle_needed_path_data(const uint64_t n_blocks_synced, const crypto::hash &top_block_hash,
       const std::unordered_set<crypto::hash> &txids, const std::unordered_set<crypto::hash> &tx_hashes_to_reprocess, const std::unordered_set<crypto::hash> &detached_tx_hashes,
       const std::vector<process_tx_entry_t> &scan_tx_entries, const std::vector<process_tx_entry_t> &rescan_tx_entries);
     void write_background_sync_wallet(const epee::wipeable_string &wallet_password, const epee::wipeable_string &background_cache_password);

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -956,10 +956,10 @@ namespace tools
       }
     };
     //----------------------------------------------------------------------------------------------------
-    struct wont_reprocess_recent_txs_via_untrusted_daemon : public scan_tx_error
+    struct wont_reprocess_txs_via_untrusted_daemon : public scan_tx_error
     {
-      explicit wont_reprocess_recent_txs_via_untrusted_daemon(std::string&& loc)
-        : scan_tx_error(std::move(loc), "The wallet has already seen 1 or more recent transactions than the scanned tx")
+      explicit wont_reprocess_txs_via_untrusted_daemon(std::string&& loc)
+        : scan_tx_error(std::move(loc), "The wallet has already seen 1 or more transactions than the scanned tx")
       {
       }
     };

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -964,6 +964,14 @@ namespace tools
       }
     };
     //----------------------------------------------------------------------------------------------------
+    struct wont_scan_future_tx : public scan_tx_error
+    {
+      explicit wont_scan_future_tx(std::string&& loc)
+        : scan_tx_error(std::move(loc), "Cannot scan a tx at height higher than the wallet's current sync height")
+      {
+      }
+    };
+    //----------------------------------------------------------------------------------------------------
     struct background_sync_error : public wallet_logic_error
     {
     protected:

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3400,7 +3400,7 @@ namespace tools
 
       try {
           m_wallet->scan_tx(txids);
-      }  catch (const tools::error::wont_reprocess_recent_txs_via_untrusted_daemon &e) {
+      }  catch (const tools::error::wont_reprocess_txs_via_untrusted_daemon &e) {
           er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
           er.message = e.what() + std::string(". Either connect to a trusted daemon or rescan the chain.");
           return false;

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -3400,9 +3400,13 @@ namespace tools
 
       try {
           m_wallet->scan_tx(txids);
-      }  catch (const tools::error::wont_reprocess_txs_via_untrusted_daemon &e) {
+      } catch (const tools::error::wont_reprocess_txs_via_untrusted_daemon &e) {
           er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
           er.message = e.what() + std::string(". Either connect to a trusted daemon or rescan the chain.");
+          return false;
+      } catch (const tools::error::wont_scan_future_tx &e) {
+          er.code = WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR;
+          er.message = e.what() + std::string(". Either refresh the wallet, or restore the wallet from the current chain height and then scan.");
           return false;
       } catch (const std::exception &e) {
           handle_rpc_exception(std::current_exception(), er, WALLET_RPC_ERROR_CODE_UNKNOWN_ERROR);

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -120,7 +120,7 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
   const auto &output_pubkey = boost::get<txout_to_key>(spending_out.target).key;
   const rct::key C = rct::zeroCommitVartime(spending_out.amount);
   const fcmp_pp::curve_trees::OutputPair output_pair{.output_pubkey = output_pubkey, .commitment = C};
-  tree_cache.register_output(output_pair, cryptonote::get_last_locked_block_index(blocks[0].miner_tx.unlock_time, 0));
+  tree_cache.register_output(output_pair);
 
   // Build the tree, keeping track of output's path in the tree
   fcmp_pp::curve_trees::TreeCacheV1::CacheStateChange tree_cache_state_change;

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -1069,7 +1069,7 @@ class TransferTest():
     def check_scan_tx(self):
         daemon = Daemon()
 
-        print('FCMP++ Testing scan_tx')
+        print('Testing scan_tx')
 
         # set up sender_wallet
         sender_wallet = self.wallet[0]
@@ -1147,8 +1147,16 @@ class TransferTest():
         expected_receiver_balance += block_header.reward
 
         print('Checking scan_tx on outgoing tx before refresh')
-        sender_wallet.scan_tx([txid])
+        try:
+            # Can't scan future tx
+            sender_wallet.scan_tx([txid])
+            assert False
+        except:
+            pass
+
+        print('Checking scan_tx on outgoing tx after refresh')
         sender_wallet.refresh()
+        sender_wallet.scan_tx([txid])
         res = sender_wallet.get_transfers()
         assert 'pending' not in res or len(res.pending) == 0
         assert 'pool' not in res or len (res.pool) == 0
@@ -1161,12 +1169,6 @@ class TransferTest():
         assert len(tx.destinations) == 1
         assert tx.destinations[0].amount == amount
         assert tx.destinations[0].address == dst['address']
-        assert sender_wallet.get_balance().balance == expected_sender_balance
-
-        print('Checking scan_tx on outgoing tx after refresh')
-        sender_wallet.refresh()
-        sender_wallet.scan_tx([txid])
-        diff_transfers(sender_wallet.get_transfers(), res)
         assert sender_wallet.get_balance().balance == expected_sender_balance
 
         print("Checking scan_tx on outgoing wallet's earliest tx")
@@ -1190,6 +1192,7 @@ class TransferTest():
         for test_type in ["all txs", "incoming first", "duplicates within", "duplicates across"]:
             print(test + ' (' + test_type + ')')
             restore_wallet(sender_wallet, seeds[0], height)
+            sender_wallet.refresh()
             if test_type == "all txs":
                 sender_wallet.scan_tx(all_txs)
             elif test_type == "incoming first":
@@ -1204,7 +1207,6 @@ class TransferTest():
             else:
                 assert True == False
             assert sender_wallet.get_balance().balance == expected_sender_balance
-            sender_wallet.refresh()
             diff_transfers(sender_wallet.get_transfers(), res)
 
         print('Sanity check against outgoing wallet restored at height 0')
@@ -1214,8 +1216,16 @@ class TransferTest():
         assert sender_wallet.get_balance().balance == expected_sender_balance
 
         print('Checking scan_tx on incoming txs before refresh')
-        receiver_wallet.scan_tx([txid, miner_txid])
+        try:
+            # Can't scan future tx
+            receiver_wallet.scan_tx([txid, miner_txid])
+            assert False
+        except:
+            pass
+
+        print('Checking scan_tx on incoming txs after refresh')
         receiver_wallet.refresh()
+        receiver_wallet.scan_tx([txid, miner_txid])
         res = receiver_wallet.get_transfers()
         assert 'pending' not in res or len(res.pending) == 0
         assert 'pool' not in res or len (res.pool) == 0
@@ -1225,12 +1235,6 @@ class TransferTest():
         tx = tx[0]
         assert tx.amount == amount
         assert tx.fee == fee
-        assert receiver_wallet.get_balance().balance == expected_receiver_balance
-
-        print('Checking scan_tx on incoming txs after refresh')
-        receiver_wallet.refresh()
-        receiver_wallet.scan_tx([txid, miner_txid])
-        diff_transfers(receiver_wallet.get_transfers(), res)
         assert receiver_wallet.get_balance().balance == expected_receiver_balance
 
         print("Checking scan_tx on incoming wallet's earliest tx")
@@ -1249,13 +1253,13 @@ class TransferTest():
         if 'out' in res:
             txids = txids + [x.txid for x in res.out]
         restore_wallet(receiver_wallet, seeds[1], height)
+        receiver_wallet.refresh()
         receiver_wallet.scan_tx(txids)
         if 'out' in res:
             for i, out_tx in enumerate(res.out):
                 if 'destinations' in out_tx:
                     del res.out[i]['destinations'] # destinations are not expected after wallet restore
         assert receiver_wallet.get_balance().balance == expected_receiver_balance
-        receiver_wallet.refresh()
         diff_transfers(receiver_wallet.get_transfers(), res)
 
         print('Sanity check against incoming wallet restored at height 0')

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -1353,7 +1353,7 @@ class TransferTest():
     def check_background_sync(self):
         daemon = Daemon()
 
-        print('Testing background sync')
+        print('FCMP++/Carrot Testing background sync')
 
         # Some helper functions
         def stop_with_wrong_inputs(wallet, wallet_password, seed = ''):

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -1353,7 +1353,7 @@ class TransferTest():
     def check_background_sync(self):
         daemon = Daemon()
 
-        print('FCMP++/Carrot Testing background sync')
+        print('Testing background sync')
 
         # Some helper functions
         def stop_with_wrong_inputs(wallet, wallet_password, seed = ''):

--- a/tests/unit_tests/tree_cache.cpp
+++ b/tests/unit_tests/tree_cache.cpp
@@ -67,10 +67,10 @@ TEST(tree_cache, register_output)
     const auto output = outputs[0].output_pair;
 
     // 2. Register output - valid
-    ASSERT_TRUE(tree_cache->register_output(output, last_locked_block_idx));
+    ASSERT_TRUE(tree_cache->register_output(output));
 
     // 3. Register same output again - already registered
-    ASSERT_FALSE(tree_cache->register_output(output, last_locked_block_idx));
+    ASSERT_FALSE(tree_cache->register_output(output));
 
     // 4. Register another output with the same output pubkey as existing, different commitment - valid
     auto output_new_commitment = output;
@@ -79,7 +79,7 @@ TEST(tree_cache, register_output)
     ASSERT_EQ(output_new_commitment.output_pubkey, output.output_pubkey);
     ASSERT_NE(output_new_commitment.commitment, output.commitment);
 
-    ASSERT_TRUE(tree_cache->register_output(output_new_commitment, last_locked_block_idx));
+    ASSERT_TRUE(tree_cache->register_output(output_new_commitment));
 
     // 5. Sync the block of outputs
     crypto::hash block_hash{0x01};
@@ -93,7 +93,7 @@ TEST(tree_cache, register_output)
 
     // 7. Register a new output where we already synced the block output unlocks in - invalid
     const auto &new_output = test::generate_random_outputs(*curve_trees, INIT_LEAVES, 1).front().output_pair;
-    ASSERT_FALSE(tree_cache->register_output(new_output, last_locked_block_idx));
+    ASSERT_FALSE(tree_cache->register_output(new_output));
 }
 //----------------------------------------------------------------------------------------------------------------------
 TEST(tree_cache, sync_block_simple)
@@ -112,7 +112,7 @@ TEST(tree_cache, sync_block_simple)
     const auto output = outputs[0].output_pair;
 
     // 2. Register output
-    ASSERT_TRUE(tree_cache->register_output(output, last_locked_block_idx));
+    ASSERT_TRUE(tree_cache->register_output(output));
 
     // 3. Sync the block of outputs
     crypto::hash block_hash{0x01};
@@ -181,7 +181,7 @@ TEST(tree_cache, sync_n_chunks_of_blocks)
     ASSERT_TRUE(last_locked_block_idx > 0);
 
     // 3. Register output
-    ASSERT_TRUE(tree_cache->register_output(output, last_locked_block_idx));
+    ASSERT_TRUE(tree_cache->register_output(output));
 
     // 4. Sync the chunks of blocks
     for (std::size_t i = 0; i < N_CHUNKS; ++i)
@@ -248,7 +248,7 @@ TEST(tree_cache, sync_n_blocks_register_n_outputs)
 
         // Register the output
         const uint64_t last_locked_block_idx = block_idx + 1;
-        ASSERT_TRUE(tree_cache->register_output(output, last_locked_block_idx));
+        ASSERT_TRUE(tree_cache->register_output(output));
 
         // Sync the outputs generated above
         crypto::hash block_hash;
@@ -327,7 +327,7 @@ TEST(tree_cache, sync_n_blocks_register_one_output)
                 auto output_to_register = i - n_outputs;
                 const auto output = outputs[output_to_register].output_pair;
 
-                ASSERT_TRUE(tree_cache->register_output(output, last_locked_block_idx));
+                ASSERT_TRUE(tree_cache->register_output(output));
 
                 registered = true;
                 registered_output = output;
@@ -414,7 +414,7 @@ TEST(tree_cache, sync_past_max_reorg_depth)
                 auto output_to_register = i - n_outputs;
                 const auto output = outputs[output_to_register].output_pair;
 
-                ASSERT_TRUE(tree_cache->register_output(output, block_idx));
+                ASSERT_TRUE(tree_cache->register_output(output));
 
                 registered = true;
                 registered_output = output;
@@ -553,7 +553,7 @@ TEST(tree_cache, reorg_after_register)
                 auto output_to_register = i - n_outputs;
                 const auto output = outputs[output_to_register].output_pair;
 
-                ASSERT_TRUE(tree_cache->register_output(output, block_idx));
+                ASSERT_TRUE(tree_cache->register_output(output));
 
                 registered = true;
                 registered_output = output;
@@ -648,7 +648,7 @@ TEST(tree_cache, register_after_reorg)
     CHECK_AND_ASSERT_THROW_MES(outputs.size() == 1, "unexpected size of outputs");
 
     const auto output = outputs[0].output_pair;
-    ASSERT_TRUE(tree_cache->register_output(output, block_idx));
+    ASSERT_TRUE(tree_cache->register_output(output));
 
     // Block metadata
     crypto::hash block_hash;
@@ -689,7 +689,7 @@ TEST(tree_cache, serialization)
     const uint64_t block_idx = 0;
     const uint64_t last_locked_block_idx = 1;
     const auto output = outputs[0].output_pair;
-    ASSERT_TRUE(tree_cache->register_output(output, last_locked_block_idx));
+    ASSERT_TRUE(tree_cache->register_output(output));
 
     crypto::hash block_hash{0x01};
     crypto::hash prev_block_hash{};

--- a/tests/unit_tests/tree_cache.cpp
+++ b/tests/unit_tests/tree_cache.cpp
@@ -80,20 +80,6 @@ TEST(tree_cache, register_output)
     ASSERT_NE(output_new_commitment.commitment, output.commitment);
 
     ASSERT_TRUE(tree_cache->register_output(output_new_commitment));
-
-    // 5. Sync the block of outputs
-    crypto::hash block_hash{0x01};
-    crypto::hash prev_block_hash{};
-    tree_cache->sync_block(0, block_hash, prev_block_hash, {{ last_locked_block_idx, outputs }});
-
-    // 6. Sync 1 more block so the outputs unlock and enter the tree
-    prev_block_hash = block_hash;
-    block_hash = crypto::hash{0x02};
-    tree_cache->sync_block(last_locked_block_idx, block_hash, prev_block_hash, {});
-
-    // 7. Register a new output where we already synced the block output unlocks in - invalid
-    const auto &new_output = test::generate_random_outputs(*curve_trees, INIT_LEAVES, 1).front().output_pair;
-    ASSERT_FALSE(tree_cache->register_output(new_output));
 }
 //----------------------------------------------------------------------------------------------------------------------
 TEST(tree_cache, sync_block_simple)


### PR DESCRIPTION
Builds on top of #43

### `scan_tx`

`scan_tx` is a real PITA. Very tricky to get right. There are 2 main situations `scan_tx` **currently** handles:

1) Scanning a **past** tx ("past" relative to the wallet's currently synced height).
2) Scanning a **future** tx, causing the wallet to skip the sync height forwards to that tx.

When scanning a **past** tx in this PR,  the wallet scans the past tx, and rescans all txs after that one already known to the wallet. It then retrieves the *newly* scanned output's paths and syncs them in the cache.

Scanning **future** txs is **deprecated** in this PR, as per discussions below. Instead, we will support faster restore via arbitrary height in a future PR.

### `/get_path_by_global_output_id.bin`

Supports retrieving output paths by global output id.

Additionally supports an optional `as_of_n_blocks` arg in order to guarantee the path returned corresponds to the path when there are n blocks in the chain. Using n blocks versus a block hash is reasonable because the result could only be inconsistent if there is a reorg >= 10 blocks (I reverted the commit using tip block hash). Theoretically we could also support an arg for tip block hash-9 blocks, but that seems overly complicated and the endpoint is reasonably safe as is.

`BlockchainLMDB::get_path_by_global_output_id` is pretty complicated because the tables aren't structured to support a single query for this. A table mapping global output ID to leaf idx would simplify this function, but doesn't seem worth it.

`BlockchainLMDB::get_path_by_global_output_id` gets each outputs' last locked block to determine which block the output should have been added to the tree. Then `find_leaf_idx_by_output_id` traverses the tree over the range of leaf tuples added to the tree when that block entered the chain.
 
____

A TODO I left that I think should be completed before v1:

- Consolidate paths in the `/get_path_by_global_output_id.bin` RPC response (e.g. don't need to re-serve the same root for every path, same for all other path elems).
    - Note: I implemented a `ConsolidatedPaths` struct working on the high FCMP++ limit over here https://github.com/j-berman/monero/blob/84daa22a878544fe2e7536f4b047e872ff8c21cb/src/fcmp_pp/curve_trees.h#L300-L306 

- ~~FCMP++ compatible wallets shouldn't be able to point to non-FCMP++ compatible daemons. FCMP++ wallets would not be able to sync necessary tree data (both for `scan_tx` and upon syncing the wallet from restore height > 0).~~ (update: see #58)
- ~~The new `TreeCache<C1, C2>::force_add_output_path` function shouldn't re-add already known output paths. This will bump the ref count. In the event a force added output path needs to be reorged out of the cache, it may not be because of this.~~ (update: done)