### PR TITLE
carrot+fcmp: unbreak wallet2::create_transactions_*()

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1631,6 +1631,8 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
         if (checkBackgroundSync("cannot create transactions"))
             break;
 
+        std::vector<uint8_t> extra;
+        std::string extra_nonce;
         vector<cryptonote::tx_destination_entry> dsts;
         if (!amount && dst_addr.size() > 1) {
             setStatusError(tr("Sending all requires one destination address"));
@@ -1641,11 +1643,15 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
             break;
         }
         if (!payment_id.empty()) {
-            setStatusError(tr("Long payment IDs are obsolete and no longer supported"));
-            break;
+            crypto::hash payment_id_long;
+            if (tools::wallet2::parse_long_payment_id(payment_id, payment_id_long)) {
+                cryptonote::set_payment_id_to_tx_extra_nonce(extra_nonce, payment_id_long);
+            } else {
+                setStatusError(tr("payment id has invalid format, expected 64 character hex string: ") + payment_id);
+                break;
+            }
         }
         bool error = false;
-        std::pair<crypto::hash8, std::size_t> payment_id{crypto::null_hash8, 0};
         for (size_t i = 0; i < dst_addr.size() && !error; i++) {
             if(!cryptonote::get_account_address_from_str(info, m_wallet->nettype(), dst_addr[i])) {
                 // TODO: copy-paste 'if treating as an address fails, try as url' from simplewallet.cpp:1982
@@ -1654,12 +1660,12 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
                 break;
             }
             if (info.has_payment_id) {
-                if (payment_id.first != crypto::null_hash8) {
+                if (!extra_nonce.empty()) {
                     setStatusError(tr("a single transaction cannot use more than one payment id"));
                     error = true;
                     break;
                 }
-                payment_id = {info.payment_id, dsts.size()};
+                set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, info.payment_id);
             }
 
             if (amount) {
@@ -1680,21 +1686,22 @@ PendingTransaction *WalletImpl::createTransactionMultDest(const std::vector<stri
         if (error) {
             break;
         }
+        if (!extra_nonce.empty() && !add_extra_nonce_to_tx_extra(extra, extra_nonce)) {
+            setStatusError(tr("failed to set up payment id, though it was decoded correctly"));
+            break;
+        }
         try {
             size_t fake_outs_count = mixin_count > 0 ? mixin_count : m_wallet->default_mixin();
             fake_outs_count = m_wallet->adjust_mixin(mixin_count);
 
             if (amount) {
-                transaction->m_pending_tx = m_wallet->create_transactions_2(dsts, payment_id, fake_outs_count,
+                transaction->m_pending_tx = m_wallet->create_transactions_2(dsts, fake_outs_count,
                                                                             adjusted_priority,
-                                                                            /*extra=*/{},
-                                                                            subaddr_account, subaddr_indices);
+                                                                            extra, subaddr_account, subaddr_indices);
             } else {
-                transaction->m_pending_tx = m_wallet->create_transactions_all(0, info.address, info.is_subaddress, 1,
-                                                                              payment_id.first, fake_outs_count,
+                transaction->m_pending_tx = m_wallet->create_transactions_all(0, info.address, info.is_subaddress, 1, fake_outs_count,
                                                                               adjusted_priority,
-                                                                              /*extra=*/{}, subaddr_account,
-                                                                              subaddr_indices);
+                                                                              extra, subaddr_account, subaddr_indices);
             }
             pendingTxPostProcess(transaction);
 

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -52,7 +52,6 @@
 #include "fcmp_pp/tower_cycle.h"
 #include "ringct/bulletproofs_plus.h"
 #include "ringct/rctSigs.h"
-#include "wallet2.h"
 
 //third party headers
 
@@ -96,6 +95,27 @@ static bool is_transfer_usable_for_input_selection(const wallet2_basic::transfer
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
+static crypto::hash8 get_up_to_one_short_payment_id(const std::vector<std::uint8_t> &extra)
+{
+    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+    CHECK_AND_ASSERT_THROW_MES(cryptonote::parse_tx_extra(extra, tx_extra_fields),
+        "failed to completely parse tx_extra");
+
+    cryptonote::tx_extra_nonce extra_nonce;
+    if (!cryptonote::find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+        return crypto::null_hash8;
+
+    crypto::hash8 short_pid = crypto::null_hash8;
+    CHECK_AND_ASSERT_THROW_MES(cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, short_pid),
+        "nonce in tx_extra contains something other than a short payment ID");
+
+    CHECK_AND_ASSERT_THROW_MES(!cryptonote::find_tx_extra_field_by_type(tx_extra_fields, extra_nonce, 1),
+        "multiple tx_extra nonces found");
+
+    return short_pid;
+}
+//-------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------------------------
 static bool build_payment_proposals(std::vector<carrot::CarrotPaymentProposalV1> &normal_payment_proposals_inout,
     std::vector<carrot::CarrotPaymentProposalVerifiableSelfSendV1> &selfsend_payment_proposals_inout,
     const cryptonote::tx_destination_entry &tx_dest_entry,
@@ -124,7 +144,8 @@ static bool build_payment_proposals(std::vector<carrot::CarrotPaymentProposalV1>
             .address_spend_pubkey = tx_dest_entry.addr.m_spend_public_key,
             .address_view_pubkey = tx_dest_entry.addr.m_view_public_key,
             .is_subaddress = tx_dest_entry.is_subaddress,
-            .payment_id = carrot::raw_byte_convert<carrot::payment_id_t>(payment_id)
+            .payment_id = tx_dest_entry.is_integrated
+                ? carrot::raw_byte_convert<carrot::payment_id_t>(payment_id) : carrot::null_payment_id
         };
 
         normal_payment_proposals_inout.push_back(carrot::CarrotPaymentProposalV1{
@@ -148,43 +169,17 @@ static void build_payment_proposals_sweep(std::vector<carrot::CarrotPaymentPropo
 {
     for (std::size_t i = 0; i < n_dests; ++i)
     {
+        cryptonote::tx_destination_entry dst(0, address, is_subaddress);
+        dst.is_integrated = i == 0 && payment_id != crypto::null_hash8;
         build_payment_proposals(normal_payment_proposals_inout,
             selfsend_payment_proposals_inout,
-            cryptonote::tx_destination_entry(0, address, is_subaddress),
-            i ? crypto::null_hash8 : payment_id,
+            dst,
+            payment_id,
             subaddress_map);
     }
 
     if (selfsend_payment_proposals_inout.size() == 2 && normal_payment_proposals_inout.empty())
         selfsend_payment_proposals_inout.back().proposal.enote_type = carrot::CarrotEnoteType::CHANGE;
-}
-//-------------------------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------------------------
-static wallet2_basic::transfer_container get_transfers(const wallet2 &w)
-{
-    wallet2_basic::transfer_container transfers;
-    w.get_transfers(transfers);
-    return transfers;
-}
-//-------------------------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------------------------
-static rct::xmr_amount get_fee_per_weight_from_priority(const fee_priority priority, wallet2 &w)
-{
-    const bool use_per_byte_fee = w.use_fork_rules(HF_VERSION_PER_BYTE_FEE, 0);
-    CHECK_AND_ASSERT_THROW_MES(use_per_byte_fee, "not using per-byte base fee");
-
-    const rct::xmr_amount fee_per_weight = w.get_base_fee(priority);
-    MDEBUG("fee_per_weight = " << fee_per_weight << ", from priority = " << priority);
-
-    return fee_per_weight;
-}
-//-------------------------------------------------------------------------------------------------------------------
-//-------------------------------------------------------------------------------------------------------------------
-static std::uint64_t get_top_block_index(const wallet2 &w)
-{
-    const std::uint64_t current_chain_height = w.get_blockchain_current_height();
-    CHECK_AND_ASSERT_THROW_MES(current_chain_height > 0, "chain height is 0; there's no top block");
-    return current_chain_height - 1;
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
@@ -320,9 +315,8 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const wallet2_basic::transfer_container &transfers,
     const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
     const std::vector<cryptonote::tx_destination_entry> &dsts,
-    const std::pair<crypto::hash8, std::size_t> &payment_id,
     const rct::xmr_amount fee_per_weight,
-    const std::vector<uint8_t> &extra,
+    std::vector<uint8_t> extra,
     const std::uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
     const rct::xmr_amount ignore_above,
@@ -332,6 +326,11 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
 {
     CARROT_CHECK_AND_THROW(subtract_fee_from_outputs.empty() || *subtract_fee_from_outputs.crbegin() < dsts.size(),
         carrot::component_out_of_order, "subtract_fee_from_outputs index is out of bounds of destinations list");
+
+    // extract short payment ID
+    const crypto::hash8 payment_id = get_up_to_one_short_payment_id(extra);
+    CHECK_AND_ASSERT_THROW_MES(cryptonote::remove_field_from_tx_extra(extra, typeid(cryptonote::tx_extra_nonce)),
+        "failed to remove tx extra nonces from `extra` construction parameter");
 
     // build payment proposals and subtractable info
     std::vector<carrot::CarrotPaymentProposalV1> normal_payment_proposals;
@@ -344,7 +343,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
         const bool is_selfsend = build_payment_proposals(normal_payment_proposals,
             selfsend_payment_proposals,
             dst,
-            i == payment_id.second ? payment_id.first : crypto::null_hash8,
+            payment_id,
             subaddress_map);
         if (subtract_fee_from_outputs.count(i))
         {
@@ -391,31 +390,6 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     return tx_proposals;
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_transfer(
-    wallet2 &w,
-    const std::vector<cryptonote::tx_destination_entry> &dsts,
-    const std::pair<crypto::hash8, std::size_t> &payment_id,
-    const fee_priority priority,
-    const std::vector<uint8_t> &extra,
-    const std::uint32_t subaddr_account,
-    const std::set<uint32_t> &subaddr_indices,
-    const std::set<std::uint32_t> &subtract_fee_from_outputs)
-{
-    return make_carrot_transaction_proposals_wallet2_transfer(
-        get_transfers(w),
-        w.get_subaddress_map_ref(),
-        dsts,
-        payment_id,
-        get_fee_per_weight_from_priority(priority, w),
-        extra,
-        subaddr_account,
-        subaddr_indices,
-        w.ignore_outputs_above(),
-        w.ignore_outputs_below(),
-        subtract_fee_from_outputs,
-        get_top_block_index(w));
-}
-//-------------------------------------------------------------------------------------------------------------------
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
     const wallet2_basic::transfer_container &transfers,
     const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
@@ -423,11 +397,15 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const cryptonote::account_public_address &address,
     const bool is_subaddress,
     const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
     const rct::xmr_amount fee_per_weight,
-    const std::vector<uint8_t> &extra,
+    std::vector<uint8_t> extra,
     const std::uint64_t top_block_index)
 {
+    // extract short payment ID
+    const crypto::hash8 payment_id = get_up_to_one_short_payment_id(extra);
+    CHECK_AND_ASSERT_THROW_MES(cryptonote::remove_field_from_tx_extra(extra, typeid(cryptonote::tx_extra_nonce)),
+        "failed to remove tx extra nonces from `extra` construction parameter");
+
     // build payment proposals
     std::vector<carrot::CarrotPaymentProposalV1> normal_payment_proposals;
     std::vector<carrot::CarrotPaymentProposalVerifiableSelfSendV1> selfsend_payment_proposals;
@@ -485,29 +463,6 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     return tx_proposals;
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
-    wallet2 &w,
-    const std::vector<crypto::key_image> &input_key_images,
-    const cryptonote::account_public_address &address,
-    const bool is_subaddress,
-    const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
-    const fee_priority priority,
-    const std::vector<uint8_t> &extra)
-{
-    return make_carrot_transaction_proposals_wallet2_sweep(
-        get_transfers(w),
-        w.get_subaddress_map_ref(),
-        input_key_images,
-        address,
-        is_subaddress,
-        n_dests_per_tx,
-        payment_id,
-        get_fee_per_weight_from_priority(priority, w),
-        extra,
-        get_top_block_index(w));
-}
-//-------------------------------------------------------------------------------------------------------------------
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep_all(
     const wallet2_basic::transfer_container &transfers,
     const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
@@ -515,13 +470,17 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const cryptonote::account_public_address &address,
     const bool is_subaddress,
     const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
     const rct::xmr_amount fee_per_weight,
-    const std::vector<uint8_t> &extra,
+    std::vector<uint8_t> extra,
     const std::uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
     const std::uint64_t top_block_index)
 {
+    // extract short payment ID
+    const crypto::hash8 payment_id = get_up_to_one_short_payment_id(extra);
+    CHECK_AND_ASSERT_THROW_MES(cryptonote::remove_field_from_tx_extra(extra, typeid(cryptonote::tx_extra_nonce)),
+        "failed to remove tx extra nonces from `extra` construction parameter");
+
     // build payment proposals
     std::vector<carrot::CarrotPaymentProposalV1> normal_payment_proposals;
     std::vector<carrot::CarrotPaymentProposalVerifiableSelfSendV1> selfsend_payment_proposals;
@@ -564,33 +523,6 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
         /*ignore_dust=*/true,
         tx_proposals);
     return tx_proposals;
-}
-//-------------------------------------------------------------------------------------------------------------------
-std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep_all(
-    wallet2 &w,
-    const rct::xmr_amount only_below,
-    const cryptonote::account_public_address &address,
-    const bool is_subaddress,
-    const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
-    const fee_priority priority,
-    const std::vector<uint8_t> &extra,
-    const std::uint32_t subaddr_account,
-    const std::set<uint32_t> &subaddr_indices)
-{
-    return make_carrot_transaction_proposals_wallet2_sweep_all(
-        get_transfers(w),
-        w.get_subaddress_map_ref(),
-        only_below,
-        address,
-        is_subaddress,
-        n_dests_per_tx,
-        payment_id,
-        get_fee_per_weight_from_priority(priority, w),
-        extra,
-        subaddr_account,
-        subaddr_indices,
-        get_top_block_index(w));
 }
 //-------------------------------------------------------------------------------------------------------------------
 carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(const wallet2_basic::transfer_details &td)
@@ -1306,68 +1238,6 @@ pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
         acc_keys);
 
     return ptx;
-}
-//-------------------------------------------------------------------------------------------------------------------
-pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
-    const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const wallet2 &w)
-{
-    return finalize_all_proofs_from_transfer_details_as_pending_tx(
-        tx_proposal,
-        get_transfers(w),
-        w.get_tree_cache_ref(),
-        w.get_curve_trees_ref(),
-        w.get_account().get_keys());
-}
-//-------------------------------------------------------------------------------------------------------------------
-std::size_t get_num_payment_id_fields_in_tx_extra(const std::vector<std::uint8_t> &tx_extra)
-{
-    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-    cryptonote::parse_tx_extra(tx_extra, tx_extra_fields); // partial parse is fine
-
-    std::size_t n_pid_fields = 0;
-    for (const cryptonote::tx_extra_field &tx_extra_field : tx_extra_fields)
-    {
-        const cryptonote::tx_extra_nonce *tx_nonce = boost::strict_get<cryptonote::tx_extra_nonce>(&tx_extra_field);
-        if (nullptr == tx_nonce || tx_nonce->nonce.empty())
-            continue;
-
-        const char &nonce_prefix = tx_nonce->nonce.at(0);
-        if (nonce_prefix == TX_EXTRA_NONCE_ENCRYPTED_PAYMENT_ID || nonce_prefix == TX_EXTRA_NONCE_PAYMENT_ID)
-            ++n_pid_fields;
-    }
-
-    return n_pid_fields;
-}
-//-------------------------------------------------------------------------------------------------------------------
-std::size_t get_num_ephemeral_tx_pubkey_fields_in_tx_extra(const std::vector<std::uint8_t> &tx_extra)
-{
-    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-    cryptonote::parse_tx_extra(tx_extra, tx_extra_fields); // partial parse is fine
-
-    std::size_t n_ephem_fields = 0;
-    for (const cryptonote::tx_extra_field &tx_extra_field : tx_extra_fields)
-    {
-        const auto &field_type = tx_extra_field.type();
-        const bool is_tx_pubkey_field = field_type == typeid(cryptonote::tx_extra_pub_key)
-                || field_type == typeid(cryptonote::tx_extra_additional_pub_keys);
-        n_ephem_fields += is_tx_pubkey_field;
-    }
-
-    return n_ephem_fields;
-}
-//-------------------------------------------------------------------------------------------------------------------
-void insert_payment_id_into_legacy_extra_unencrypted(const crypto::hash8 &payment_id,
-    std::vector<std::uint8_t> &extra_inout)
-{
-    CARROT_CHECK_AND_THROW(get_num_payment_id_fields_in_tx_extra(extra_inout) == 0,
-        std::logic_error, "tx_extra already contains a payment ID field");
-
-    cryptonote::blobdata extra_nonce;
-    cryptonote::set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, payment_id);
-
-    CARROT_CHECK_AND_THROW(cryptonote::add_extra_nonce_to_tx_extra(extra_inout, extra_nonce),
-        std::logic_error, "failed to insert extra tx nonce");
 }
 //-------------------------------------------------------------------------------------------------------------------
 } //namespace wallet

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -43,8 +43,6 @@
 
 namespace tools
 {
-class wallet2;
-
 namespace wallet
 {
 struct multisig_sig
@@ -135,24 +133,14 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const wallet2_basic::transfer_container &transfers,
     const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
     const std::vector<cryptonote::tx_destination_entry> &dsts,
-    const std::pair<crypto::hash8, std::size_t> &payment_id,
     const rct::xmr_amount fee_per_weight,
-    const std::vector<uint8_t> &extra,
+    std::vector<uint8_t> extra,
     const uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
     const rct::xmr_amount ignore_above,
     const rct::xmr_amount ignore_below,
     std::set<std::uint32_t> subtract_fee_from_outputs,
     const std::uint64_t top_block_index);
-std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_transfer(
-    wallet2 &w,
-    const std::vector<cryptonote::tx_destination_entry> &dsts,
-    const std::pair<crypto::hash8, std::size_t> &payment_id,
-    const tools::fee_priority priority,
-    const std::vector<uint8_t> &extra,
-    const std::uint32_t subaddr_account,
-    const std::set<uint32_t> &subaddr_indices,
-    const std::set<std::uint32_t> &subtract_fee_from_outputs);
 
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
     const wallet2_basic::transfer_container &transfers,
@@ -161,19 +149,9 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const cryptonote::account_public_address &address,
     const bool is_subaddress,
     const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
     const rct::xmr_amount fee_per_weight,
-    const std::vector<uint8_t> &extra,
+    std::vector<uint8_t> extra,
     const std::uint64_t top_block_index);
-std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
-    wallet2 &w,
-    const std::vector<crypto::key_image> &input_key_images,
-    const cryptonote::account_public_address &address,
-    const bool is_subaddress,
-    const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
-    const tools::fee_priority priority,
-    const std::vector<uint8_t> &extra);
 
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep_all(
     const wallet2_basic::transfer_container &transfers,
@@ -182,23 +160,11 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const cryptonote::account_public_address &address,
     const bool is_subaddress,
     const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
     const rct::xmr_amount fee_per_weight,
-    const std::vector<uint8_t> &extra,
+    std::vector<uint8_t> extra,
     const std::uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
     const std::uint64_t top_block_index);
-std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep_all(
-    wallet2 &w,
-    const rct::xmr_amount only_below,
-    const cryptonote::account_public_address &address,
-    const bool is_subaddress,
-    const size_t n_dests_per_tx,
-    const crypto::hash8 payment_id,
-    const tools::fee_priority priority,
-    const std::vector<uint8_t> &extra,
-    const std::uint32_t subaddr_account,
-    const std::set<uint32_t> &subaddr_indices);
 
 carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(const wallet2_basic::transfer_details &td);
 
@@ -230,15 +196,6 @@ pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
     const cryptonote::account_keys &acc_keys);
-pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
-    const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const wallet2 &w);
 
-std::size_t get_num_payment_id_fields_in_tx_extra(const std::vector<std::uint8_t> &tx_extra);
-
-std::size_t get_num_ephemeral_tx_pubkey_fields_in_tx_extra(const std::vector<std::uint8_t> &tx_extra);
-
-void insert_payment_id_into_legacy_extra_unencrypted(const crypto::hash8 &payment_id,
-    std::vector<std::uint8_t> &extra_inout);
 } //namespace wallet
 } //namespace tools

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -908,6 +908,43 @@ uint64_t calculate_fee(bool use_per_byte_fee, const cryptonote::transaction &tx,
     return calculate_fee(base_fee, blob_size);
 }
 
