### PR TITLE
carrot_impl: misc utility changes and refactorings Jul 25

### DIFF
--- a/src/carrot_impl/CMakeLists.txt
+++ b/src/carrot_impl/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 set(carrot_impl_sources
   address_device_ram_borrowed.cpp
-  address_utils_compat.cpp
+  address_utils.cpp
   format_utils.cpp
   input_selection.cpp
   key_image_device_composed.cpp

--- a/src/carrot_impl/address_device_ram_borrowed.cpp
+++ b/src/carrot_impl/address_device_ram_borrowed.cpp
@@ -30,7 +30,7 @@
 #include "address_device_ram_borrowed.h"
 
 //local headers
-#include "address_utils_compat.h"
+#include "address_utils.h"
 #include "carrot_core/address_utils.h"
 
 //third party headers

--- a/src/carrot_impl/address_utils.h
+++ b/src/carrot_impl/address_utils.h
@@ -37,6 +37,10 @@
 #include <cstdint>
 
 //forward declarations
+namespace carrot
+{
+struct cryptonote_hierarchy_address_device;
+}
 
 namespace carrot
 {
@@ -57,9 +61,32 @@ void make_legacy_subaddress_extension(const crypto::secret_key &k_view,
  *   K^j_s = K_s + k^j_subext G
  * param: legacy_subaddress_extension_out - k^j_subext
  * param: account_spend_pubkey - K_s
+ * param: addr_dev -
+ * param: major_index - j_major
+ * param: minor_index - j_minor
  * outparam: legacy_subaddress_spend_pubkey_out - K^j_s
  */
 void make_legacy_subaddress_spend_pubkey(const crypto::secret_key &legacy_subaddress_extension,
     const crypto::public_key &account_spend_pubkey,
     crypto::public_key &legacy_subaddress_spend_pubkey_out);
+void make_legacy_subaddress_spend_pubkey(const cryptonote_hierarchy_address_device &addr_dev,
+    const std::uint32_t major_index,
+    const std::uint32_t minor_index,
+    crypto::public_key &legacy_subaddress_spend_pubkey_out);
+/**
+ * brief: make_legacy_subaddress_spend_pubkey - K^j_s
+ *   K^j_s = K_s + k^j_subext G
+ *   K^j_v = k_v (G if j=0, else K^j_s)
+ * param: addr_dev
+ * param: major_index - j_major
+ * param: minor_index - j_minor
+ * param: account_spend_pubkey - K_s
+ * outparam: legacy_subaddress_spend_pubkey_out - K^j_s
+ * outparam: legacy_subaddress_view_pubkey_out - K^j_v
+ */
+void make_legacy_subaddress_pubkeys(const cryptonote_hierarchy_address_device &addr_dev,
+    const std::uint32_t major_index,
+    const std::uint32_t minor_index,
+    crypto::public_key &legacy_subaddress_spend_pubkey_out,
+    crypto::public_key &legacy_subaddress_view_pubkey_out);
 } //namespace carrot

--- a/src/carrot_impl/format_utils.h
+++ b/src/carrot_impl/format_utils.h
@@ -211,5 +211,11 @@ rct::rctSigPrunable store_fcmp_proofs_to_rct_prunable_v1(
     const fcmp_pp::FcmpMembershipProof &membership_proof,
     const std::uint64_t fcmp_reference_block,
     const std::uint8_t n_tree_layers);
+/**
+ * brief: calculate_signable_transaction_hash -
+ * param: tx - pruned or full FCMP++ transaction
+ * throw: std::runtime_error if `tx` is not FCMP++ or fails to serialize
+ */
+crypto::hash calculate_signable_fcmp_pp_transaction_hash(const cryptonote::transaction &tx);
 
 } //namespace carrot

--- a/src/carrot_impl/key_image_device_composed.cpp
+++ b/src/carrot_impl/key_image_device_composed.cpp
@@ -127,7 +127,7 @@ crypto::key_image key_image_device_composed::derive_key_image(const OutputOpenin
     // get k^g_o, k^t_o
     crypto::secret_key sender_extension_g;
     crypto::secret_key sender_extension_t;
-    if (!try_scan_opening_hint(opening_hint,
+    if (!try_scan_opening_hint_sender_extensions(opening_hint,
         {&main_address_spend_pubkey, 1},
         m_k_view_incoming_dev,
         m_s_view_balance_dev,

--- a/src/carrot_impl/key_image_device_precomputed.h
+++ b/src/carrot_impl/key_image_device_precomputed.h
@@ -42,6 +42,7 @@ namespace carrot
 {
 class key_image_device_precompted: public key_image_device
 {
+public:
     key_image_device_precompted(std::unordered_map<crypto::public_key, crypto::key_image> &&key_image_map):
         m_key_image_map(std::move(key_image_map))
     {}

--- a/src/carrot_impl/output_opening_types.cpp
+++ b/src/carrot_impl/output_opening_types.cpp
@@ -1,21 +1,21 @@
 // Copyright (c) 2025, The Monero Project
-// 
+//
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without modification, are
 // permitted provided that the following conditions are met:
-// 
+//
 // 1. Redistributions of source code must retain the above copyright notice, this list of
 //    conditions and the following disclaimer.
-// 
+//
 // 2. Redistributions in binary form must reproduce the above copyright notice, this list
 //    of conditions and the following disclaimer in the documentation and/or other
 //    materials provided with the distribution.
-// 
+//
 // 3. Neither the name of the copyright holder nor the names of its contributors may be
 //    used to endorse or promote products derived from this software without specific
 //    prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
 // EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
 // MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
@@ -60,17 +60,18 @@ static CarrotEnoteV1 make_carrot_enote_from_v2_opening_hint(const CarrotOutputOp
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-static bool try_sender_extension_scan_on_carrot_enote(const CarrotEnoteV1 &enote,
+static bool try_opening_hint_scan_on_carrot_enote(const CarrotEnoteV1 &enote,
     const std::optional<encrypted_payment_id_t> &encrypted_payment_id,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
     const view_incoming_key_device *k_view_incoming_dev,
     const view_balance_secret_device *s_view_balance_dev,
     crypto::secret_key &sender_extension_g_out,
-    crypto::secret_key &sender_extension_t_out)
+    crypto::secret_key &sender_extension_t_out,
+    rct::xmr_amount &amount_out,
+    rct::key &amount_blinding_factor_out)
 {
     crypto::public_key dummy_address_spend_pubkey;
-    rct::xmr_amount dummy_amount;
-    crypto::secret_key dummy_amount_blinding_factor;
+    crypto::secret_key amount_blinding_factor_sk;
     CarrotEnoteType dummy_enote_type;
     janus_anchor_t dummy_internal_message;
     payment_id_t dummy_payment_id;
@@ -81,11 +82,14 @@ static bool try_sender_extension_scan_on_carrot_enote(const CarrotEnoteV1 &enote
                 sender_extension_g_out,
                 sender_extension_t_out,
                 dummy_address_spend_pubkey,
-                dummy_amount,
-                dummy_amount_blinding_factor,
+                amount_out,
+                amount_blinding_factor_sk,
                 dummy_enote_type,
                 dummy_internal_message))
+        {
+            amount_blinding_factor_out = rct::sk2rct(amount_blinding_factor_sk);
             return true;
+        }
     }
     if (k_view_incoming_dev != nullptr)
     {
@@ -102,15 +106,158 @@ static bool try_sender_extension_scan_on_carrot_enote(const CarrotEnoteV1 &enote
                     sender_extension_g_out,
                     sender_extension_t_out,
                     dummy_address_spend_pubkey,
-                    dummy_amount,
-                    dummy_amount_blinding_factor,
+                    amount_out,
+                    amount_blinding_factor_sk,
                     dummy_payment_id,
                     dummy_enote_type))
+            {
+                amount_blinding_factor_out = rct::sk2rct(amount_blinding_factor_sk);
                 return true;
+            }
         }
     }
 
     return false;
+}
+//-------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------------------------
+static bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
+    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const view_incoming_key_device *k_view_incoming_dev,
+    const view_balance_secret_device *s_view_balance_dev,
+    crypto::secret_key &sender_extension_g_out,
+    crypto::secret_key &sender_extension_t_out,
+    rct::xmr_amount &amount_out,
+    rct::key &amount_blinding_factor_out)
+{
+    struct try_scan_opening_hint_visitor
+    {
+        bool operator()(const LegacyOutputOpeningHintV1 &hint) const
+        {
+            sender_extension_g_out = crypto::null_skey;
+            sender_extension_t_out = crypto::null_skey;
+            amount_out = hint.amount;
+            amount_blinding_factor_out = hint.amount_blinding_factor;
+
+            if (k_view_incoming_dev == nullptr)
+                return false;
+
+            // k_v K_e
+            crypto::public_key kd_tors;
+            if (!k_view_incoming_dev->view_key_scalar_mult_ed25519(hint.ephemeral_tx_pubkey, kd_tors))
+                return false;
+
+            // 8 k_v K_e
+            kd_tors = rct::rct2pk(rct::scalarmult8(rct::pk2rct(kd_tors)));
+            crypto::key_derivation kd;
+            memcpy(&kd, &kd_tors, sizeof(kd));
+
+            // d = k_o = Hs1(8 k_v K_e, i)
+            crypto::derivation_to_scalar(kd, hint.local_output_index, unwrap(unwrap(sender_extension_g_out)));
+
+            return true;
+        }
+
+        bool operator()(const CarrotOutputOpeningHintV1 &hint) const
+        {
+            return try_opening_hint_scan_on_carrot_enote(hint.source_enote,
+                hint.encrypted_payment_id,
+                main_address_spend_pubkeys,
+                k_view_incoming_dev,
+                s_view_balance_dev,
+                sender_extension_g_out,
+                sender_extension_t_out,
+                amount_out,
+                amount_blinding_factor_out);
+        }
+
+        bool operator()(const CarrotOutputOpeningHintV2 &hint) const
+        {
+            // input_context = "R" || KI_1
+            const input_context_t input_context = carrot::make_carrot_input_context(hint.tx_first_key_image);
+
+            // s^ctx_sr = H_32(s_sr, D_e, input_context) for internal&external s_sr
+            crypto::hash s_sender_receiver[2]; //! @TODO: wipe
+            std::size_t n_keys_available = 0;
+            if (s_view_balance_dev != nullptr)
+            {
+                // s^ctx_sr = H_32(s_vb, D_e, input_context)
+                s_view_balance_dev->make_internal_sender_receiver_secret(hint.enote_ephemeral_pubkey,
+                    input_context, s_sender_receiver[n_keys_available++]);
+            }
+            if (k_view_incoming_dev != nullptr)
+            {
+                // s_sr = k_v D_e
+                mx25519_pubkey s_sender_receiver_unctx;
+                carrot::make_carrot_uncontextualized_shared_key_receiver(*k_view_incoming_dev,
+                    hint.enote_ephemeral_pubkey,
+                    s_sender_receiver_unctx);
+
+                // s^ctx_sr = H_32(k_v D_e, D_e, input_context)
+                carrot::make_carrot_sender_receiver_secret(s_sender_receiver_unctx.data,
+                    hint.enote_ephemeral_pubkey,
+                    input_context,
+                    s_sender_receiver[n_keys_available++]);
+            }
+
+            for (std::size_t i = 0; i < n_keys_available; ++i)
+            {
+                if (try_opening_hint_scan_on_carrot_enote(
+                    make_carrot_enote_from_v2_opening_hint(hint, s_sender_receiver[i]),
+                    hint.encrypted_payment_id,
+                    main_address_spend_pubkeys,
+                    k_view_incoming_dev,
+                    s_view_balance_dev,
+                    sender_extension_g_out,
+                    sender_extension_t_out,
+                    amount_out,
+                    amount_blinding_factor_out))
+                return true;
+            }
+
+            return false;
+        }
+
+        bool operator()(const CarrotCoinbaseOutputOpeningHintV1 &hint) const
+        {
+            amount_out = hint.source_enote.amount;
+            amount_blinding_factor_out = rct::I;
+
+            mx25519_pubkey s_sender_receiver_unctx;
+            if (make_carrot_uncontextualized_shared_key_receiver(*k_view_incoming_dev,
+                hint.source_enote.enote_ephemeral_pubkey,
+                s_sender_receiver_unctx))
+            {
+                crypto::public_key dummy_address_spend_pubkey;
+                return try_scan_carrot_coinbase_enote_receiver(hint.source_enote,
+                    s_sender_receiver_unctx,
+                    main_address_spend_pubkeys,
+                    sender_extension_g_out,
+                    sender_extension_t_out,
+                    dummy_address_spend_pubkey);
+            }
+
+            return false;
+        }
+
+        epee::span<const crypto::public_key> main_address_spend_pubkeys;
+        const view_incoming_key_device *k_view_incoming_dev;
+        const view_balance_secret_device *s_view_balance_dev;
+        crypto::secret_key &sender_extension_g_out;
+        crypto::secret_key &sender_extension_t_out;
+        rct::xmr_amount &amount_out;
+        rct::key &amount_blinding_factor_out;
+    };
+
+    return std::visit(try_scan_opening_hint_visitor{
+            main_address_spend_pubkeys,
+            k_view_incoming_dev,
+            s_view_balance_dev,
+            sender_extension_g_out,
+            sender_extension_t_out,
+            amount_out,
+            amount_blinding_factor_out},
+        opening_hint);
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
@@ -156,9 +303,9 @@ const crypto::public_key &onetime_address_ref(const OutputOpeningHintVariant &op
     {
         const crypto::public_key &operator()(const LegacyOutputOpeningHintV1 &h) const
         { return h.onetime_address; }
-        const crypto::public_key &operator()(const CarrotOutputOpeningHintV1 &h) const 
+        const crypto::public_key &operator()(const CarrotOutputOpeningHintV1 &h) const
         { return h.source_enote.onetime_address; }
-        const crypto::public_key &operator()(const CarrotOutputOpeningHintV2 &h) const 
+        const crypto::public_key &operator()(const CarrotOutputOpeningHintV2 &h) const
         { return h.onetime_address; }
         const crypto::public_key &operator()(const CarrotCoinbaseOutputOpeningHintV1 &h) const
         { return h.source_enote.onetime_address; }
@@ -173,9 +320,9 @@ rct::key amount_commitment_ref(const OutputOpeningHintVariant &opening_hint)
     {
         rct::key operator()(const LegacyOutputOpeningHintV1 &h) const
         { return rct::commit(h.amount, h.amount_blinding_factor); }
-        rct::key operator()(const CarrotOutputOpeningHintV1 &h) const 
+        rct::key operator()(const CarrotOutputOpeningHintV1 &h) const
         { return h.source_enote.amount_commitment; }
-        rct::key operator()(const CarrotOutputOpeningHintV2 &h) const 
+        rct::key operator()(const CarrotOutputOpeningHintV2 &h) const
         { return h.amount_commitment; }
         rct::key operator()(const CarrotCoinbaseOutputOpeningHintV1 &h) const
         { return rct::zeroCommitVartime(h.source_enote.amount); }
@@ -190,9 +337,9 @@ subaddress_index_extended subaddress_index_ref(const OutputOpeningHintVariant &o
     {
         subaddress_index_extended operator()(const LegacyOutputOpeningHintV1 &h) const
         { return {h.subaddr_index, AddressDeriveType::PreCarrot}; }
-        subaddress_index_extended operator()(const CarrotOutputOpeningHintV1 &h) const 
+        subaddress_index_extended operator()(const CarrotOutputOpeningHintV1 &h) const
         { return h.subaddr_index; }
-        subaddress_index_extended operator()(const CarrotOutputOpeningHintV2 &h) const 
+        subaddress_index_extended operator()(const CarrotOutputOpeningHintV2 &h) const
         { return h.subaddr_index; }
         subaddress_index_extended operator()(const CarrotCoinbaseOutputOpeningHintV1 &h) const
         { return {{0, 0}, h.derive_type}; }
@@ -201,128 +348,41 @@ subaddress_index_extended subaddress_index_ref(const OutputOpeningHintVariant &o
     return std::visit(subaddress_index_ref_visitor{}, opening_hint);
 }
 //-------------------------------------------------------------------------------------------------------------------
-bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
+bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &opening_hint,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
     const view_incoming_key_device *k_view_incoming_dev,
     const view_balance_secret_device *s_view_balance_dev,
     crypto::secret_key &sender_extension_g_out,
     crypto::secret_key &sender_extension_t_out)
 {
-    struct try_scan_opening_hint_visitor
-    {
-        bool operator()(const LegacyOutputOpeningHintV1 &hint) const
-        {
-            sender_extension_g_out = crypto::null_skey;
-            sender_extension_t_out = crypto::null_skey;
-
-            if (k_view_incoming_dev == nullptr)
-                return false;
-
-            // k_v K_e
-            crypto::public_key kd_tors;
-            if (!k_view_incoming_dev->view_key_scalar_mult_ed25519(hint.ephemeral_tx_pubkey, kd_tors))
-                return false;
-
-            // 8 k_v K_e
-            kd_tors = rct::rct2pk(rct::scalarmult8(rct::pk2rct(kd_tors)));
-            crypto::key_derivation kd;
-            memcpy(&kd, &kd_tors, sizeof(kd));
-
-            // d = k_o = Hs1(8 k_v K_e, i)
-            crypto::derivation_to_scalar(kd, hint.local_output_index, unwrap(unwrap(sender_extension_g_out)));
-
-            return true;
-        }
-
-        bool operator()(const CarrotOutputOpeningHintV1 &hint) const
-        {
-            return try_sender_extension_scan_on_carrot_enote(hint.source_enote,
-                hint.encrypted_payment_id,
-                main_address_spend_pubkeys,
-                k_view_incoming_dev,
-                s_view_balance_dev,
-                sender_extension_g_out,
-                sender_extension_t_out);
-        }
-
-        bool operator()(const CarrotOutputOpeningHintV2 &hint) const
-        {
-            // input_context = "R" || KI_1
-            const input_context_t input_context = carrot::make_carrot_input_context(hint.tx_first_key_image);
-
-            // s^ctx_sr = H_32(s_sr, D_e, input_context) for internal&external s_sr
-            crypto::hash s_sender_receiver[2]; //! @TODO: wipe
-            std::size_t n_keys_available = 0;
-            if (s_view_balance_dev != nullptr)
-            {
-                // s^ctx_sr = H_32(s_vb, D_e, input_context)
-                s_view_balance_dev->make_internal_sender_receiver_secret(hint.enote_ephemeral_pubkey,
-                    input_context, s_sender_receiver[n_keys_available++]);
-            }
-            if (k_view_incoming_dev != nullptr)
-            {
-                // s_sr = k_v D_e
-                mx25519_pubkey s_sender_receiver_unctx;
-                carrot::make_carrot_uncontextualized_shared_key_receiver(*k_view_incoming_dev,
-                    hint.enote_ephemeral_pubkey,
-                    s_sender_receiver_unctx);
-
-                // s^ctx_sr = H_32(k_v D_e, D_e, input_context)
-                carrot::make_carrot_sender_receiver_secret(s_sender_receiver_unctx.data,
-                    hint.enote_ephemeral_pubkey,
-                    input_context,
-                    s_sender_receiver[n_keys_available++]);
-            }
-
-            for (std::size_t i = 0; i < n_keys_available; ++i)
-            {
-                if (try_sender_extension_scan_on_carrot_enote(
-                    make_carrot_enote_from_v2_opening_hint(hint, s_sender_receiver[i]),
-                    hint.encrypted_payment_id,
-                    main_address_spend_pubkeys,
-                    k_view_incoming_dev,
-                    s_view_balance_dev,
-                    sender_extension_g_out,
-                    sender_extension_t_out))
-                return true;
-            }
-
-            return false;
-        }
-
-        bool operator()(const CarrotCoinbaseOutputOpeningHintV1 &hint) const
-        {
-            mx25519_pubkey s_sender_receiver_unctx;
-            if (make_carrot_uncontextualized_shared_key_receiver(*k_view_incoming_dev,
-                hint.source_enote.enote_ephemeral_pubkey,
-                s_sender_receiver_unctx))
-            {
-                crypto::public_key dummy_address_spend_pubkey;
-                return try_scan_carrot_coinbase_enote_receiver(hint.source_enote,
-                    s_sender_receiver_unctx,
-                    main_address_spend_pubkeys,
-                    sender_extension_g_out,
-                    sender_extension_t_out,
-                    dummy_address_spend_pubkey);
-            }
-
-            return false;
-        }
-
-        epee::span<const crypto::public_key> main_address_spend_pubkeys;
-        const view_incoming_key_device *k_view_incoming_dev;
-        const view_balance_secret_device *s_view_balance_dev;
-        crypto::secret_key &sender_extension_g_out;
-        crypto::secret_key &sender_extension_t_out;
-    };
-
-    return std::visit(try_scan_opening_hint_visitor{
-            main_address_spend_pubkeys,
-            k_view_incoming_dev,
-            s_view_balance_dev,
-            sender_extension_g_out,
-            sender_extension_t_out},
-        opening_hint);
+    rct::xmr_amount amount;
+    rct::key amount_blinding_factor;
+    return try_scan_opening_hint(opening_hint,
+        main_address_spend_pubkeys,
+        k_view_incoming_dev,
+        s_view_balance_dev,
+        sender_extension_g_out,
+        sender_extension_t_out,
+        amount,
+        amount_blinding_factor);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool try_scan_opening_hint_amount(const OutputOpeningHintVariant &opening_hint,
+    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const view_incoming_key_device *k_view_incoming_dev,
+    const view_balance_secret_device *s_view_balance_dev,
+    rct::xmr_amount &amount_out,
+    rct::key &amount_blinding_factor_out)
+{
+    crypto::secret_key sender_extension_g, sender_extension_t;
+    return try_scan_opening_hint(opening_hint,
+        main_address_spend_pubkeys,
+        k_view_incoming_dev,
+        s_view_balance_dev,
+        sender_extension_g,
+        sender_extension_t,
+        amount_out,
+        amount_blinding_factor_out);
 }
 //-------------------------------------------------------------------------------------------------------------------
 } //namespace carrot

--- a/src/carrot_impl/output_opening_types.h
+++ b/src/carrot_impl/output_opening_types.h
@@ -143,18 +143,33 @@ rct::key amount_commitment_ref(const OutputOpeningHintVariant&);
 subaddress_index_extended subaddress_index_ref(const OutputOpeningHintVariant&);
 
 /**
- * brief: try_scan_sender_extensions_on_opening_hint - get sender extensions for given opening hint
+ * brief: try_scan_opening_hint_sender_extensions - scan sender extensions for given opening hint
  * param: opening_hint
  * param: k_view_incoming_dev - k_v [OPTIONAL]
  * param: s_view_balance_dev - s_vb [OPTIONAL]
- * param: sender_extension_g_out - k^g_o
- * param: sender_extension_t_out - k^t_o
+ * outparam: sender_extension_g_out - k^g_o
+ * outparam: sender_extension_t_out - k^t_o
  * return: true iff Carrot enote scan was successful, or if nominal legacy derivation-to-scalar didn't fail
  */
-bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
+bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &opening_hint,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
     const view_incoming_key_device *k_view_incoming_dev,
     const view_balance_secret_device *s_view_balance_dev,
     crypto::secret_key &sender_extension_g_out,
     crypto::secret_key &sender_extension_t_out);
+/**
+ * brief: try_scan_opening_hint_amount - scan amount and blinding factor for given opening hint
+ * param: opening_hint
+ * param: k_view_incoming_dev - k_v [OPTIONAL]
+ * param: s_view_balance_dev - s_vb [OPTIONAL]
+ * outparam: amount_out - a
+ * outparam: amount_blinding_factor_out - k_a
+ * return: true iff Carrot enote scan was successful, or if nominal legacy derivation-to-scalar didn't fail
+ */
+bool try_scan_opening_hint_amount(const OutputOpeningHintVariant &opening_hint,
+    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const view_incoming_key_device *k_view_incoming_dev,
+    const view_balance_secret_device *s_view_balance_dev,
+    rct::xmr_amount &amount_out,
+    rct::key &amount_blinding_factor_out);
 } //namespace carrot

--- a/src/carrot_impl/tx_builder_inputs.cpp
+++ b/src/carrot_impl/tx_builder_inputs.cpp
@@ -96,7 +96,7 @@ static void make_sal_proof_nominal_address(const crypto::hash &signable_tx_hash,
     // scan k^g_o, k^t_o
     crypto::secret_key sender_extension_g;
     crypto::secret_key sender_extension_t;
-    CHECK_AND_ASSERT_THROW_MES(try_scan_opening_hint(opening_hint,
+    CHECK_AND_ASSERT_THROW_MES(try_scan_opening_hint_sender_extensions(opening_hint,
             main_address_spend_pubkeys,
             k_view_incoming_dev,
             s_view_balance_dev,

--- a/src/carrot_impl/tx_builder_outputs.h
+++ b/src/carrot_impl/tx_builder_outputs.h
@@ -76,12 +76,36 @@ void get_output_enote_proposals_from_proposal_v1(const CarrotTransactionProposal
     encrypted_payment_id_t &encrypted_payment_id_out,
     std::vector<std::pair<bool, std::size_t>> *payment_proposal_order_out = nullptr);
 /**
+ * brief: get_sender_receiver_secrets_from_proposal_v1 - get s_sr for all enotes in finalized order
+ * param: normal_payment_proposals -
+ * param: selfsend_payment_proposals -
+ * param: s_view_balance_dev - device for s_vb (optional)
+ * param: k_view_dev - device for k_v (optional)
+ * param: tx_first_key_image - KI_1
+ * outparam: s_sender_receiver_unctx_out - s_sr for each enote in order of output enote enote set
+ * outparam: payment_proposal_order_out - order of payment proposals in resultant output enote set
+ */
+void get_sender_receiver_secrets_from_proposal_v1(const std::vector<CarrotPaymentProposalV1> &normal_payment_proposals,
+    const std::vector<CarrotPaymentProposalVerifiableSelfSendV1> &selfsend_payment_proposals,
+    const view_balance_secret_device *s_view_balance_dev,
+    const view_incoming_key_device *k_view_dev,
+    const crypto::key_image &tx_first_key_image,
+    std::vector<crypto::secret_key> &s_sender_receiver_unctx_out,
+    std::vector<std::pair<bool, std::size_t>> &payment_proposal_order_out);
+/**
  * brief: make_signable_tx_hash_from_proposal_v1 - make signable transaction hash from tx proposal and keys
  * param: tx_proposal - transaction proposal
  * param: s_view_balance_dev - device for s_vb (optional)
  * param: k_view_dev - device for k_v (optional)
+ * param: sorted_input_key_images -
+ * param: key_image_dev - device for deriving key images
  * outparam: signable_tx_hash_out - signable transaction hash
  */
+void make_signable_tx_hash_from_proposal_v1(const CarrotTransactionProposalV1 &tx_proposal,
+    const view_balance_secret_device *s_view_balance_dev,
+    const view_incoming_key_device *k_view_dev,
+    const std::vector<crypto::key_image> &sorted_input_key_images,
+    crypto::hash &signable_tx_hash_out);
 void make_signable_tx_hash_from_proposal_v1(const CarrotTransactionProposalV1 &tx_proposal,
     const view_balance_secret_device *s_view_balance_dev,
     const view_incoming_key_device *k_view_dev,


### PR DESCRIPTION
- rename files `address_utils_compact.*` -> `address_utils.*`
- add `make_legacy_subaddress_spend_pubkey()` overload
- add `make_legacy_subaddress_pubkeys()`
- add `calculate_signable_fcmp_pp_transaction_hash()`
- fix public access of `key_image_device_precompted`'s methods
- split `try_scan_opening_hint()` into `try_scan_opening_hint_sender_extensions()` and `try_scan_opening_hint_amount()`
- add `get_sender_receiver_secrets_from_proposal_v1()`
- add `make_signable_tx_hash_from_proposal_v1()` overload with viewkey device

Prerequisite for #52 