### PR TITLE
ringct: treat n_inputs as 0 when calculating FCMP++ signable_tx_hash

### DIFF
--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -611,9 +611,9 @@ namespace rct {
       std::stringstream ss;
       binary_archive<true> ba(ss);
       const size_t inputs = !rct::is_rct_simple(rv.type) ? rv.mixRing.at(0).size()
-        : rct::is_rct_fcmp(rv.type) ? rv.p.pseudoOuts.size()
+        : rct::is_rct_fcmp(rv.type) ? 0
         : rv.mixRing.size();
-      CHECK_AND_ASSERT_THROW_MES(inputs > 0, "Empty pseudoOuts");
+      CHECK_AND_ASSERT_THROW_MES(rct::is_rct_fcmp(rv.type) || inputs > 0, "Empty pseudoOuts");
       const size_t outputs = rv.ecdhInfo.size();
       key prehash;
       CHECK_AND_ASSERT_THROW_MES(const_cast<rctSig&>(rv).serialize_rctsig_base(ba, inputs, outputs),


### PR DESCRIPTION
The number of inputs does not affect FCMP++ `rctSigBase` serialization and is not used elsewhere, except when passed to the `mlsag_prehash` device method. The default device ignores this parameter. Setting this variable to 0 for FCMP++ means that resizing `pseudoOuts` before calling `get_pre_mlsag_hash` isn't needed.