### PR TITLE
fcmp++: store indexes for outputs in tree instead of complete `OutputContext`, saving 65 bytes/output

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -481,7 +481,9 @@ private:
 
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const;
 
-  uint64_t find_leaf_idx_by_output_id(uint64_t output_id, uint64_t leaf_idx_start, uint64_t leaf_idx_end) const;
+  fcmp_pp::curve_trees::OutputContext get_output_context_by_output_id(uint64_t output_id) const;
+
+  uint64_t find_leaf_idx_by_output_id_bounded_search(uint64_t output_id, uint64_t leaf_idx_start, uint64_t leaf_idx_end) const;
 
   // Hard fork
   virtual void set_hard_fork_version(uint64_t height, uint8_t version);

--- a/src/blockchain_db/lmdb/db_lmdb.h
+++ b/src/blockchain_db/lmdb/db_lmdb.h
@@ -481,7 +481,7 @@ private:
 
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const;
 
-  fcmp_pp::curve_trees::OutputContext get_output_context_by_output_id(uint64_t output_id) const;
+  std::vector<fcmp_pp::curve_trees::OutputContext> get_output_context_by_output_id(const std::vector<uint64_t> &output_ids) const;
 
   uint64_t find_leaf_idx_by_output_id_bounded_search(uint64_t output_id, uint64_t leaf_idx_start, uint64_t leaf_idx_end) const;
 

--- a/tests/unit_tests/curve_trees.cpp
+++ b/tests/unit_tests/curve_trees.cpp
@@ -1067,7 +1067,7 @@ TEST(curve_trees, path_for_proof_inner_layer_single_elem)
     const uint64_t N_LEAF_TUPLES = 52000;
     const auto curve_trees = fcmp_pp::curve_trees::curve_trees_v1();
     CurveTreesGlobalTree global_tree(*curve_trees);
-    const auto init_outputs = test::generate_random_outputs(*curve_trees, 0, N_LEAF_TUPLES);
+    const auto init_outputs = test::generate_random_outputs(0, N_LEAF_TUPLES);
     ASSERT_TRUE(global_tree.grow_tree(0, init_outputs.size(), init_outputs));
 
     const auto path = global_tree.get_path_at_leaf_idx(init_outputs.size() - 1);