+static wallet2_basic::transfer_container get_transfers(const tools::wallet2 &w)
+{
+  wallet2_basic::transfer_container transfers;
+  w.get_transfers(transfers);
+  return transfers;
+}
+
+static rct::xmr_amount get_fee_per_weight_from_priority(const tools::fee_priority priority, tools::wallet2 &w)
+{
+  const bool use_per_byte_fee = w.use_fork_rules(HF_VERSION_PER_BYTE_FEE, 0);
+  CHECK_AND_ASSERT_THROW_MES(use_per_byte_fee, "not using per-byte base fee");
+
+  const rct::xmr_amount fee_per_weight = w.get_base_fee(priority);
+  MDEBUG("fee_per_weight = " << fee_per_weight << ", from priority = " << priority);
+
+  return fee_per_weight;
+}
+
+static std::uint64_t get_top_block_index(const tools::wallet2 &w)
+{
+  const std::uint64_t current_chain_height = w.get_blockchain_current_height();
+  CHECK_AND_ASSERT_THROW_MES(current_chain_height > 0, "chain height is 0; there's no top block");
+  return current_chain_height - 1;
+}
+
+static tools::wallet::pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const tools::wallet2 &w)
+{
+  return tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(
+    tx_proposal,
+    get_transfers(w),
+    w.get_tree_cache_ref(),
+    w.get_curve_trees_ref(),
+    w.get_account().get_keys());
+}
+
 static const tools::wallet2::tx_construction_data &get_construction_data(const tools::wallet2::pending_tx &ptx)
 {
   THROW_WALLET_EXCEPTION_IF(!std::holds_alternative<tools::wallet2::tx_construction_data>(ptx.construction_data),
@@ -1007,20 +1044,6 @@ crypto::chacha_key derive_cache_key(const crypto::chacha_key& keys_data_key, con
 
   return cache_key;
 }
-
-/**
- * @brief Checks that `extra` parameter used in wallet2 tx construction methods does not contain deprecated fields
- */
-void check_tx_extra_construction_parameter(const std::vector<std::uint8_t> &extra)
-{
-  THROW_WALLET_EXCEPTION_IF(tools::wallet::get_num_ephemeral_tx_pubkey_fields_in_tx_extra(extra),
-    tools::error::wallet_internal_error,
-    "There should be no ephemeral tx pubkey fields in `extra` passed to transaction construction methods.");
-  THROW_WALLET_EXCEPTION_IF(tools::wallet::get_num_payment_id_fields_in_tx_extra(extra),
-    tools::error::wallet_internal_error,
-    "Do not pass PIDs inside of `extra` to transaction construction methods. Use the `payment_id` argument instead.");
-}
-
   //-----------------------------------------------------------------
 } //namespace
 
@@ -10343,28 +10366,33 @@ static uint32_t get_count_above(const std::vector<wallet2::transfer_details> &tr
 // This system allows for sending (almost) the entire balance, since it does
 // not generate spurious change in all txes, thus decreasing the instantaneous
 // usable balance.
-std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const std::pair<crypto::hash8, std::size_t> &payment_id, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs)
 {
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
   boost::unique_lock<hw::device> hwdev_lock (hwdev);
   hw::reset_mode rst(hwdev);  
 
-  check_tx_extra_construction_parameter(extra);
-
   const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
   if (do_carrot_tx_construction)
   {
-    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(*this, dsts, payment_id, priority, extra, subaddr_account, subaddr_indices, subtract_fee_from_outputs);
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(::get_transfers(*this),
+      m_subaddresses,
+      dsts,
+      get_fee_per_weight_from_priority(priority, *this),
+      extra,
+      subaddr_account,
+      subaddr_indices,
+      ignore_outputs_above(),
+      ignore_outputs_below(),
+      subtract_fee_from_outputs,
+      get_top_block_index(*this));
     std::vector<pending_tx> ptx_vector;
     ptx_vector.reserve(tx_proposals.size());
     for (const auto &tx_proposal : tx_proposals)
-      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+      ptx_vector.push_back(::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
     return ptx_vector;
   }
-
-  if (payment_id.first != crypto::null_hash8)
-    wallet::insert_payment_id_into_legacy_extra_unencrypted(payment_id.first, extra);
 
   auto original_dsts = dsts;
 
@@ -11127,23 +11155,28 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, c
   return true;
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const crypto::hash8 payment_id, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 {
-  check_tx_extra_construction_parameter(extra);
-
   const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
   if (do_carrot_tx_construction)
   {
-    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep_all(*this, below, address, is_subaddress, outputs, payment_id, priority, extra, subaddr_account, subaddr_indices);
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep_all(::get_transfers(*this),
+      m_subaddresses,
+      below,
+      address,
+      is_subaddress,
+      outputs,
+      get_fee_per_weight_from_priority(priority, *this),
+      extra,
+      subaddr_account,
+      subaddr_indices,
+      get_top_block_index(*this));
     std::vector<pending_tx> ptx_vector;
     ptx_vector.reserve(tx_proposals.size());
     for (const auto &tx_proposal : tx_proposals)
-      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+      ptx_vector.push_back(::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
     return ptx_vector;
   }
-
-  if (payment_id != crypto::null_hash8)
-    wallet::insert_payment_id_into_legacy_extra_unencrypted(payment_id, extra);
 
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
@@ -11213,26 +11246,29 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
     }
   }
 
-  return create_transactions_from(address, is_subaddress, outputs, payment_id, unused_transfers_indices, unused_dust_indices, fake_outs_count, priority, extra);
+  return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, priority, extra);
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const crypto::hash8 payment_id, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra)
 {
-  check_tx_extra_construction_parameter(extra);
-
   const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
   if (do_carrot_tx_construction)
   {
-    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(*this, {ki}, address, is_subaddress, outputs, payment_id, priority, extra);
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(::get_transfers(*this),
+        m_subaddresses,
+        {ki},
+        address,
+        is_subaddress,
+        outputs,
+        get_fee_per_weight_from_priority(priority, *this),
+        extra,
+        get_top_block_index(*this));
     std::vector<pending_tx> ptx_vector;
     ptx_vector.reserve(tx_proposals.size());
     for (const auto &tx_proposal : tx_proposals)
-      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+      ptx_vector.push_back(::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
     return ptx_vector;
   }
-
-  if (payment_id != crypto::null_hash8)
-    wallet::insert_payment_id_into_legacy_extra_unencrypted(payment_id, extra);
 
   std::vector<size_t> unused_transfers_indices;
   std::vector<size_t> unused_dust_indices;
@@ -11250,13 +11286,11 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypt
       break;
     }
   }
-  return create_transactions_from(address, is_subaddress, outputs, payment_id, unused_transfers_indices, unused_dust_indices, fake_outs_count, priority, extra);
+  return create_transactions_from(address, is_subaddress, outputs, unused_transfers_indices, unused_dust_indices, fake_outs_count, priority, extra);
 }
 
