### PR TITLE
fcmp++: Use 32 byte slices instead of borrowed pointers for OutputBytes

### DIFF
--- a/src/fcmp_pp/curve_trees.cpp
+++ b/src/fcmp_pp/curve_trees.cpp
@@ -1528,13 +1528,7 @@ CurveTrees<Selene, Helios>::PathForProof CurveTrees<Selene, Helios>::path_for_pr
     {
         output_bytes.reserve(path.leaves.size());
         for (const auto &leaf : path.leaves)
-        {
-            output_bytes.push_back({
-                    .O_bytes = (uint8_t *)&leaf.O.bytes,
-                    .I_bytes = (uint8_t *)&leaf.I.bytes,
-                    .C_bytes = (uint8_t *)&leaf.C.bytes,
-                });
-        }
+            output_bytes.push_back(leaf.to_output_bytes());
     }
 
     const size_t n_tree_layers = path.c1_layers.size() + path.c2_layers.size();

--- a/src/fcmp_pp/curve_trees.h
+++ b/src/fcmp_pp/curve_trees.h
@@ -167,7 +167,19 @@ struct OutputTuple final
     rct::key I;
     rct::key C;
 
-    const OutputBytes to_output_bytes() const { return OutputBytes { O.bytes, I.bytes, C.bytes }; }
+    const OutputBytes to_output_bytes() const
+    {
+        OutputBytes out;
+        memcpy(out.O_bytes, O.bytes, sizeof(O.bytes));
+        memcpy(out.I_bytes, I.bytes, sizeof(I.bytes));
+        memcpy(out.C_bytes, C.bytes, sizeof(C.bytes));
+        static_assert(sizeof(out.O_bytes) == sizeof(O.bytes) &&
+            sizeof(out.I_bytes) == sizeof(I.bytes) &&
+            sizeof(out.C_bytes) == sizeof(C.bytes),
+            "unexpected size mismatch on O, I, C");
+        static_assert(sizeof(OutputBytes) == (3 * sizeof(rct::key)), "unexpected size of OutputBytes");
+        return out;
+    }
 };
 
 // Struct composed of ec elems needed to get a full-fledged leaf tuple

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -70,10 +70,11 @@ struct SelenePoint {
 
 // ----- End deps C bindings -----
 
-struct OutputBytes {
-  const uint8_t *O_bytes;
-  const uint8_t *I_bytes;
-  const uint8_t *C_bytes;
+struct OutputBytes
+{
+  uint8_t O_bytes[32];
+  uint8_t I_bytes[32];
+  uint8_t C_bytes[32];
 };
 
 struct FcmpInputCompressed

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -59,11 +59,18 @@ FcmpRerandomizedOutputCompressed rerandomize_output(const crypto::public_key &on
     crypto::ec_point I;
     crypto::derive_key_image_generator(onetime_address, I);
 
-    return rerandomize_output(OutputBytes{
-        .O_bytes = to_bytes(onetime_address),
-        .I_bytes = to_bytes(I),
-        .C_bytes = to_bytes(amount_commitment)
-    });
+    OutputBytes output_bytes;
+    memcpy(output_bytes.O_bytes, onetime_address.data, sizeof(onetime_address));
+    memcpy(output_bytes.I_bytes, I.data, sizeof(I));
+    memcpy(output_bytes.C_bytes, amount_commitment.data, sizeof(amount_commitment));
+
+    static_assert(sizeof(output_bytes.O_bytes) == sizeof(onetime_address) &&
+        sizeof(output_bytes.I_bytes) == sizeof(I) &&
+        sizeof(output_bytes.C_bytes) == sizeof(amount_commitment),
+        "unexpected size mismatch OutputTuple <> data types");
+    static_assert(sizeof(OutputBytes) == (3 * 32), "unexpected size of OutputBytes");
+
+    return rerandomize_output(output_bytes);
 }
 //----------------------------------------------------------------------------------------------------------------------
 FcmpInputCompressed calculate_fcmp_input_for_rerandomizations(const crypto::public_key &onetime_address,


### PR DESCRIPTION
Stronger type safety and avoids pointers where unnecessary