--- a/tests/unit_tests/curve_trees.h
+++ b/tests/unit_tests/curve_trees.h
@@ -41,8 +41,7 @@ using CurveTreesV1 = fcmp_pp::curve_trees::CurveTreesV1;
 //----------------------------------------------------------------------------------------------------------------------
 namespace test
 {
-const std::vector<fcmp_pp::curve_trees::OutputContext> generate_random_outputs(const CurveTreesV1 &curve_trees,
-    const std::size_t old_n_leaf_tuples,
+const std::vector<fcmp_pp::curve_trees::OutputContext> generate_random_outputs(const std::size_t old_n_leaf_tuples,
     const std::size_t new_n_leaf_tuples);
 
 std::shared_ptr<CurveTreesV1> init_curve_trees_test(const std::size_t helios_chunk_width,

--- a/tests/unit_tests/tree_cache.cpp
+++ b/tests/unit_tests/tree_cache.cpp
@@ -59,7 +59,7 @@ TEST(tree_cache, register_output)
     auto tree_cache = new fcmp_pp::curve_trees::TreeCache<Selene, Helios>(curve_trees);
 
     const std::size_t INIT_LEAVES = 10;
-    auto outputs = test::generate_random_outputs(*curve_trees, 0, INIT_LEAVES);
+    auto outputs = test::generate_random_outputs(0, INIT_LEAVES);
     CHECK_AND_ASSERT_THROW_MES(outputs.size() == INIT_LEAVES, "unexpected size of outputs");
 
     // Mock values
@@ -90,7 +90,7 @@ TEST(tree_cache, sync_block_simple)
     auto curve_trees = fcmp_pp::curve_trees::curve_trees_v1();
     auto tree_cache = new fcmp_pp::curve_trees::TreeCache<Selene, Helios>(curve_trees);
 
-    auto outputs = test::generate_random_outputs(*curve_trees, 0, INIT_LEAVES);
+    auto outputs = test::generate_random_outputs(0, INIT_LEAVES);
     CHECK_AND_ASSERT_THROW_MES(outputs.size() == INIT_LEAVES, "unexpected size of outputs");
 
     // Mock values
@@ -148,7 +148,7 @@ TEST(tree_cache, sync_n_chunks_of_blocks)
         std::vector<fcmp_pp::curve_trees::OutsByLastLockedBlock> outs;
         for (std::size_t j = 0; j < N_BLOCKS_PER_CHUNK; ++j)
         {
-            auto outputs = test::generate_random_outputs(*curve_trees, leaf_count, INIT_LEAVES);
+            auto outputs = test::generate_random_outputs(leaf_count, INIT_LEAVES);
             leaf_count += INIT_LEAVES;
             const auto last_locked_block = 1 + i * N_BLOCKS_PER_CHUNK + j;
 
@@ -224,7 +224,7 @@ TEST(tree_cache, sync_n_blocks_register_n_outputs)
         LOG_PRINT_L1("Syncing "<< sync_n_outputs << " outputs in block " << (block_idx+1)
             << " (" << n_unlocked_outputs << " unlocked / " << n_leaves_needed << " outputs)");
 
-        auto outputs = test::generate_random_outputs(*curve_trees, n_outputs, sync_n_outputs);
+        auto outputs = test::generate_random_outputs(n_outputs, sync_n_outputs);
         CHECK_AND_ASSERT_THROW_MES(outputs.size() == sync_n_outputs, "unexpected size of outputs");
 
         // Pick an output to register
@@ -299,7 +299,7 @@ TEST(tree_cache, sync_n_blocks_register_one_output)
             MDEBUG("Syncing "<< sync_n_outputs << " outputs in block " << (block_idx+1)
                 << " (" << n_unlocked_outputs << " unlocked / " << n_leaves_needed << " outputs)");
 
-            auto outputs = test::generate_random_outputs(*curve_trees, n_outputs, sync_n_outputs);
+            auto outputs = test::generate_random_outputs(n_outputs, sync_n_outputs);
             CHECK_AND_ASSERT_THROW_MES(outputs.size() == sync_n_outputs, "unexpected size of outputs");
 
             // Check if this chunk includes the output we're supposed to register
@@ -387,7 +387,7 @@ TEST(tree_cache, sync_past_max_reorg_depth)
             const auto sync_n_outputs = (block_idx % max_outputs_per_block) + 1;
             MDEBUG("Syncing "<< sync_n_outputs << " outputs in block " << block_idx);
 
-            auto outputs = test::generate_random_outputs(*curve_trees, n_outputs, sync_n_outputs);
+            auto outputs = test::generate_random_outputs(n_outputs, sync_n_outputs);
             CHECK_AND_ASSERT_THROW_MES(outputs.size() == sync_n_outputs, "unexpected size of outputs");
 
             // Check if this chunk includes the output we're supposed to register
@@ -499,7 +499,7 @@ TEST(tree_cache, reorg_after_register)
                     MDEBUG("Re-syncing "<< sync_n_outputs << " outputs in block " << (cur_block_idx+1)
                         << " (" << (n_outputs_unlocked(cur_block_idx)) << " unlocked / " << n_leaves_needed << " outputs)");
 
-                    auto outputs = test::generate_random_outputs(*curve_trees, n_outputs_unlocked(cur_block_idx+1), sync_n_outputs);
+                    auto outputs = test::generate_random_outputs(n_outputs_unlocked(cur_block_idx+1), sync_n_outputs);
                     CHECK_AND_ASSERT_THROW_MES(outputs.size() == sync_n_outputs, "unexpected size of outputs");
 
                     // Sync the outputs generated above
@@ -523,7 +523,7 @@ TEST(tree_cache, reorg_after_register)
             MDEBUG("Syncing "<< sync_n_outputs << " outputs in block " << (block_idx+1)
                 << " (" << n_unlocked_outputs << " unlocked / " << n_leaves_needed << " outputs)");
 
-            auto outputs = test::generate_random_outputs(*curve_trees, n_outputs, sync_n_outputs);
+            auto outputs = test::generate_random_outputs(n_outputs, sync_n_outputs);
             CHECK_AND_ASSERT_THROW_MES(outputs.size() == sync_n_outputs, "unexpected size of outputs");
 
             // Block metadata
@@ -595,7 +595,7 @@ TEST(tree_cache, register_after_reorg)
         LOG_PRINT_L1("Syncing "<< sync_n_outputs << " outputs in block " << (block_idx+1)
             << " (" << n_unlocked_outputs << " unlocked / " << n_leaves_needed << " outputs)");
 
-        auto outputs = test::generate_random_outputs(*curve_trees, n_outputs, sync_n_outputs);
+        auto outputs = test::generate_random_outputs(n_outputs, sync_n_outputs);
         CHECK_AND_ASSERT_THROW_MES(outputs.size() == sync_n_outputs, "unexpected size of outputs");
 
         // Block metadata
@@ -630,7 +630,7 @@ TEST(tree_cache, register_after_reorg)
 
     // Register output and sync it in the next block
     LOG_PRINT_L1("Registering 1 output and syncing in next block");
-    auto outputs = test::generate_random_outputs(*curve_trees, n_unlocked_outputs, 1);
+    auto outputs = test::generate_random_outputs(n_unlocked_outputs, 1);
     CHECK_AND_ASSERT_THROW_MES(outputs.size() == 1, "unexpected size of outputs");
 
     const auto output = outputs[0].output_pair;
@@ -669,7 +669,7 @@ TEST(tree_cache, serialization)
     static const std::size_t INIT_LEAVES = 10;
     auto curve_trees = fcmp_pp::curve_trees::curve_trees_v1();
     auto tree_cache = new fcmp_pp::curve_trees::TreeCache<Selene, Helios>(curve_trees);
-    auto outputs = test::generate_random_outputs(*curve_trees, 0, INIT_LEAVES);
+    auto outputs = test::generate_random_outputs(0, INIT_LEAVES);
     CHECK_AND_ASSERT_THROW_MES(outputs.size() == INIT_LEAVES, "unexpected size of outputs");
 
     const uint64_t block_idx = 0;


### PR DESCRIPTION
Builds on #49 

For every leaf in the tree, stores `{leaf_idx,output_id}` (16 bytes) instead of `{leaf_idx,output_context}` (81 bytes), saving 65 bytes per leaf. We now read the db for the complete `output_context` when it's needed, using the `output_id` (forward sync does not need to read the `leaves` table for `OutputContext`s).

This saves ~10 GB for both pruned and unpruned nodes for the current tree (150mn outputs * 65 bytes).

Note to @nahuhh: existing testnet nodes cannot run this code, they would break. However, an updated node running this code should be able to sync from scratch pointing to a testnet node not running this code.

### Some comments on the code

I had to modify the curve trees unit test's `grow_tree_db` function to add tx output data to the db, so that it can be read back from the db during `trim_tree` and `audit_tree`.

I removed the `trim_tree_then_regrow` unit test because it broke, and I figure fixing the test is more involved than the test is worth (e.g. moving `BlockchainLMDB::trim_block()` out of `BlockchainLMDB::remove_block()` is probably not ideal), and the `_test_reorg_handling` functional test also tests trimming then regrowing.

Note that`get_path_by_global_output_id` reads for output data twice: once in beginning of its fn, and then again at the end inside `get_path`.

I figure this is ok for now because:
1) `get_path_by_global_output_id` is not a commonly called fn, used only to serve the `COMMAND_RPC_GET_PATH_BY_GLOBAL_OUTPUT_ID_BIN` endpoint.
2) The duplication should not be a significant slowdown on those operations even if read from disk.
3) LMDB takes advantage of the OS buffer cache ([1](https://www.symas.com/mdb), [2](https://tldp.org/LDP/sag/html/buffer-cache.html)), which means the duplicate reads may end up being read from memory anyway.

I think this fairly simple PR is a solid win that makes sense to take as is for now.