-std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const crypto::hash8 payment_id, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra)
 {
-  check_tx_extra_construction_parameter(extra);
-
   const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
   if (do_carrot_tx_construction)
   {
@@ -11268,16 +11302,22 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
     for (const size_t transfer_idx : unused_dust_indices)
       input_key_images.push_back(m_transfers.at(transfer_idx).m_key_image);
 
-    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(*this, input_key_images, address, is_subaddress, outputs, payment_id, priority, extra);
+    const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(::get_transfers(*this),
+        m_subaddresses,
+        input_key_images,
+        address,
+        is_subaddress,
+        outputs,
+        get_fee_per_weight_from_priority(priority, *this),
+        extra,
+        get_top_block_index(*this));
+
     std::vector<pending_tx> ptx_vector;
     ptx_vector.reserve(tx_proposals.size());
     for (const auto &tx_proposal : tx_proposals)
-      ptx_vector.push_back(tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
+      ptx_vector.push_back(::finalize_all_proofs_from_transfer_details_as_pending_tx(tx_proposal, *this));
     return ptx_vector;
   }
-
-  if (payment_id != crypto::null_hash8)
-    wallet::insert_payment_id_into_legacy_extra_unencrypted(payment_id, extra);
 
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
@@ -11767,7 +11807,7 @@ std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions()
       unmixable_transfer_outputs.push_back(n);
   }
 
-  return create_transactions_from(m_account_public_address, false, 1, crypto::null_hash8, unmixable_transfer_outputs, unmixable_dust_outputs, 0 /*fake_outs_count */, fee_priority::Unimportant, std::vector<uint8_t>());
+  return create_transactions_from(m_account_public_address, false, 1, unmixable_transfer_outputs, unmixable_dust_outputs, 0 /*fake_outs_count */, fee_priority::Unimportant, std::vector<uint8_t>());
 }
 //----------------------------------------------------------------------------------------------------
 void wallet2::discard_unmixable_outputs()

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -741,10 +741,9 @@ private:
     /**
      * brief: create_transactions_2: create "transfer" style txs (or tx proposals in hot/cold & multisig wallets)
      * param: dsts - list of (address, amount) payments to fulfill
-     * param: payment_id - short payment ID and index into `dsts` to which address it is associated to
      * param: fake_outs_count - the number of decoys per input, AKA "mixin"
      * param: priority - fee priority level
-     * param: extra - any "truly extra" tx.extra fields that don't appear in normal txs; no PIDs, or tx pubkeys
+     * param: extra - any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
      * param: subaddr_account - the only account (AKA major) index for which input selection should pull inputs from
      * param: subaddr_indices - if non-empty, the only minor indices for which input selection should pull inputs from
      * param: subtract_fee_from_outputs - indices into `dsts` which are "fee-subtractable"
@@ -752,39 +751,37 @@ private:
      *
      * Transfer-style means that transactions are added until all payment outlays are fulfilled.
      */
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const std::pair<crypto::hash8, std::size_t> &payment_id, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
+    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
     /**
      * brief: create_transactions_all: create "sweep-all" style txs (or tx proposals in hot/cold & multisig wallets)
      * param: below - the money amount below which input selection should pull inputs from; higher amounts are excluded
      * param: address - public address for all destinations in txs
      * param: is_subaddress - true iff `address` refers to a subaddress
      * param: outputs - the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
-     * param: payment_id - short payment ID
      * param: fake_outs_count - the number of decoys per input, AKA "mixin"
      * param: priority - fee priority level
-     * param: extra - any "truly extra" tx.extra fields that don't appear in normal txs; no PIDs, or tx pubkeys
+     * param: extra - any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
      * param: subaddr_account - the only account (AKA major) index for which input selection should pull inputs from
      * param: subaddr_indices - if non-empty, the only minor indices for which input selection should pull inputs from
      * return: list of "pending txs": structs which contain partially or fully formed txs and construction information
      *
      * Sweep-all-style means that transactions are added until all inputs <= amount `below` are spent.
      */
