### PR TITLE
fcmp++: fix path_for_proof when a non-root layer has single elem

### DIFF
--- a/src/fcmp_pp/curve_trees.cpp
+++ b/src/fcmp_pp/curve_trees.cpp
@@ -28,6 +28,7 @@
 
 #include "curve_trees.h"
 
+#include "common/container_helpers.h"
 #include "common/threadpool.h"
 #include "profile_tools.h"
 #include "ringct/rctOps.h"

--- a/src/fcmp_pp/curve_trees.cpp
+++ b/src/fcmp_pp/curve_trees.cpp
@@ -1537,12 +1537,12 @@ CurveTrees<Selene, Helios>::PathForProof CurveTrees<Selene, Helios>::path_for_pr
 
     // c2 helios scalars from c1 selene points
     std::vector<std::vector<fcmp_pp::HeliosScalar>> c2_scalar_chunks;
+    c2_scalar_chunks.reserve(n_c2_scalar_chunk_layers);
     for (std::size_t i = 0; i < n_c2_scalar_chunk_layers; ++i)
     {
         const auto &c1_points = path.c1_layers.at(i);
-        c2_scalar_chunks.emplace_back();
-        auto &c2_scalar_layer = c2_scalar_chunks.back();
-        c2_scalar_layer.reserve(c1_points.size());
+        auto &c2_scalar_layer = tools::add_element(c2_scalar_chunks);
+        c2_scalar_layer.reserve(m_c2_width);
         for (const auto &c1_point : c1_points)
             c2_scalar_layer.emplace_back(m_c1->point_to_cycle_scalar(c1_point));
         // Padding with 0's
@@ -1552,12 +1552,12 @@ CurveTrees<Selene, Helios>::PathForProof CurveTrees<Selene, Helios>::path_for_pr
 
     // c1 selene scalars from c2 helios points
     std::vector<std::vector<fcmp_pp::SeleneScalar>> c1_scalar_chunks;
+    c1_scalar_chunks.reserve(n_c1_scalar_chunk_layers);
     for (std::size_t i = 0; i < n_c1_scalar_chunk_layers; ++i)
     {
         const auto &c2_points = path.c2_layers.at(i);
-        c1_scalar_chunks.emplace_back();
-        auto &c1_scalar_layer = c1_scalar_chunks.back();
-        c1_scalar_layer.reserve(c2_points.size());
+        auto &c1_scalar_layer = tools::add_element(c1_scalar_chunks);
+        c1_scalar_layer.reserve(m_c1_width);
         for (const auto &c2_point : c2_points)
             c1_scalar_layer.emplace_back(m_c2->point_to_cycle_scalar(c2_point));
         // Padding with 0's

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -968,6 +968,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         CHECK_AND_ASSERT_THROW_MES(tree_cache.get_output_path(input_pair, fcmp_path),
             "finalize_all_proofs_from_transfer_details: failed to get FCMP path from tree cache");
         CHECK_AND_ASSERT_THROW_MES(!fcmp_path.empty(), "finalize_all_proofs_from_transfer_details: FCMP path is empty");
+        assert(curve_trees.audit_path(fcmp_path, input_pair, tree_cache.get_n_leaf_tuples()));
     }
 
     // assert dimension properties of FCMP paths

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -715,63 +715,20 @@ TEST(fcmp_pp, membership_completeness)
             const auto path = global_tree.get_path_at_leaf_idx(leaf_idx);
             const std::size_t output_idx = leaf_idx % curve_trees->m_c1_width;
 
-            // Collect leaves in this path
-            std::vector<fcmp_pp::OutputBytes> output_bytes;
-            output_bytes.reserve(path.leaves.size());
-            for (const auto &leaf : path.leaves)
-            {
-                output_bytes.push_back({
-                        .O_bytes = (uint8_t *)&leaf.O.bytes,
-                        .I_bytes = (uint8_t *)&leaf.I.bytes,
-                        .C_bytes = (uint8_t *)&leaf.C.bytes,
-                    });
-            }
-            const fcmp_pp::OutputChunk leaves{output_bytes.data(), output_bytes.size()};
+            // Set up rust path
+            const fcmp_pp::curve_trees::OutputPair output_pair{rct::rct2pk(path.leaves[output_idx].O), path.leaves[output_idx].C};
+            const auto output_tuple = fcmp_pp::curve_trees::output_to_tuple(output_pair);
+            const auto path_for_proof = curve_trees->path_for_proof(path, output_tuple);
 
-            // selene scalars from helios points
-            std::vector<std::vector<fcmp_pp::tower_cycle::Selene::Scalar>> selene_scalars;
-            std::vector<fcmp_pp::tower_cycle::Selene::Chunk> selene_chunks;
-            for (const auto &helios_points : path.c2_layers)
-            {
-                // Exclude the root
-                if (helios_points.size() == 1)
-                    break;
-                selene_scalars.emplace_back();
-                auto &selene_layer = selene_scalars.back();
-                selene_layer.reserve(helios_points.size());
-                for (const auto &c2_point : helios_points)
-                    selene_layer.emplace_back(curve_trees->m_c2->point_to_cycle_scalar(c2_point));
-                // Padding with 0's
-                for (std::size_t i = helios_points.size(); i < curve_trees->m_c1_width; ++i)
-                    selene_layer.emplace_back(curve_trees->m_c1->zero_scalar());
-                selene_chunks.emplace_back(fcmp_pp::tower_cycle::Selene::Chunk{selene_layer.data(), selene_layer.size()});
-            }
-            const Selene::ScalarChunks selene_scalar_chunks{selene_chunks.data(), selene_chunks.size()};
+            const auto helios_scalar_chunks = fcmp_pp::tower_cycle::scalar_chunks_to_chunk_vector<fcmp_pp::HeliosT>(
+                path_for_proof.c2_scalar_chunks);
+            const auto selene_scalar_chunks = fcmp_pp::tower_cycle::scalar_chunks_to_chunk_vector<fcmp_pp::SeleneT>(
+                path_for_proof.c1_scalar_chunks);
 
-            // helios scalars from selene points
-            std::vector<std::vector<fcmp_pp::tower_cycle::Helios::Scalar>> helios_scalars;
-            std::vector<fcmp_pp::tower_cycle::Helios::Chunk> helios_chunks;
-            for (const auto &selene_points : path.c1_layers)
-            {
-                // Exclude the root
-                if (selene_points.size() == 1)
-                    break;
-                helios_scalars.emplace_back();
-                auto &helios_layer = helios_scalars.back();
-                helios_layer.reserve(selene_points.size());
-                for (const auto &c1_point : selene_points)
-                    helios_layer.emplace_back(curve_trees->m_c1->point_to_cycle_scalar(c1_point));
-                // Padding with 0's
-                for (std::size_t i = selene_points.size(); i < curve_trees->m_c2_width; ++i)
-                    helios_layer.emplace_back(curve_trees->m_c2->zero_scalar());
-                helios_chunks.emplace_back(fcmp_pp::tower_cycle::Helios::Chunk{helios_layer.data(), helios_layer.size()});
-            }
-            const Helios::ScalarChunks helios_scalar_chunks{helios_chunks.data(), helios_chunks.size()};
-
-            const auto path_rust = fcmp_pp::path_new(leaves,
-                output_idx,
-                helios_scalar_chunks,
-                selene_scalar_chunks);
+            const auto path_rust = fcmp_pp::path_new({path_for_proof.leaves.data(), path_for_proof.leaves.size()},
+                path_for_proof.output_idx,
+                {helios_scalar_chunks.data(), helios_scalar_chunks.size()},
+                {selene_scalar_chunks.data(), selene_scalar_chunks.size()});
 
             // Rerandomize output. We use rerandomize_output_manual() here just to test out the U, V
             // generators and manually constructing a FcmpRerandomizedOutputCompressed. But
@@ -780,10 +737,6 @@ TEST(fcmp_pp, membership_completeness)
             const FcmpRerandomizedOutputCompressed rerandomized_output = rerandomize_output_manual(
                 path.leaves.at(output_idx).O,
                 path.leaves.at(output_idx).C);
-
-            // check the size of our precalculated branch blind cache
-            ASSERT_EQ(helios_scalars.size(), expected_num_selene_branch_blinds);
-            ASSERT_EQ(selene_scalars.size(), expected_num_helios_branch_blinds);
 
             // Calculate output blinds for rerandomized output
             LOG_PRINT_L1("Calculating output blind");

--- a/tests/unit_tests/fcmp_pp.cpp
+++ b/tests/unit_tests/fcmp_pp.cpp
@@ -738,6 +738,10 @@ TEST(fcmp_pp, membership_completeness)
                 path.leaves.at(output_idx).O,
                 path.leaves.at(output_idx).C);
 
+            // check the size of our precalculated branch blind cache
+            ASSERT_EQ(helios_scalar_chunks.size(), expected_num_selene_branch_blinds);
+            ASSERT_EQ(selene_scalar_chunks.size(), expected_num_helios_branch_blinds);
+
             // Calculate output blinds for rerandomized output
             LOG_PRINT_L1("Calculating output blind");
             const SeleneScalar o_blind = fcmp_pp::o_blind(rerandomized_output);


### PR DESCRIPTION
This edge case was triggered by the tree being in a particular state (check the test case for a deeper explanation). Should fix the transfer failure @nahuhh reported [here](https://github.com/seraphis-migration/monero/pull/39#issuecomment-2970520570) (@nahuhh you'd need to include #39 and this PR to transfer successfully).

Credit to @nahuhh for triggering this with solid testing and maintaining a reproducible setup that made it easier to track down and fix.