### PR TITLE
wallet: move [un]signed_tx_set into hot_cold.h and add serialization header

### DIFF
--- a/src/device/device_cold.hpp
+++ b/src/device/device_cold.hpp
@@ -30,15 +30,32 @@
 #ifndef MONERO_DEVICE_COLD_H
 #define MONERO_DEVICE_COLD_H
 
-#include "wallet/wallet2.h"
+#include "cryptonote_basic/cryptonote_basic_impl.h"
+
 #include <boost/optional/optional.hpp>
 #include <boost/function.hpp>
 
+// fwd
+namespace wallet2_basic
+{
+struct transfer_details;
+} //namespace wallet2_basic
+namespace tools
+{
+namespace wallet
+{
+namespace cold
+{
+struct UnsignedPreCarrotTransactionSet;
+struct SignedFullTransactionSet;
+} //namespace cold
+} //namespace wallet
+} //namespace tools
 
 namespace hw {
 
   typedef struct wallet_shim {
-    boost::function<crypto::public_key (const tools::wallet2::transfer_details &td)> get_tx_pub_key_from_received_outs;
+    boost::function<crypto::public_key (const wallet2_basic::transfer_details &td)> get_tx_pub_key_from_received_outs;
   } wallet_shim;
 
   class tx_aux_data {
@@ -106,15 +123,15 @@ namespace hw {
      * Key image sync with the cold protocol.
      */
     virtual void ki_sync(wallet_shim * wallet,
-                 const std::vector<::tools::wallet2::transfer_details> & transfers,
+                 const std::vector<::wallet2_basic::transfer_details> & transfers,
                  exported_key_image & ski) =0;
 
     /**
      * Signs unsigned transaction with the cold protocol.
      */
     virtual void tx_sign(wallet_shim * wallet,
-                 const ::tools::wallet2::unsigned_tx_set & unsigned_tx,
-                 ::tools::wallet2::signed_tx_set & signed_tx,
+                 const ::tools::wallet::cold::UnsignedPreCarrotTransactionSet & unsigned_tx,
+                 ::tools::wallet::cold::SignedFullTransactionSet& signed_tx,
                  tx_aux_data & aux_data) =0;
 
     /**

--- a/src/device_trezor/device_trezor.cpp
+++ b/src/device_trezor/device_trezor.cpp
@@ -310,7 +310,7 @@ namespace trezor {
     }
 
     void device_trezor::ki_sync(wallet_shim * wallet,
-                                const std::vector<tools::wallet2::transfer_details> & transfers,
+                                const std::vector<wallet2_basic::transfer_details> & transfers,
                                 hw::device_cold::exported_key_image & ski)
     {
 #define EVENT_PROGRESS(P) do { if (m_callback) {(m_callback)->on_progress(device_cold::op_progress(P)); } }while(0)
@@ -507,8 +507,8 @@ namespace trezor {
     }
 
     void device_trezor::tx_sign(wallet_shim * wallet,
-                                const tools::wallet2::unsigned_tx_set & unsigned_tx,
-                                tools::wallet2::signed_tx_set & signed_tx,
+                                const tools::wallet::cold::UnsignedPreCarrotTransactionSet & unsigned_tx,
+                                tools::wallet::cold::SignedFullTransactionSet & signed_tx,
                                 hw::tx_aux_data & aux_data)
     {
       CHECK_AND_ASSERT_THROW_MES(std::get<0>(unsigned_tx.transfers) == 0, "Unsupported non zero offset");
@@ -540,7 +540,6 @@ namespace trezor {
         cpend.fee = cpend.tx.rct_signatures.txnFee;
         cpend.dust_added_to_fee = false;
         cpend.change_dts = cdata.tx_data.change_dts;
-        cpend.selected_transfers = cdata.tx_data.selected_transfers;
         cpend.key_images = "";
         cpend.dests = cdata.tx_data.dests;
         cpend.construction_data = cdata.tx_data;
@@ -595,7 +594,7 @@ namespace trezor {
     }
 
     void device_trezor::tx_sign(wallet_shim * wallet,
-                   const tools::wallet2::unsigned_tx_set & unsigned_tx,
+                   const tools::wallet::cold::UnsignedPreCarrotTransactionSet & unsigned_tx,
                    size_t idx,
                    hw::tx_aux_data & aux_data,
                    std::shared_ptr<protocol::tx::Signer> & signer)
@@ -613,7 +612,7 @@ namespace trezor {
 
       CHECK_AND_ASSERT_THROW_MES(idx < unsigned_tx.txes.size(), "Invalid transaction index");
       signer = std::make_shared<protocol::tx::Signer>(wallet, &unsigned_tx, idx, &aux_data);
-      const tools::wallet2::tx_construction_data & cur_tx = unsigned_tx.txes[idx];
+      const tools::wallet::PreCarrotTransactionProposal & cur_tx = unsigned_tx.txes[idx];
       unsigned long num_sources = cur_tx.sources.size();
       unsigned long num_outputs = cur_tx.splitted_dsts.size();
 
@@ -712,7 +711,7 @@ namespace trezor {
       return client_version;
     }
 
-    void device_trezor::transaction_versions_check(const ::tools::wallet2::unsigned_tx_set & unsigned_tx, hw::tx_aux_data & aux_data)
+    void device_trezor::transaction_versions_check(const ::tools::wallet::cold::UnsignedPreCarrotTransactionSet & unsigned_tx, hw::tx_aux_data & aux_data)
     {
       unsigned cversion = client_version();
 

--- a/src/device_trezor/device_trezor.hpp
+++ b/src/device_trezor/device_trezor.hpp
@@ -68,7 +68,7 @@ namespace trezor {
       size_t m_num_transations_to_sign;
 
       unsigned client_version();
-      void transaction_versions_check(const ::tools::wallet2::unsigned_tx_set & unsigned_tx, hw::tx_aux_data & aux_data);
+      void transaction_versions_check(const ::tools::wallet::cold::UnsignedPreCarrotTransactionSet & unsigned_tx, hw::tx_aux_data & aux_data);
       void transaction_pre_check(std::shared_ptr<messages::monero::MoneroTransactionInitRequest> init_msg);
       void transaction_check(const protocol::tx::TData & tdata, const hw::tx_aux_data & aux_data);
       void device_state_initialize_unsafe() override;
@@ -80,7 +80,7 @@ namespace trezor {
        * Signs particular transaction idx in the unsigned set, keeps state in the signer
        */
       virtual void tx_sign(wallet_shim * wallet,
-                   const ::tools::wallet2::unsigned_tx_set & unsigned_tx,
+                   const ::tools::wallet::cold::UnsignedPreCarrotTransactionSet & unsigned_tx,
                    size_t idx,
                    hw::tx_aux_data & aux_data,
                    std::shared_ptr<protocol::tx::Signer> & signer);
@@ -156,7 +156,7 @@ namespace trezor {
        * Key image sync with the Trezor.
        */
       void ki_sync(wallet_shim * wallet,
-                   const std::vector<::tools::wallet2::transfer_details> & transfers,
+                   const std::vector<::wallet2_basic::transfer_details> & transfers,
                    hw::device_cold::exported_key_image & ski) override;
 
       bool is_live_refresh_supported() const override;
@@ -202,8 +202,8 @@ namespace trezor {
        * Signs unsigned transaction with the Trezor.
        */
       void tx_sign(wallet_shim * wallet,
-                   const ::tools::wallet2::unsigned_tx_set & unsigned_tx,
-                   ::tools::wallet2::signed_tx_set & signed_tx,
+                   const ::tools::wallet::cold::UnsignedPreCarrotTransactionSet & unsigned_tx,
+                   ::tools::wallet::cold::SignedFullTransactionSet & signed_tx,
                    hw::tx_aux_data & aux_data) override;
 
       /**

--- a/src/device_trezor/trezor/protocol.cpp
+++ b/src/device_trezor/trezor/protocol.cpp
@@ -145,7 +145,7 @@ namespace chacha {
 namespace ki {
 
   bool key_image_data(wallet_shim * wallet,
-                      const std::vector<tools::wallet2::transfer_details> & transfers,
+                      const std::vector<wallet2_basic::transfer_details> & transfers,
                       std::vector<MoneroTransferDetails> & res)
   {
     for(auto & td : transfers){
@@ -189,7 +189,7 @@ namespace ki {
   }
 
   void generate_commitment(std::vector<MoneroTransferDetails> & mtds,
-                           const std::vector<tools::wallet2::transfer_details> & transfers,
+                           const std::vector<wallet2_basic::transfer_details> & transfers,
                            std::shared_ptr<messages::monero::MoneroKeyImageExportInitRequest> & req)
   {
     req = std::make_shared<messages::monero::MoneroKeyImageExportInitRequest>();
@@ -441,7 +441,7 @@ namespace tx {
 
   void Signer::set_tx_input(MoneroTransactionSourceEntry * dst, size_t idx, bool need_ring_keys, bool need_ring_indices){
     const cryptonote::tx_source_entry & src = cur_tx().sources[idx];
-    const tools::wallet2::transfer_details & transfer = get_source_transfer(idx);
+    const wallet2_basic::transfer_details & transfer = get_source_transfer(idx);
 
     dst->set_real_output(src.real_output);
     for(size_t i = 0; i < src.outputs.size(); ++i){

--- a/src/device_trezor/trezor/protocol.hpp
+++ b/src/device_trezor/trezor/protocol.hpp
@@ -34,7 +34,7 @@
 #include "device/device_cold.hpp"
 #include "messages_map.hpp"
 #include "transport.hpp"
-#include "wallet/wallet2.h"
+#include "wallet/hot_cold.h"
 
 namespace hw{
 namespace trezor{
@@ -115,7 +115,7 @@ namespace ki {
    * Converts transfer details to the MoneroTransferDetails required for KI sync
    */
   bool key_image_data(wallet_shim * wallet,
-                      const std::vector<tools::wallet2::transfer_details> & transfers,
+                      const std::vector<wallet2_basic::transfer_details> & transfers,
                       std::vector<MoneroTransferDetails> & res);
 
   /**
@@ -127,7 +127,7 @@ namespace ki {
    * Generates KI sync request with commitments computed.
    */
   void generate_commitment(std::vector<MoneroTransferDetails> & mtds,
-                           const std::vector<tools::wallet2::transfer_details> & transfers,
+                           const std::vector<wallet2_basic::transfer_details> & transfers,
                            std::shared_ptr<messages::monero::MoneroKeyImageExportInitRequest> & req);
 
   /**
@@ -151,8 +151,8 @@ namespace tx {
   using MoneroRctKey = messages::monero::MoneroTransactionSourceEntry_MoneroOutputEntry_MoneroRctKeyPublic;
   using MoneroRsigData = messages::monero::MoneroTransactionRsigData;
 
-  using tx_construction_data = tools::wallet2::tx_construction_data;
-  using unsigned_tx_set = tools::wallet2::unsigned_tx_set;
+  using tx_construction_data = tools::wallet::PreCarrotTransactionProposal;
+  using unsigned_tx_set = tools::wallet::cold::UnsignedPreCarrotTransactionSet;
 
   void translate_address(MoneroAccountPublicAddress * dst, const cryptonote::account_public_address * src);
   void translate_dst_entry(MoneroTransactionDestinationEntry * dst, const cryptonote::tx_destination_entry * src);
@@ -229,12 +229,12 @@ namespace tx {
       return m_ct.tx_data;
     }
 
-    const tools::wallet2::transfer_details & get_transfer(size_t idx) const {
+    const wallet2_basic::transfer_details & get_transfer(size_t idx) const {
       CHECK_AND_ASSERT_THROW_MES(idx < std::get<2>(m_unsigned_tx->transfers).size() + std::get<0>(m_unsigned_tx->transfers) && idx >= std::get<0>(m_unsigned_tx->transfers), "Invalid transfer index");
       return std::get<2>(m_unsigned_tx->transfers)[idx - std::get<0>(m_unsigned_tx->transfers)];
     }
 
-    const tools::wallet2::transfer_details & get_source_transfer(size_t idx) const {
+    const wallet2_basic::transfer_details & get_source_transfer(size_t idx) const {
       const auto & sel_transfers = cur_tx().selected_transfers;
       CHECK_AND_ASSERT_THROW_MES(idx < m_ct.source_permutation.size(), "Invalid source index - permutation");
       CHECK_AND_ASSERT_THROW_MES(m_ct.source_permutation[idx] < sel_transfers.size(), "Invalid source index");

--- a/src/wallet/hot_cold.h
+++ b/src/wallet/hot_cold.h
@@ -32,6 +32,7 @@
 #include "carrot_impl/address_device.h"
 #include "carrot_impl/subaddress_index.h"
 #include "span.h"
+#include "tx_builder.h"
 #include "wallet2_basic/wallet2_types.h"
 
 //third party headers
@@ -44,6 +45,8 @@
 namespace tools
 {
 namespace wallet
+{
+namespace cold
 {
 struct exported_pre_carrot_transfer_details
 {
@@ -116,8 +119,26 @@ struct exported_carrot_transfer_details
     mx25519_pubkey selfsend_enote_ephemeral_pubkey;
 };
 
-using exported_transfer_details_variant = std::variant<exported_pre_carrot_transfer_details,
-    exported_carrot_transfer_details>;
+using exported_transfer_details_variant = std::variant<
+        exported_pre_carrot_transfer_details,
+        exported_carrot_transfer_details
+    >;
+
+// The term "Unsigned tx" is not really a tx since it's not signed yet.
+// It doesnt have tx hash, key and the integrated address is not separated into addr + payment id.
+struct UnsignedPreCarrotTransactionSet
+{
+    std::vector<PreCarrotTransactionProposal> txes;
+    std::tuple<uint64_t, uint64_t, wallet2_basic::transfer_container> transfers;
+    std::tuple<uint64_t, uint64_t, std::vector<exported_pre_carrot_transfer_details>> new_transfers;
+};
+
+struct SignedFullTransactionSet
+{
+    std::vector<pending_tx> ptx;
+    std::vector<crypto::key_image> key_images;
+    std::unordered_map<crypto::public_key, crypto::key_image> tx_key_images;
+};
 
 exported_pre_carrot_transfer_details export_cold_pre_carrot_output(const wallet2_basic::transfer_details &td);
 
@@ -136,8 +157,6 @@ wallet2_basic::transfer_details import_cold_carrot_output(const exported_carrot_
 wallet2_basic::transfer_details import_cold_output(const exported_transfer_details_variant &etd,
     const cryptonote::account_keys &acc_keys);
 
-DECLARE_SERIALIZE_OBJECT(exported_pre_carrot_transfer_details, bool skip_version = false)
-DECLARE_SERIALIZE_OBJECT(exported_carrot_transfer_details, bool skip_version = false)
-DECLARE_SERIALIZE_OBJECT(exported_transfer_details_variant)
+} //namespace cold
 } //namespace wallet
 } //namespace tools

--- a/src/wallet/hot_cold_serialization.h
+++ b/src/wallet/hot_cold_serialization.h
@@ -1,0 +1,188 @@
+// Copyright (c) 2025, The Monero Project
+//
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+#include "hot_cold.h"
+#include "tx_builder_serialization.h"
+
+//third party headers
+
+//standard headers
+
+//forward declarations
+
+#define PASSTHROUGH_VERSION(ver_lo, ver_hi) if (!handle_version_passthrough(ar, ver_lo, ver_hi, version)) return false;
+
+#define BEGIN_SERIALIZE_VERSIONED_VARIANT(vtype)                                                     \
+    DISABLE_DEFAULT_VARIANT_SERIALIZATION(vtype)                                                     \
+    template <template <bool> class Archive> bool do_serialize(Archive<true> &ar, vtype &v) {        \
+        ar.begin_object();                                                                           \
+        const bool r = std::visit([&ar](auto &x) -> bool { return do_serialize_object(ar, x); }, v); \
+        ar.end_object();                                                                             \
+        return r && ar.good(); }                                                                     \
+    template <template <bool> class Archive> bool do_serialize(Archive<false> &ar, vtype &v) {       \
+        ar.begin_object();
+
+#define END_SERIALIZE_VERSIONED_VARIANT() do { ar.end_object(); return ar.good(); } while (0); }
+
+#define LOAD_VARIANT_AS_OBJECT_OF_TYPE(ty)                       \
+    do {                                                         \
+        ty vv;                                                   \
+        if (!do_serialize_object(ar, vv, version) || !ar.good()) \
+            return false;                                        \
+        v = std::move(vv);                                       \
+        return true;                                             \
+    } while (0);
+
+namespace tools
+{
+namespace wallet
+{
+namespace cold
+{
+//-------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------------------------
+template <bool W, template <bool> class Archive>
+static bool handle_version_passthrough(Archive<W> &ar,
+    const std::uint32_t min_version,
+    const std::uint32_t max_version,
+    std::uint32_t &version_inout)
+{
+    if (version_inout == (std::uint32_t)-1)
+    {
+        version_inout = max_version;
+        VARINT_FIELD_N("version", version_inout)
+    }
+    else if (W && version_inout != max_version) {
+        // passed conflicting version
+        return false;
+    }
+    return min_version <= version_inout && version_inout <= max_version;
+}
+//-------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------------------------
+BEGIN_SERIALIZE_OBJECT_FN(exported_pre_carrot_transfer_details, uint32_t version = (uint32_t)-1)
+    PASSTHROUGH_VERSION(1, 1)
+    FIELD_F(m_pubkey)
+    VARINT_FIELD_F(m_internal_output_index)
+    VARINT_FIELD_F(m_global_output_index)
+    FIELD_F(m_tx_pubkey)
+    FIELD_F(m_flags.flags)
+    VARINT_FIELD_F(m_amount)
+    FIELD_F(m_additional_tx_keys)
+    VARINT_FIELD_F(m_subaddr_index_major)
+    VARINT_FIELD_F(m_subaddr_index_minor)
+END_SERIALIZE()
+//-------------------------------------------------------------------------------------------------------------------
+BEGIN_SERIALIZE_OBJECT_FN(exported_carrot_transfer_details, uint32_t version = (uint32_t)-1)
+    PASSTHROUGH_VERSION(2, 2)
+    VARINT_FIELD_N("flags", v.flags.flags)
+    if (v.flags.m_coinbase)
+    {
+        FIELD_F(block_index)
+        v.tx_first_key_image = crypto::key_image{};
+    }
+    else
+    {
+        v.block_index = 0;
+        FIELD_F(tx_first_key_image)
+    }
+    if (v.flags.m_has_pid)
+    {
+        FIELD_F(payment_id)
+        v.subaddr_index = {0, 0};
+    }
+    else // !m_has_pid
+    {
+        if (v.flags.m_coinbase)
+        {
+            v.subaddr_index = {0, 0};
+        }
+        else
+        {
+            FIELD_F(subaddr_index)
+        }
+        v.payment_id = carrot::null_payment_id;
+    }
+    VARINT_FIELD_F(amount)
+    FIELD_F(janus_anchor)
+    if (v.flags.m_selfsend)
+        FIELD_F(selfsend_enote_ephemeral_pubkey)
+    else
+        v.selfsend_enote_ephemeral_pubkey = mx25519_pubkey{{0}};
+END_SERIALIZE()
+//-------------------------------------------------------------------------------------------------------------------
+BEGIN_SERIALIZE_OBJECT_FN(UnsignedPreCarrotTransactionSet, uint32_t version = (uint32_t)-1)
+    PASSTHROUGH_VERSION(0, 2)
+    FIELD_F(txes)
+    if (version == 0)
+    {
+        std::pair<size_t, wallet2_basic::transfer_container> v0_transfers;
+        FIELD(v0_transfers);
+        std::get<0>(v.transfers) = std::get<0>(v0_transfers);
+        std::get<1>(v.transfers) = std::get<0>(v0_transfers) + std::get<1>(v0_transfers).size();
+        std::get<2>(v.transfers) = std::get<1>(v0_transfers);
+        return true;
+    }
+    if (version == 1)
+    {
+        std::pair<size_t, std::vector<exported_pre_carrot_transfer_details>> v1_transfers;
+        FIELD(v1_transfers);
+        std::get<0>(v.new_transfers) = std::get<0>(v1_transfers);
+        std::get<1>(v.new_transfers) = std::get<0>(v1_transfers) + std::get<1>(v1_transfers).size();
+        std::get<2>(v.new_transfers) = std::get<1>(v1_transfers);
+        return true;
+    }
+    FIELD_F(new_transfers)
+END_SERIALIZE()
+//-------------------------------------------------------------------------------------------------------------------
+BEGIN_SERIALIZE_OBJECT_FN(SignedFullTransactionSet, uint32_t version = (uint32_t)-1)
+    PASSTHROUGH_VERSION(0, 0)
+    FIELD_F(ptx)
+    FIELD_F(key_images)
+    FIELD_F(tx_key_images)
+END_SERIALIZE()
+//-------------------------------------------------------------------------------------------------------------------
+} //namespace cold
+} //namespace wallet
+} //namespace tools
+//-------------------------------------------------------------------------------------------------------------------
+BEGIN_SERIALIZE_VERSIONED_VARIANT(tools::wallet::cold::exported_transfer_details_variant)
+    using namespace tools::wallet::cold;
+    VERSION_FIELD(0)
+    if (version == 0 || version > 2)
+        return false;
+
+    if (version == 1)
+        LOAD_VARIANT_AS_OBJECT_OF_TYPE(exported_pre_carrot_transfer_details)
+    else
+        LOAD_VARIANT_AS_OBJECT_OF_TYPE(exported_carrot_transfer_details)
+END_SERIALIZE_VERSIONED_VARIANT()
+//-------------------------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -98,6 +98,7 @@ using namespace epee;
 #include "carrot_impl/format_utils.h"
 #include "tx_builder.h"
 #include "tx_builder_serialization.h"
+#include "hot_cold_serialization.h" //! @TODO: remove line after #52 is merged
 
 extern "C"
 {

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -269,7 +269,7 @@ private:
     };
 
     using transfer_details = wallet2_basic::transfer_details;
-    using exported_transfer_details = wallet::exported_pre_carrot_transfer_details;
+    using exported_transfer_details = wallet::cold::exported_pre_carrot_transfer_details;
 
     typedef std::vector<uint64_t> amounts_container;
     using payment_details = wallet2_basic::payment_details;
@@ -293,53 +293,8 @@ private:
     using multisig_sig = wallet::multisig_sig;
     using pending_tx = wallet::pending_tx;
 
-    // The term "Unsigned tx" is not really a tx since it's not signed yet.
-    // It doesnt have tx hash, key and the integrated address is not separated into addr + payment id.
-    struct unsigned_tx_set
-    {
-      std::vector<tx_construction_data> txes;
-      std::tuple<uint64_t, uint64_t, wallet2::transfer_container> transfers;
-      std::tuple<uint64_t, uint64_t, std::vector<wallet2::exported_transfer_details>> new_transfers;
-
-      BEGIN_SERIALIZE_OBJECT()
-        VERSION_FIELD(2)
-        FIELD(txes)
-        if (version == 0)
-        {
-          std::pair<size_t, wallet2::transfer_container> v0_transfers;
-          FIELD(v0_transfers);
-          std::get<0>(transfers) = std::get<0>(v0_transfers);
-          std::get<1>(transfers) = std::get<0>(v0_transfers) + std::get<1>(v0_transfers).size();
-          std::get<2>(transfers) = std::get<1>(v0_transfers);
-          return true;
-        }
-        if (version == 1)
-        {
-          std::pair<size_t, std::vector<wallet2::exported_transfer_details>> v1_transfers;
-          FIELD(v1_transfers);
-          std::get<0>(new_transfers) = std::get<0>(v1_transfers);
-          std::get<1>(new_transfers) = std::get<0>(v1_transfers) + std::get<1>(v1_transfers).size();
-          std::get<2>(new_transfers) = std::get<1>(v1_transfers);
-          return true;
-        }
-
-        FIELD(new_transfers)
-      END_SERIALIZE()
-    };
-
-    struct signed_tx_set
-    {
-      std::vector<pending_tx> ptx;
-      std::vector<crypto::key_image> key_images;
-      std::unordered_map<crypto::public_key, crypto::key_image> tx_key_images;
-
-      BEGIN_SERIALIZE_OBJECT()
-        VERSION_FIELD(0)
-        FIELD(ptx)
-        FIELD(key_images)
-        FIELD(tx_key_images)
-      END_SERIALIZE()
-    };
+    using unsigned_tx_set = wallet::cold::UnsignedPreCarrotTransactionSet;
+    using signed_tx_set = wallet::cold::SignedFullTransactionSet;
 
     struct multisig_tx_set
     {

--- a/tests/fuzz/cold-transaction.cpp
+++ b/tests/fuzz/cold-transaction.cpp
@@ -31,7 +31,7 @@
 #include "cryptonote_basic/blobdatatype.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
-#include "wallet/tx_builder_serialization.h"
+#include "wallet/hot_cold_serialization.h"
 #include "wallet/wallet2.h"
 #include "wallet/wallet2_basic/wallet2_cocobo_serialization.h"
 #include "fuzzer.h"


### PR DESCRIPTION
And move existing hot-cold serializations into that header too. Also allows trezor_device to pull in only wallet/hot_cold.h, not all of wallet/wallet2.h.

Prerequisite for #52.
Depends on #75 and #76.