-    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const crypto::hash8 payment_id, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices);
+    std::vector<wallet2::pending_tx> create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices);
     /**
      * brief: create_transactions_single: create "sweep-single" style txs (or tx proposals in hot/cold & multisig wallets)
      * param: ki - the key image of the input that is to be spent
      * param: address - public address for all destinations in txs
      * param: is_subaddress - true iff `address` refers to a subaddress
      * param: outputs - the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
-     * param: payment_id - short payment ID
      * param: fake_outs_count - the number of decoys per input, AKA "mixin"
      * param: priority - fee priority level
-     * param: extra - any "truly extra" tx.extra fields that don't appear in normal txs; no PIDs, or tx pubkeys
+     * param: extra - any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
      * return: list of "pending txs": structs which contain partially or fully formed txs and construction information
      *
      * Sweep-single-style means that 1 transaction is returned which spends the given key image
      */
-    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const crypto::hash8 payment_id, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra);
+    std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
     /**
      * brief: create_transactions_all: create "sweep-multiple" style txs (or tx proposals in hot/cold & multisig wallets)
      * param: address - public address for all destinations in txs
@@ -795,12 +792,12 @@ private:
      * param: unused_dust_indices - indices into `m_transfers` of non-validly-decomposed pre-RingCT inputs
      * param: fake_outs_count - the number of decoys per input, AKA "mixin"
      * param: priority - fee priority level
-     * param: extra - any "truly extra" tx.extra fields that don't appear in normal txs; no PIDs, or tx pubkeys
+     * param: extra - any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
      * return: list of "pending txs": structs which contain partially or fully formed txs and construction information
      *
      * Sweep-multiple-style means that transactions are added until all inputs specified by index are spent.
      */
-    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const crypto::hash8 payment_id, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, const tools::fee_priority priority, std::vector<uint8_t> extra);
+    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
     bool sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, const std::vector<cryptonote::tx_destination_entry>& dsts, const unique_index_container& subtract_fee_from_outputs = {}) const;
     void cold_tx_aux_import(const std::vector<pending_tx>& ptx, const std::vector<std::string>& tx_device_aux);
     void cold_sign_tx(const std::vector<pending_tx>& ptx_vector, signed_tx_set &exported_txs, std::vector<cryptonote::address_parse_info> &dsts_info, std::vector<std::string> & tx_device_aux);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1034,13 +1034,12 @@ namespace tools
     return true;
   }
   //------------------------------------------------------------------------------------------------------------------------------
-  bool wallet_rpc_server::validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::pair<crypto::hash8, std::size_t> &payment_id_out, bool at_least_one_destination, epee::json_rpc::error& er)
+  bool wallet_rpc_server::validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination, epee::json_rpc::error& er)
   {
-    payment_id_out = {crypto::null_hash8, 0};
-
     CHECK_IF_BACKGROUND_SYNCING();
 
-    std::size_t dst_idx = 0;
+    crypto::hash8 integrated_payment_id = crypto::null_hash8;
+    std::string extra_nonce;
     for (auto it = destinations.begin(); it != destinations.end(); it++)
     {
       cryptonote::address_parse_info info;
@@ -1076,16 +1075,22 @@ namespace tools
 
       if (info.has_payment_id)
       {
-        if (!payment_id.empty() || payment_id_out.first != crypto::null_hash8)
+        if (!payment_id.empty() || integrated_payment_id != crypto::null_hash8)
         {
           er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
           er.message = "A single payment id is allowed per transaction";
           return false;
         }
-        payment_id_out = {info.payment_id, dst_idx};
-      }
+        integrated_payment_id = info.payment_id;
+        cryptonote::set_encrypted_payment_id_to_tx_extra_nonce(extra_nonce, integrated_payment_id);
 
-      ++dst_idx;
+        /* Append Payment ID data into extra */
+        if (!cryptonote::add_extra_nonce_to_tx_extra(extra, extra_nonce)) {
+          er.code = WALLET_RPC_ERROR_CODE_WRONG_PAYMENT_ID;
+          er.message = "Something went wrong with integrated payment_id.";
+          return false;
+        }
+      }
     }
 
     if (at_least_one_destination && dsts.empty())
@@ -1230,6 +1235,7 @@ namespace tools
   {
 
     std::vector<cryptonote::tx_destination_entry> dsts;
+    std::vector<uint8_t> extra;
 
     LOG_PRINT_L3("on_transfer starts");
     if (!m_wallet) return not_open(er);
@@ -1254,9 +1260,8 @@ namespace tools
 
     CHECK_MULTISIG_ENABLED();
 
-    // validate the transfer requested and populate dsts & pid
-    std::pair<crypto::hash8, std::size_t> payment_id;
-    if (!validate_transfer(req.destinations, req.payment_id, dsts, payment_id, true, er))
+    // validate the transfer requested and populate dsts & extra
+    if (!validate_transfer(req.destinations, req.payment_id, dsts, extra, true, er))
     {
       return false;
     }
@@ -1265,7 +1270,7 @@ namespace tools
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, payment_id, mixin, priority, /*extra=*/{}, req.account_index, req.subaddr_indices, req.subtract_fee_from_outputs);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, priority, extra, req.account_index, req.subaddr_indices, req.subtract_fee_from_outputs);
 
       if (ptx_vector.empty())
       {
@@ -1297,6 +1302,7 @@ namespace tools
   {
 
     std::vector<cryptonote::tx_destination_entry> dsts;
+    std::vector<uint8_t> extra;
 
     if (!m_wallet) return not_open(er);
     if (m_restricted)
@@ -1321,8 +1327,7 @@ namespace tools
     CHECK_MULTISIG_ENABLED();
 
     // validate the transfer requested and populate dsts & extra; RPC_TRANSFER::request and RPC_TRANSFER_SPLIT::request are identical types.
-    std::pair<crypto::hash8, std::size_t> payment_id;
-    if (!validate_transfer(req.destinations, req.payment_id, dsts, payment_id, true, er))
+    if (!validate_transfer(req.destinations, req.payment_id, dsts, extra, true, er))
     {
       return false;
     }
@@ -1332,7 +1337,7 @@ namespace tools
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
       LOG_PRINT_L2("on_transfer_split calling create_transactions_2");
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, payment_id, mixin, priority, /*extra=*/{}, req.account_index, req.subaddr_indices);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_2(dsts, mixin, priority, extra, req.account_index, req.subaddr_indices);
       LOG_PRINT_L2("on_transfer_split called create_transactions_2");
 
       if (ptx_vector.empty())
@@ -1777,8 +1782,7 @@ namespace tools
     destination.push_back(wallet_rpc::transfer_destination());
     destination.back().amount = 0;
     destination.back().address = req.address;
-    std::pair<crypto::hash8, std::size_t> payment_id;
-    if (!validate_transfer(destination, req.payment_id, dsts, payment_id, true, er))
+    if (!validate_transfer(destination, req.payment_id, dsts, extra, true, er))
     {
       return false;
     }
@@ -1805,7 +1809,7 @@ namespace tools
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, payment_id.first, mixin, priority, /*extra=*/{}, req.account_index, subaddr_indices);
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_all(req.below_amount, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, priority, extra, req.account_index, subaddr_indices);
 
       return fill_response(ptx_vector, req.get_tx_keys, res.tx_key_list, res.amount_list, res.amounts_by_dest_list, res.fee_list, res.weight_list, res.multisig_txset, res.unsigned_txset, req.do_not_relay,
           res.tx_hash_list, req.get_tx_hex, res.tx_blob_list, req.get_tx_metadata, res.tx_metadata_list, res.spent_key_images_list, er);
@@ -1857,8 +1861,7 @@ namespace tools
     destination.push_back(wallet_rpc::transfer_destination());
     destination.back().amount = 0;
     destination.back().address = req.address;
-    std::pair<crypto::hash8, std::size_t> payment_id;
-    if (!validate_transfer(destination, req.payment_id, dsts, payment_id, true, er))
+    if (!validate_transfer(destination, req.payment_id, dsts, extra, true, er))
     {
       return false;
     }
@@ -1875,7 +1878,7 @@ namespace tools
     {
       uint64_t mixin = m_wallet->adjust_mixin(req.ring_size ? req.ring_size - 1 : 0);
       const fee_priority priority = m_wallet->adjust_priority(fee_priority_utilities::from_integral(req.priority));
-      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, payment_id.first, mixin, priority, /*extra=*/{});
+      std::vector<wallet2::pending_tx> ptx_vector = m_wallet->create_transactions_single(ki, dsts[0].addr, dsts[0].is_subaddress, req.outputs, mixin, priority, extra);
 
       if (ptx_vector.empty())
       {

--- a/src/wallet/wallet_rpc_server.h
+++ b/src/wallet/wallet_rpc_server.h
@@ -280,7 +280,7 @@ namespace tools
           bool get_tx_key, Ts& tx_key, Tu &amount, Ta &amounts_by_dest, Tu &fee, Tu &weight, std::string &multisig_txset, std::string &unsigned_txset, bool do_not_relay,
           Ts &tx_hash, bool get_tx_hex, Ts &tx_blob, bool get_tx_metadata, Ts &tx_metadata, Tk &spent_key_images, epee::json_rpc::error &er);
 
-      bool validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::pair<crypto::hash8, std::size_t> &payment_id_out, bool at_least_one_destination, epee::json_rpc::error& er);
+      bool validate_transfer(const std::list<wallet_rpc::transfer_destination>& destinations, const std::string& payment_id, std::vector<cryptonote::tx_destination_entry>& dsts, std::vector<uint8_t>& extra, bool at_least_one_destination, epee::json_rpc::error& er);
 
       void check_background_mining();
 

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -397,7 +397,6 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
       {wallet2_td},
       subaddrs,
       destinations,
-      /*payment_id=*/{},
       /*fee_per_weight=*/10000000, // This is just a mock value to pass the test
       /*extra=*/{},
       /*subaddr_account=*/0,

--- a/tests/functional_tests/transactions_flow_test.cpp
+++ b/tests/functional_tests/transactions_flow_test.cpp
@@ -85,7 +85,7 @@ bool do_send_money(tools::wallet2& w1, tools::wallet2& w2, size_t mix_in_factor,
   try
   {
     std::vector<tools::wallet2::pending_tx> ptx;
-    ptx = w1.create_transactions_2(dsts, {}, mix_in_factor, tools::fee_priority::Default, std::vector<uint8_t>(), 0, {});
+    ptx = w1.create_transactions_2(dsts, mix_in_factor, tools::fee_priority::Default, std::vector<uint8_t>(), 0, {});
     for (auto &p: ptx)
       w1.commit_tx(p);
     return true;

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -101,7 +101,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_1)
         transfers,
         {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
         dsts,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         /*subaddr_account=*/0,
@@ -163,7 +162,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_2)
         transfers,
         alice.subaddress_map_cn(),
         dsts,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         /*subaddr_account=*/spending_subaddr_account,
@@ -239,7 +237,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_3)
         transfers,
         {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
         dsts,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         /*subaddr_account=*/0,
@@ -281,7 +278,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_1)
         bob.get_keys().m_account_address,
         /*is_subaddress=*/false,
         /*n_dests_per_tx=*/1,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
@@ -316,7 +312,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_2)
         bob.get_keys().m_account_address,
         /*is_subaddress=*/false,
         /*n_dests_per_tx=*/FCMP_PLUS_PLUS_MAX_OUTPUTS - 1,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
@@ -359,7 +354,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_3)
         alice.get_keys().m_account_address,
         /*is_subaddress=*/false,
         /*n_dests_per_tx=*/FCMP_PLUS_PLUS_MAX_OUTPUTS,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         transfers.front().m_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
@@ -435,7 +429,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_4)
         bob.get_keys().m_account_address,
         /*is_subaddress=*/false,
         /*n_dests_per_tx=*/n_dests_per_tx,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         top_block_index);
@@ -518,7 +511,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_5)
         alice.get_keys().m_account_address,
         /*is_subaddress=*/false,
         /*n_dests_per_tx=*/n_dests_per_tx,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         top_block_index);
@@ -604,7 +596,6 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_6)
         alice.get_keys().m_account_address,
         /*is_subaddress=*/false,
         /*n_dests_per_tx=*/n_dests_per_tx,
-        /*payment_id=*/{},
         /*fee_per_weight=*/1,
         /*extra=*/{},
         top_block_index);
@@ -712,7 +703,6 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
             alice.m_transfers,
             alice.m_subaddresses,
             {cryptonote::tx_destination_entry(out_amount, bob_main_addr, false)},
-            /*payment_id=*/{},
             /*fee_per_weight=*/1,
             /*extra=*/{},
             /*subaddr_account=*/0,


### PR DESCRIPTION
Partially reverts 93387063ae2a74f36d5eb23aeb924a3d3ecbd37e. Resolves #70 by reverting methods to previous API. Keeps the functional behavior of #61.

Also moves all `wallet2`-specific overloads out of `tx_builder` and into `wallet2.cpp`, so `tx_builder` no longer depends on `wallet2`.