### PR TITLE
FCMP++: get rid of init hash download on restore + fix deep reorg handling + more

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2677,7 +2677,7 @@ static bool get_fcmp_tx_tree_root(const BlockchainDB *db, const cryptonote::tran
 
   // Make sure reference block exists in the chain
   CHECK_AND_ASSERT_MES(tx.rct_signatures.p.reference_block < db->height(), false,
-      "tx " + epee::string_tools::pod_to_hex(get_transaction_hash(tx)) + " included reference block that was too high");
+      "tx " << get_transaction_hash(tx) << " included reference block that was too high");
 
   // Get the tree root and n tree layers at provided block
   const uint8_t n_tree_layers = db->get_tree_root_at_blk_idx(tx.rct_signatures.p.reference_block, tree_root_out);
@@ -2685,7 +2685,7 @@ static bool get_fcmp_tx_tree_root(const BlockchainDB *db, const cryptonote::tran
   // Make sure the provided n tree layers matches expected
   // IMPORTANT!
   CHECK_AND_ASSERT_MES(tx.rct_signatures.p.n_tree_layers == n_tree_layers, false,
-      "tx " + epee::string_tools::pod_to_hex(get_transaction_hash(tx)) + " included incorrect number of tree layers");
+      "tx " << get_transaction_hash(tx) << " included incorrect number of tree layers");
 
   return true;
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2980,7 +2980,7 @@ bool Blockchain::find_blockchain_supplement(const uint64_t req_start_block, cons
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
   // if a specific start height has been requested
-  if(qblock_ids.empty() || req_start_block > 0)
+  if(req_start_block > 0)
   {
     // if requested height is higher than our chain, return false -- we can't help
     top_hash = m_db->top_block_hash(&total_height);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2980,7 +2980,7 @@ bool Blockchain::find_blockchain_supplement(const uint64_t req_start_block, cons
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
 
   // if a specific start height has been requested
-  if(req_start_block > 0)
+  if(qblock_ids.empty() || req_start_block > 0)
   {
     // if requested height is higher than our chain, return false -- we can't help
     top_hash = m_db->top_block_hash(&total_height);

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2677,7 +2677,7 @@ static bool get_fcmp_tx_tree_root(const BlockchainDB *db, const cryptonote::tran
 
   // Make sure reference block exists in the chain
   CHECK_AND_ASSERT_MES(tx.rct_signatures.p.reference_block < db->height(), false,
-      "tx included reference block that was too high");
+      "tx " + epee::string_tools::pod_to_hex(get_transaction_hash(tx)) + " included reference block that was too high");
 
   // Get the tree root and n tree layers at provided block
   const uint8_t n_tree_layers = db->get_tree_root_at_blk_idx(tx.rct_signatures.p.reference_block, tree_root_out);
@@ -2685,7 +2685,7 @@ static bool get_fcmp_tx_tree_root(const BlockchainDB *db, const cryptonote::tran
   // Make sure the provided n tree layers matches expected
   // IMPORTANT!
   CHECK_AND_ASSERT_MES(tx.rct_signatures.p.n_tree_layers == n_tree_layers, false,
-      "tx included incorrect number of tree layers");
+      "tx " + epee::string_tools::pod_to_hex(get_transaction_hash(tx)) + " included incorrect number of tree layers");
 
   return true;
 }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2674,6 +2674,7 @@ static bool get_fcmp_tx_tree_root(const BlockchainDB *db, const cryptonote::tran
   tree_root_out = crypto::ec_point{};
   if (!rct::is_rct_fcmp(tx.rct_signatures.type))
     return true;
+  CHECK_AND_ASSERT_MES(!tx.pruned, false, "can't get root for pruned FCMP txs");
 
   // Make sure reference block exists in the chain
   CHECK_AND_ASSERT_MES(tx.rct_signatures.p.reference_block < db->height(), false,
@@ -2696,6 +2697,7 @@ static bool set_fcmp_tx_tree_root(const BlockchainDB *db,
 {
   if (!rct::is_rct_fcmp(tx.rct_signatures.type))
     return true;
+  CHECK_AND_ASSERT_MES(!tx.pruned, false, "can't set root for pruned FCMP txs");
 
   const uint64_t ref_block_index = tx.rct_signatures.p.reference_block;
 
@@ -3007,7 +3009,7 @@ bool Blockchain::find_blockchain_supplement(const uint64_t req_start_block, cons
       // if start_height is now the chain tip, we can return a truthy empty resp
       if (start_height == total_height)
       {
-        LOG_PRINT_L2("Returning empty find_blockchain_supplement, start_height: " << start_height);
+        LOG_PRINT_L3("Returning empty find_blockchain_supplement, start_height: " << start_height);
         blocks.clear();
         return true;
       }

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -508,10 +508,11 @@ namespace cryptonote
      * @param pruned whether to return full or pruned tx blobs
      * @param max_block_count the max number of blocks to get
      * @param max_tx_count the max number of txes to get (it can get overshot by the last block's number of txes minus 1)
+     * @param qblock_ids_skip_common_block when using qblock_ids, indicates whether or not to include common block in response
      *
      * @return true if a block found in common or req_start_block specified, else false
      */
-    bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count) const;
+    bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count, bool qblock_ids_skip_common_block = false) const;
 
     /**
      * @brief retrieves a set of blocks and their transactions, and possibly other transactions

--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1271,9 +1271,9 @@ namespace cryptonote
     return m_blockchain_storage.find_blockchain_supplement(qblock_ids, clip_pruned, resp);
   }
   //-----------------------------------------------------------------------------------------------
-  bool core::find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count) const
+  bool core::find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count, bool qblock_ids_skip_common_block) const
   {
-    return m_blockchain_storage.find_blockchain_supplement(req_start_block, qblock_ids, blocks, total_height, top_hash, start_height, pruned, get_miner_tx_hash, max_block_count, max_tx_count);
+    return m_blockchain_storage.find_blockchain_supplement(req_start_block, qblock_ids, blocks, total_height, top_hash, start_height, pruned, get_miner_tx_hash, max_block_count, max_tx_count, qblock_ids_skip_common_block);
   }
   //-----------------------------------------------------------------------------------------------
   bool core::get_outs(const COMMAND_RPC_GET_OUTPUTS_BIN::request& req, COMMAND_RPC_GET_OUTPUTS_BIN::response& res) const

--- a/src/cryptonote_core/cryptonote_core.h
+++ b/src/cryptonote_core/cryptonote_core.h
@@ -589,11 +589,11 @@ namespace cryptonote
      bool find_blockchain_supplement(const std::list<crypto::hash>& qblock_ids, bool clip_pruned, NOTIFY_RESPONSE_CHAIN_ENTRY::request& resp) const;
 
      /**
-      * @copydoc Blockchain::find_blockchain_supplement(const uint64_t, const std::list<crypto::hash>&, std::vector<std::pair<cryptonote::blobdata, std::vector<cryptonote::blobdata> > >&, uint64_t&, uint64_t&, size_t) const
+      * @copydoc Blockchain::find_blockchain_supplement(const uint64_t, const std::list<crypto::hash>&, std::vector<std::pair<cryptonote::blobdata, std::vector<cryptonote::blobdata> > >&, uint64_t&, uint64_t&, size_t, bool) const
       *
-      * @note see Blockchain::find_blockchain_supplement(const uint64_t, const std::list<crypto::hash>&, std::vector<std::pair<cryptonote::blobdata, std::vector<transaction> > >&, uint64_t&, uint64_t&, size_t) const
+      * @note see Blockchain::find_blockchain_supplement(const uint64_t, const std::list<crypto::hash>&, std::vector<std::pair<cryptonote::blobdata, std::vector<transaction> > >&, uint64_t&, uint64_t&, size_t, bool) const
       */
-     bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count) const;
+     bool find_blockchain_supplement(const uint64_t req_start_block, const std::list<crypto::hash>& qblock_ids, std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > >& blocks, uint64_t& total_height, crypto::hash& top_hash, uint64_t& start_height, bool pruned, bool get_miner_tx_hash, size_t max_block_count, size_t max_tx_count, bool qblock_ids_skip_common_block = false) const;
 
      /**
       * @copydoc Blockchain::get_tx_outputs_gindexs

--- a/src/fcmp_pp/tree_cache.h
+++ b/src/fcmp_pp/tree_cache.h
@@ -185,9 +185,17 @@ public:
     uint64_t get_n_leaf_tuples() const noexcept;
     bool get_top_block(BlockMeta &top_block_out) const
     {
-        CHECK_AND_ASSERT_MES(!m_cached_blocks.empty(), false, "empty cached blocks");
+        CHECK_AND_ASSERT_MES(!m_cached_blocks.empty(), false, "get_top_block: empty cached blocks");
         BlockMeta top_block = m_cached_blocks.back();
         top_block_out = std::move(top_block);
+        return true;
+    };
+
+    bool get_front_block(BlockMeta &front_block_out) const
+    {
+        CHECK_AND_ASSERT_MES(!m_cached_blocks.empty(), false, "get_front_block: empty cached blocks");
+        BlockMeta front_block = m_cached_blocks.front();
+        front_block_out = std::move(front_block);
         return true;
     };
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -851,7 +851,7 @@ namespace cryptonote
       }
 
       std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > > bs;
-      if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.top_block_hash, res.start_height, req.prune, !req.no_miner_tx, max_blocks, COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT))
+      if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.top_block_hash, res.start_height, req.prune, !req.no_miner_tx, max_blocks, COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT, req.block_ids_skip_common_block))
       {
         res.status = "Failed";
         add_host_fail(ctx);
@@ -2029,6 +2029,7 @@ namespace cryptonote
     {
       error_resp.code = CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT;
       error_resp.message = std::string("Requested block height: ") + std::to_string(h) + " greater than current top block height: " +  std::to_string(m_core.get_current_blockchain_height() - 1);
+      return false;
     }
     res = string_tools::pod_to_hex(m_core.get_block_id_by_height(h));
     return true;
@@ -3201,9 +3202,7 @@ namespace cryptonote
 
     res.version = CORE_RPC_VERSION;
     res.release = MONERO_VERSION_IS_RELEASE;
-    crypto::hash top_hash;
-    m_core.get_blockchain_top(res.current_height, top_hash);
-    res.top_hash = epee::string_tools::pod_to_hex(top_hash);
+    res.current_height = m_core.get_current_blockchain_height();
     res.target_height = m_p2p.get_payload_object().is_synchronized() ? 0 : m_core.get_target_blockchain_height();
     for (const auto &hf : m_core.get_blockchain_storage().get_hardforks())
        res.hard_forks.push_back({hf.version, hf.height});

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -923,7 +923,7 @@ namespace cryptonote
 
       // Get the data necessary to start syncing the tree from the first returned block
       const uint64_t init_block_idx = res.start_height == 0 ? 0 : (res.start_height - 1);
-      const crypto::hash init_block_hash = b.prev_id;
+      const crypto::hash init_block_hash = res.start_height == 0 ? get_block_hash(b) : b.prev_id;
       if (!set_init_tree_sync_data(init_block_idx, init_block_hash, m_core, res.init_tree_sync_data))
       {
         res.status = "Failed";
@@ -3201,7 +3201,9 @@ namespace cryptonote
 
     res.version = CORE_RPC_VERSION;
     res.release = MONERO_VERSION_IS_RELEASE;
-    res.current_height = m_core.get_current_blockchain_height();
+    crypto::hash top_hash;
+    m_core.get_blockchain_top(res.current_height, top_hash);
+    res.top_hash = epee::string_tools::pod_to_hex(top_hash);
     res.target_height = m_p2p.get_payload_object().is_synchronized() ? 0 : m_core.get_target_blockchain_height();
     for (const auto &hf : m_core.get_blockchain_storage().get_hardforks())
        res.hard_forks.push_back({hf.version, hf.height});

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -915,15 +915,16 @@ namespace cryptonote
       }
 
       block b;
-      crypto::hash init_block_hash;
-      if(!parse_and_validate_block_from_blob(res.blocks.front().block, b, init_block_hash))
+      if(!parse_and_validate_block_from_blob(res.blocks.front().block, b))
       {
         res.status = "Failed";
         return true;
       }
 
-      // Get the data necessary to start syncing the tree from the provided height
-      if (!set_init_tree_sync_data(res.start_height, init_block_hash, m_core, res.init_tree_sync_data))
+      // Get the data necessary to start syncing the tree from the first returned block
+      const uint64_t init_block_idx = res.start_height == 0 ? 0 : (res.start_height - 1);
+      const crypto::hash init_block_hash = b.prev_id;
+      if (!set_init_tree_sync_data(init_block_idx, init_block_hash, m_core, res.init_tree_sync_data))
       {
         res.status = "Failed";
         return true;

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -194,6 +194,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint64_t    pool_info_since;
       uint64_t    max_block_count;
       bool        init_tree_sync;
+      bool        block_ids_skip_common_block;
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE_PARENT(rpc_access_request_base)
         KV_SERIALIZE_OPT(requested_info, (uint8_t)0)
@@ -204,6 +205,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE_OPT(pool_info_since, (uint64_t)0)
         KV_SERIALIZE_OPT(max_block_count, (uint64_t)0)
         KV_SERIALIZE_OPT(init_tree_sync, false)
+        KV_SERIALIZE_OPT(block_ids_skip_common_block, false)
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<request_t> request;
@@ -2296,7 +2298,6 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint32_t version;
       bool release;
       uint64_t current_height;
-      std::string top_hash;
       uint64_t target_height;
       std::vector<hf_entry> hard_forks;
 
@@ -2305,7 +2306,6 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE(version)
         KV_SERIALIZE(release)
         KV_SERIALIZE_OPT(current_height, (uint64_t)0)
-        KV_SERIALIZE_OPT(top_hash, std::string(""))
         KV_SERIALIZE_OPT(target_height, (uint64_t)0)
         KV_SERIALIZE_OPT(hard_forks, std::vector<hf_entry>())
       END_KV_SERIALIZE_MAP()

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2296,6 +2296,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint32_t version;
       bool release;
       uint64_t current_height;
+      std::string top_hash;
       uint64_t target_height;
       std::vector<hf_entry> hard_forks;
 
@@ -2304,6 +2305,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE(version)
         KV_SERIALIZE(release)
         KV_SERIALIZE_OPT(current_height, (uint64_t)0)
+        KV_SERIALIZE_OPT(top_hash, std::string(""))
         KV_SERIALIZE_OPT(target_height, (uint64_t)0)
         KV_SERIALIZE_OPT(hard_forks, std::vector<hf_entry>())
       END_KV_SERIALIZE_MAP()

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -8534,6 +8534,7 @@ bool simple_wallet::get_transfers(std::vector<std::string>& local_args, std::vec
         }
         else
         {
+          // FIXME: update for FCMP++
           const uint64_t adjusted_time = m_wallet->get_daemon_adjusted_time();
           uint64_t threshold = adjusted_time + (m_wallet->use_fork_rules(2, 0) ? CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V2 : CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1);
           if (threshold < pd.m_unlock_time)
@@ -10271,6 +10272,7 @@ bool simple_wallet::show_transfer(const std::vector<std::string> &args)
       }
       else
       {
+        // FIXME: update for FCMP++
         const uint64_t adjusted_time = m_wallet->get_daemon_adjusted_time();
         uint64_t threshold = adjusted_time + (m_wallet->use_fork_rules(2, 0) ? CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V2 : CRYPTONOTE_LOCKED_TX_ALLOWED_DELTA_SECONDS_V1);
         if (threshold >= pd.m_unlock_time)

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -61,7 +61,6 @@ NodeRPCProxy::NodeRPCProxy(epee::net_utils::http::abstract_http_client &http_cli
 void NodeRPCProxy::invalidate()
 {
   m_height = 0;
-  m_top_hash = crypto::hash{};
   for (size_t n = 0; n < 256; ++n)
     m_earliest_height[n] = 0;
   m_dynamic_base_fee_estimate = 0;
@@ -101,7 +100,6 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_version(uint32_t &rpc_version
     if (resp_t.current_height > 0 || resp_t.target_height > 0)
     {
       m_height = resp_t.current_height;
-      epee::string_tools::hex_to_pod(resp_t.top_hash, m_top_hash);
       m_target_height = resp_t.target_height;
       m_height_time = now;
       m_target_height_time = now;
@@ -119,10 +117,9 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_version(uint32_t &rpc_version
   return boost::optional<std::string>();
 }
 
-void NodeRPCProxy::set_height(uint64_t h, const crypto::hash &top_hash)
+void NodeRPCProxy::set_height(uint64_t h)
 {
   m_height = h;
-  m_top_hash = top_hash;
   m_height_time = time(NULL);
 }
 
@@ -143,7 +140,6 @@ boost::optional<std::string> NodeRPCProxy::get_info()
     }
 
     m_height = resp_t.height;
-    epee::string_tools::hex_to_pod(resp_t.top_block_hash, m_top_hash);
     m_target_height = resp_t.target_height;
     m_block_weight_limit = resp_t.block_weight_limit ? resp_t.block_weight_limit : resp_t.block_size_limit;
     m_adjusted_time = resp_t.adjusted_time;
@@ -167,15 +163,6 @@ boost::optional<std::string> NodeRPCProxy::get_height(uint64_t &height)
   if (res)
     return res;
   height = m_height;
-  return boost::optional<std::string>();
-}
-
-boost::optional<std::string> NodeRPCProxy::get_top_hash(uint64_t &height, crypto::hash &top_hash)
-{
-  auto res = this->get_height(height);
-  if (res)
-    return res;
-  top_hash = m_top_hash;
   return boost::optional<std::string>();
 }
 

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -61,6 +61,7 @@ NodeRPCProxy::NodeRPCProxy(epee::net_utils::http::abstract_http_client &http_cli
 void NodeRPCProxy::invalidate()
 {
   m_height = 0;
+  m_top_hash = crypto::hash{};
   for (size_t n = 0; n < 256; ++n)
     m_earliest_height[n] = 0;
   m_dynamic_base_fee_estimate = 0;
@@ -100,6 +101,7 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_version(uint32_t &rpc_version
     if (resp_t.current_height > 0 || resp_t.target_height > 0)
     {
       m_height = resp_t.current_height;
+      epee::string_tools::hex_to_pod(resp_t.top_hash, m_top_hash);
       m_target_height = resp_t.target_height;
       m_height_time = now;
       m_target_height_time = now;
@@ -117,9 +119,10 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_version(uint32_t &rpc_version
   return boost::optional<std::string>();
 }
 
-void NodeRPCProxy::set_height(uint64_t h)
+void NodeRPCProxy::set_height(uint64_t h, const crypto::hash &top_hash)
 {
   m_height = h;
+  m_top_hash = top_hash;
   m_height_time = time(NULL);
 }
 
@@ -140,6 +143,7 @@ boost::optional<std::string> NodeRPCProxy::get_info()
     }
 
     m_height = resp_t.height;
+    epee::string_tools::hex_to_pod(resp_t.top_block_hash, m_top_hash);
     m_target_height = resp_t.target_height;
     m_block_weight_limit = resp_t.block_weight_limit ? resp_t.block_weight_limit : resp_t.block_size_limit;
     m_adjusted_time = resp_t.adjusted_time;
@@ -163,6 +167,15 @@ boost::optional<std::string> NodeRPCProxy::get_height(uint64_t &height)
   if (res)
     return res;
   height = m_height;
+  return boost::optional<std::string>();
+}
+
+boost::optional<std::string> NodeRPCProxy::get_top_hash(uint64_t &height, crypto::hash &top_hash)
+{
+  auto res = this->get_height(height);
+  if (res)
+    return res;
+  top_hash = m_top_hash;
   return boost::optional<std::string>();
 }
 

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -48,7 +48,8 @@ public:
 
   boost::optional<std::string> get_rpc_version(uint32_t &rpc_version, std::vector<std::pair<uint8_t, uint64_t>> &daemon_hard_forks, uint64_t &height, uint64_t &target_height);
   boost::optional<std::string> get_height(uint64_t &height);
-  void set_height(uint64_t h);
+  boost::optional<std::string> get_top_hash(uint64_t &height, crypto::hash &top_hash);
+  void set_height(uint64_t h, const crypto::hash &top_hash);
   boost::optional<std::string> get_target_height(uint64_t &height);
   boost::optional<std::string> get_block_weight_limit(uint64_t &block_weight_limit);
   boost::optional<std::string> get_adjusted_time(uint64_t &adjusted_time);
@@ -67,6 +68,7 @@ private:
   bool m_offline;
 
   uint64_t m_height;
+  crypto::hash m_top_hash;
   uint64_t m_earliest_height[256];
   uint64_t m_dynamic_base_fee_estimate;
   uint64_t m_dynamic_base_fee_estimate_cached_height;

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -48,8 +48,7 @@ public:
 
   boost::optional<std::string> get_rpc_version(uint32_t &rpc_version, std::vector<std::pair<uint8_t, uint64_t>> &daemon_hard_forks, uint64_t &height, uint64_t &target_height);
   boost::optional<std::string> get_height(uint64_t &height);
-  boost::optional<std::string> get_top_hash(uint64_t &height, crypto::hash &top_hash);
-  void set_height(uint64_t h, const crypto::hash &top_hash);
+  void set_height(uint64_t h);
   boost::optional<std::string> get_target_height(uint64_t &height);
   boost::optional<std::string> get_block_weight_limit(uint64_t &block_weight_limit);
   boost::optional<std::string> get_adjusted_time(uint64_t &adjusted_time);
@@ -68,7 +67,6 @@ private:
   bool m_offline;
 
   uint64_t m_height;
-  crypto::hash m_top_hash;
   uint64_t m_earliest_height[256];
   uint64_t m_dynamic_base_fee_estimate;
   uint64_t m_dynamic_base_fee_estimate_cached_height;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3233,7 +3233,7 @@ set_start_parsed_block_i_out:
   if (split_point_out == 0)
   {
     // No reorg, set start_parsed_block_i_inout to the first block in parsed_blocks we have not yet processed.
-    start_parsed_block_i_inout += std::max(blockchain.size(), parsed_blocks_start_idx) - parsed_blocks_start_idx;
+    start_parsed_block_i_inout += std::max((uint64_t)blockchain.size(), parsed_blocks_start_idx) - parsed_blocks_start_idx;
     return split_point_out;
   }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3292,10 +3292,10 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const std::vect
   }
 
   // Start processing blockchain entries with scanned outputs
-  size_t current_index = start_height;
   tx_output_idx = 0;
   for (size_t i = tree_sync_start_params.start_parsed_block_i; i < blocks.size(); ++i)
   {
+    const size_t current_index = start_height + i;
     const crypto::hash &bl_id = parsed_blocks[i].hash;
     const cryptonote::block &bl = parsed_blocks[i].block;
 
@@ -3325,7 +3325,6 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const std::vect
       LOG_PRINT_L2("Block is already in blockchain: " << string_tools::pod_to_hex(bl_id));
     }
     tx_output_idx += n_block_outputs;
-    ++current_index;
   }
   }
   catch (...)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3001,8 +3001,8 @@ void wallet2::pull_blocks(bool first, bool try_incremental, uint64_t &blocks_sta
 {
   cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
   cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res = AUTO_VAL_INIT(res);
-
   req.block_ids = short_chain_history;
+
   req.prune = true;
   req.no_miner_tx = false; // always need the miner tx so we can grow the tree correctly
   req.init_tree_sync = m_tree_cache.n_synced_blocks() == 0;
@@ -3514,7 +3514,7 @@ void wallet2::pull_and_parse_next_blocks(bool first, bool try_incremental, uint6
     // pull the new blocks
     std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> o_indices;
     boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> init_tree_sync_data;
-    pull_blocks(first, try_incremental, short_chain_history, blocks_start_height, blocks, o_indices, top_hash, process_pool_txs, init_tree_sync_data);
+    pull_blocks(first, try_incremental, blocks_start_height, short_chain_history, blocks, o_indices, top_hash, process_pool_txs, init_tree_sync_data);
     THROW_WALLET_EXCEPTION_IF(blocks.size() != o_indices.size(), error::wallet_internal_error, "Mismatched sizes of blocks and o_indices");
 
     tools::threadpool& tpool = tools::threadpool::getInstanceForCompute();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3983,7 +3983,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
     std::string err;
     const uint64_t daemon_height = this->get_daemon_blockchain_height(err);
     THROW_WALLET_EXCEPTION_IF(!err.empty(), error::wallet_internal_error, "Failed to get height");
-    if (m_refresh_from_block_height >= daemon_height) {
+    if (m_refresh_from_block_height > daemon_height) {
       MWARNING("Restore height is higher than the current chain tip, not syncing");
       return;
     }

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3200,7 +3200,7 @@ static uint64_t check_for_reorg(const uint64_t parsed_blocks_start_idx, const cr
   if (cur_block_idx >= blockchain.size())
     goto set_start_parsed_block_i_out;
 
- // Finally, check the last hash in parsed blocks for a reorg
+  // Finally, check the last hash in parsed blocks for a reorg
   MDEBUG("Checking for reorg split point on last parsed block " << cur_block_idx);
   THROW_WALLET_EXCEPTION_IF(!blockchain.is_in_bounds(cur_block_idx), error::wallet_internal_error,
     "check_for_reorg: last parsed block is not in bounds");
@@ -3329,7 +3329,7 @@ static std::list<crypto::hash> prepare_first_short_chain_history(const bool m_fi
   return short_chain_history;
 }
 //----------------------------------------------------------------------------------------------------
-// Return true if wallet should preoceed with refresh, or false if wallet should not
+// Return true if wallet should proceed with refresh, or false if wallet should not
 bool wallet2::bump_refresh_start_height(const uint64_t init_start_height, const bool trusted_daemon)
 {
   const uint64_t start_height = std::max(m_refresh_from_block_height, init_start_height);
@@ -11728,7 +11728,7 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks)
 
   bool close_enough = (int64_t)height >= (int64_t)earliest_height - early_blocks && earliest_height != std::numeric_limits<uint64_t>::max(); // start using the rules that many blocks beforehand
   if (close_enough)
-    LOG_PRINT_L3("Using v" << (unsigned)version << " rules");
+    LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
   else
     LOG_PRINT_L2("Not using v" << (unsigned)version << " rules");
   return close_enough;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4245,6 +4245,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
         last = false;
         blocks.clear();
         parsed_blocks.clear();
+        cur_chain = m_blockchain;
         ++try_count;
       }
       else

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3270,7 +3270,7 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const std::vect
   // create tx scanning jobs for all relevant tx outputs in all blocks
   tools::threadpool::waiter scan_blocks_waiter(tpool);
   size_t tx_output_idx = 0;
-  for (size_t i = 0; i < blocks.size(); ++i)
+  for (size_t i = tree_sync_start_params.start_parsed_block_i; i < blocks.size(); ++i)
   {
     const parsed_block &par_blk = parsed_blocks.at(i);
     const std::uint64_t height = start_height + i;
@@ -3294,7 +3294,7 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const std::vect
   // Start processing blockchain entries with scanned outputs
   size_t current_index = start_height;
   tx_output_idx = 0;
-  for (size_t i = 0; i < blocks.size(); ++i)
+  for (size_t i = tree_sync_start_params.start_parsed_block_i; i < blocks.size(); ++i)
   {
     const crypto::hash &bl_id = parsed_blocks[i].hash;
     const cryptonote::block &bl = parsed_blocks[i].block;

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3093,6 +3093,7 @@ static bool check_for_reorg(const uint64_t parsed_blocks_start_idx, const crypto
     return false;
   }
 
+  // We don't expect to ever need to start from genesis
   THROW_WALLET_EXCEPTION_IF(parsed_blocks_start_idx == 0, error::wallet_internal_error,
     "check_for_reorg: did not expect parsed_blocks_start_idx == 0");
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2872,7 +2872,7 @@ void wallet2::process_new_blockchain_entry(const cryptonote::block& b,
 
   // Shrink m_blockchain to max reorg depth
   while ((m_blockchain.offset() + m_max_reorg_depth) < m_blockchain.size())
-    m_blockchain.pop_front();
+    m_blockchain.pop_oldest();
 
   if (0 != m_callback)
     m_callback->on_new_block(height, b);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3146,7 +3146,7 @@ uint64_t wallet2::check_and_handle_reorg(const uint64_t start_height, const cryp
   uint64_t start_parsed_block_i = 0;
   if (!check_for_reorg(start_height, top_hash, parsed_blocks, m_blockchain, reorg_split_point))
   {
-    // No reorg, return
+    MDEBUG("No reorg detected");
     return start_parsed_block_i;
   }
 
@@ -4152,7 +4152,7 @@ void wallet2::refresh(bool trusted_daemon, uint64_t start_height, uint64_t & blo
 
   m_multisig_rescan_k = std::vector<std::vector<rct::key>>{};
 
-  LOG_PRINT_L1("Refresh done, blocks received: " << blocks_fetched << ", balance (all accounts): " << print_money(balance_all(false)) << ", unlocked: " << print_money(unlocked_balance_all(false)));
+  LOG_PRINT_L1("Refresh done, blocks received: " << blocks_fetched << ", current sync height: " << m_blockchain.size() << ", balance (all accounts): " << print_money(balance_all(false)) << ", unlocked: " << print_money(unlocked_balance_all(false)));
 }
 //----------------------------------------------------------------------------------------------------
 bool wallet2::refresh(bool trusted_daemon, uint64_t & blocks_fetched, bool& received_money, bool& ok)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1431,7 +1431,6 @@ private:
     detached_blockchain_data detach_blockchain(uint64_t height,
       std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     void handle_reorg(uint64_t height, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
-    void get_short_chain_history(std::list<crypto::hash>& ids, uint64_t granularity = 1) const;
     bool clear();
     void clear_soft(bool keep_key_images=false);
     /*
@@ -1443,10 +1442,8 @@ private:
      * that this function deletes data that is not useful for background syncing
      */
     void clear_user_data();
-    void pull_blocks(bool first, bool try_incremental, uint64_t start_height, uint64_t& blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, uint64_t &current_height, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
-    void pull_hashes(uint64_t start_height, uint64_t& blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<crypto::hash> &hashes);
-    void fast_refresh(uint64_t stop_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, bool force = false);
-    void pull_and_parse_next_blocks(bool first, bool try_incremental, uint64_t start_height, uint64_t &blocks_start_height, std::list<crypto::hash> &short_chain_history, const std::vector<cryptonote::block_complete_entry> &prev_blocks, const std::vector<parsed_block> &prev_parsed_blocks, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, bool &last, bool &error, std::exception_ptr &exception);
+    void pull_blocks(bool first, bool try_incremental, uint64_t start_height, uint64_t& blocks_start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, uint64_t &current_height, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
+    void pull_and_parse_next_blocks(bool first, bool try_incremental, uint64_t start_height, uint64_t &blocks_start_height, const std::vector<cryptonote::block_complete_entry> &prev_blocks, const std::vector<parsed_block> &prev_parsed_blocks, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, bool &last, bool &error, std::exception_ptr &exception);
     void process_parsed_blocks(const uint64_t start_height, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     bool accept_pool_tx_for_processing(const crypto::hash &txid);
     void process_unconfirmed_transfer(bool incremental, const crypto::hash &txid, wallet2::unconfirmed_transfer_details &tx_details, bool seen_in_pool, std::chrono::system_clock::time_point now, bool refreshed);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1432,7 +1432,6 @@ private:
     detached_blockchain_data detach_blockchain(uint64_t height,
       std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     void handle_reorg(uint64_t height, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
-    void get_short_chain_history(std::list<crypto::hash>& ids) const;
     bool clear();
     void clear_soft(bool keep_key_images=false);
     /*
@@ -1444,8 +1443,8 @@ private:
      * that this function deletes data that is not useful for background syncing
      */
     void clear_user_data();
-    void pull_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, crypto::hash &top_hash, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
-    void pull_and_parse_next_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, crypto::hash &top_hash, bool &error, std::exception_ptr &exception);
+    void pull_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, crypto::hash &top_hash, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
+    void pull_and_parse_next_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, crypto::hash &top_hash, bool &error, std::exception_ptr &exception);
     void process_parsed_blocks(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     uint64_t check_and_handle_reorg(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<parsed_block> &parsed_blocks, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     bool accept_pool_tx_for_processing(const crypto::hash &txid);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1442,9 +1442,10 @@ private:
      * that this function deletes data that is not useful for background syncing
      */
     void clear_user_data();
-    void pull_blocks(bool first, bool try_incremental, uint64_t start_height, uint64_t& blocks_start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, uint64_t &current_height, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
-    void pull_and_parse_next_blocks(bool first, bool try_incremental, uint64_t start_height, uint64_t &blocks_start_height, const std::vector<cryptonote::block_complete_entry> &prev_blocks, const std::vector<parsed_block> &prev_parsed_blocks, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, bool &last, bool &error, std::exception_ptr &exception);
-    void process_parsed_blocks(const uint64_t start_height, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
+    void pull_blocks(bool first, bool try_incremental, const uint64_t start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, crypto::hash &top_hash, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
+    void pull_and_parse_next_blocks(bool first, bool try_incremental, const uint64_t start_height, const std::vector<cryptonote::block_complete_entry> &prev_blocks, const std::vector<parsed_block> &prev_parsed_blocks, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, crypto::hash &top_hash, bool &error, std::exception_ptr &exception);
+    void process_parsed_blocks(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
+    uint64_t check_and_handle_reorg(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<parsed_block> &parsed_blocks, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     bool accept_pool_tx_for_processing(const crypto::hash &txid);
     void process_unconfirmed_transfer(bool incremental, const crypto::hash &txid, wallet2::unconfirmed_transfer_details &tx_details, bool seen_in_pool, std::chrono::system_clock::time_point now, bool refreshed);
     void process_pool_info_extent(const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response &res, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> &process_txs, bool refreshed);
@@ -1474,7 +1475,6 @@ private:
     bool tx_add_fake_output(std::vector<std::vector<tools::wallet2::get_outs_entry>> &outs, uint64_t global_index, const crypto::public_key& tx_public_key, const rct::key& mask, uint64_t real_index, bool unlocked, std::unordered_set<crypto::public_key> &valid_public_keys_cache) const;
     bool should_pick_a_second_output(bool use_rct, size_t n_transfers, const std::vector<size_t> &unused_transfers_indices, const std::vector<size_t> &unused_dust_indices) const;
     std::vector<size_t> get_only_rct(const std::vector<size_t> &unused_dust_indices, const std::vector<size_t> &unused_transfers_indices) const;
-    void trim_hashchain();
     crypto::key_image get_multisig_composite_key_image(size_t n) const;
     rct::multisig_kLRki get_multisig_composite_kLRki(size_t n,  const std::unordered_set<crypto::public_key> &ignore_set, std::unordered_set<rct::key> &used_L, std::unordered_set<rct::key> &new_used_L) const;
     rct::multisig_kLRki get_multisig_kLRki(size_t n, const rct::key &k) const;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1653,6 +1653,9 @@ private:
     boost::optional<crypto::chacha_key> m_custom_background_key = boost::none;
     std::shared_ptr<wallet_keys_unlocker> m_encrypt_keys_after_refresh;
     /// synchronizes access to m_encrypt_keys_after_refresh and password callback
+    boost::mutex m_encrypt_keys_after_refresh_mutex;
+
+    /// synchronizes access to main refresh loop
     boost::mutex m_refresh_mutex;
 
     bool m_unattended;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1117,6 +1117,7 @@ private:
     std::string get_daemon_address() const;
     const boost::optional<epee::net_utils::http::login>& get_daemon_login() const { return m_daemon_login; }
     uint64_t get_daemon_blockchain_height(std::string& err);
+    uint64_t get_daemon_blockchain_top_hash(crypto::hash& top_hash);
     uint64_t get_daemon_blockchain_target_height(std::string& err);
     uint64_t get_daemon_adjusted_time();
 
@@ -1431,6 +1432,7 @@ private:
     detached_blockchain_data detach_blockchain(uint64_t height,
       std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     void handle_reorg(uint64_t height, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
+    void get_short_chain_history(std::list<crypto::hash>& ids) const;
     bool clear();
     void clear_soft(bool keep_key_images=false);
     /*
@@ -1442,8 +1444,8 @@ private:
      * that this function deletes data that is not useful for background syncing
      */
     void clear_user_data();
-    void pull_blocks(bool first, bool try_incremental, const uint64_t start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, crypto::hash &top_hash, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
-    void pull_and_parse_next_blocks(bool first, bool try_incremental, const uint64_t start_height, const std::vector<cryptonote::block_complete_entry> &prev_blocks, const std::vector<parsed_block> &prev_parsed_blocks, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, crypto::hash &top_hash, bool &error, std::exception_ptr &exception);
+    void pull_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, crypto::hash &top_hash, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
+    void pull_and_parse_next_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, crypto::hash &top_hash, bool &error, std::exception_ptr &exception);
     void process_parsed_blocks(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     uint64_t check_and_handle_reorg(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<parsed_block> &parsed_blocks, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     bool accept_pool_tx_for_processing(const crypto::hash &txid);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1117,7 +1117,6 @@ private:
     std::string get_daemon_address() const;
     const boost::optional<epee::net_utils::http::login>& get_daemon_login() const { return m_daemon_login; }
     uint64_t get_daemon_blockchain_height(std::string& err);
-    uint64_t get_daemon_blockchain_top_hash(crypto::hash& top_hash);
     uint64_t get_daemon_blockchain_target_height(std::string& err);
     uint64_t get_daemon_adjusted_time();
 

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1442,10 +1442,11 @@ private:
      * that this function deletes data that is not useful for background syncing
      */
     void clear_user_data();
+    bool bump_refresh_start_height(const uint64_t init_start_height, const bool trusted_daemon);
+    uint64_t check_and_handle_reorg(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<parsed_block> &parsed_blocks, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     void pull_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::block_output_indices> &o_indices, crypto::hash &top_hash, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, boost::optional<cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t> &init_tree_sync_data);
     void pull_and_parse_next_blocks(bool first, bool try_incremental, uint64_t &blocks_start_height, const std::list<crypto::hash> &short_chain_history, std::vector<cryptonote::block_complete_entry> &blocks, std::vector<parsed_block> &parsed_blocks, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>>& process_pool_txs, crypto::hash &top_hash, bool &error, std::exception_ptr &exception);
-    void process_parsed_blocks(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
-    uint64_t check_and_handle_reorg(const uint64_t start_height, const crypto::hash &top_hash, const std::vector<parsed_block> &parsed_blocks, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
+    void process_parsed_blocks(const uint64_t start_height, const uint64_t start_parsed_block_i, const std::vector<cryptonote::block_complete_entry> &blocks, const std::vector<parsed_block> &parsed_blocks, uint64_t& blocks_added, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     bool accept_pool_tx_for_processing(const crypto::hash &txid);
     void process_unconfirmed_transfer(bool incremental, const crypto::hash &txid, wallet2::unconfirmed_transfer_details &tx_details, bool seen_in_pool, std::chrono::system_clock::time_point now, bool refreshed);
     void process_pool_info_extent(const cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response &res, std::vector<std::tuple<cryptonote::transaction, crypto::hash, bool>> &process_txs, bool refreshed);

--- a/src/wallet/wallet2_basic/wallet2_types.h
+++ b/src/wallet/wallet2_basic/wallet2_types.h
@@ -107,6 +107,10 @@ public:
      * @brief: push a block hash onto the chain and move all block hashes back by one block
     */
     void refill(const crypto::hash &hash) { m_blockchain.push_back(hash); --m_offset; }
+    /**
+     * @brief: manually set the top block hash and offset
+    */
+    void set_top_block(const crypto::hash &hash, size_t idx) { m_blockchain.clear(); m_blockchain.push_back(hash); m_offset = idx; };
 
 private:
     size_t m_offset;

--- a/src/wallet/wallet2_basic/wallet2_types.h
+++ b/src/wallet/wallet2_basic/wallet2_types.h
@@ -100,13 +100,9 @@ public:
     */
     bool empty() const { return m_blockchain.empty() && m_offset == 0; }
     /**
-     * @brief: crop stored hashes before a certain height and shift the offset accordingly, but always leave at least 1 hash
+     * @brief: pop the oldest block
     */
-    void trim(size_t height) { while (height > m_offset && m_blockchain.size() > 1) { m_blockchain.pop_front(); ++m_offset; } m_blockchain.shrink_to_fit(); }
-    /**
-     * @brief: push a block hash onto the chain and move all block hashes back by one block
-    */
-    void refill(const crypto::hash &hash) { m_blockchain.push_back(hash); --m_offset; }
+    void pop_front() { m_blockchain.pop_front(); ++m_offset; }
     /**
      * @brief: manually set the top block hash and offset
     */

--- a/src/wallet/wallet2_basic/wallet2_types.h
+++ b/src/wallet/wallet2_basic/wallet2_types.h
@@ -102,7 +102,7 @@ public:
     /**
      * @brief: pop the oldest block
     */
-    void pop_front() { m_blockchain.pop_front(); ++m_offset; }
+    void pop_oldest() { if (m_blockchain.size()) { m_blockchain.pop_front(); ++m_offset; } }
     /**
      * @brief: manually set the top block hash and offset
     */

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -74,7 +74,8 @@ namespace tools
     //         get_out_indexes_error
     //         tx_parse_error
     //         get_tx_pool_error
-    //         out_of_hashchain_bounds_error
+    //         reorg_before_first_block_error
+    //         reorg_depth_error
     //       signature_check_failed
     //       transfer_error *
     //         get_outs_general_error
@@ -439,10 +440,10 @@ namespace tools
       std::string to_string() const { return refresh_error::to_string(); }
     };
     //----------------------------------------------------------------------------------------------------
-    struct out_of_hashchain_bounds_error : public refresh_error
+    struct reorg_before_first_block_error : public refresh_error
     {
-      explicit out_of_hashchain_bounds_error(std::string&& loc)
-        : refresh_error(std::move(loc), "Index out of bounds of of hashchain")
+      explicit reorg_before_first_block_error(std::string&& loc)
+        : refresh_error(std::move(loc), "Reorg identified, we need to request older blocks to find the split point")
       {
       }
 

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -72,6 +72,7 @@ namespace tools
     //         get_blocks_error
     //         get_hashes_error
     //         get_out_indexes_error
+    //         get_block_hash_error
     //         tx_parse_error
     //         get_tx_pool_error
     //         reorg_depth_error
@@ -136,14 +137,16 @@ namespace tools
       "failed to get blocks",
       "failed to get hashes",
       "failed to get out indices",
-      "failed to get random outs"
+      "failed to get random outs",
+      "failed to get block hash"
     };
     enum failed_rpc_request_message_indices
     {
       get_blocks_error_message_index,
       get_hashes_error_message_index,
       get_out_indices_error_message_index,
-      get_outs_error_message_index
+      get_outs_error_message_index,
+      get_block_hash_error_message_index
     };
 
     template<typename Base, int msg_index>
@@ -414,6 +417,8 @@ namespace tools
     typedef failed_rpc_request<refresh_error, get_hashes_error_message_index> get_hashes_error;
     //----------------------------------------------------------------------------------------------------
     typedef failed_rpc_request<refresh_error, get_out_indices_error_message_index> get_out_indices_error;
+    //----------------------------------------------------------------------------------------------------
+    typedef failed_rpc_request<refresh_error, get_block_hash_error_message_index> get_block_hash_error;
     //----------------------------------------------------------------------------------------------------
     struct tx_parse_error : public refresh_error
     {

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -76,6 +76,8 @@ namespace tools
     //         get_tx_pool_error
     //         reorg_before_first_block_error
     //         reorg_depth_error
+    //         incorrect_fork_version
+    //         needs_rescan
     //       signature_check_failed
     //       transfer_error *
     //         get_outs_general_error
@@ -464,6 +466,16 @@ namespace tools
     {
       explicit incorrect_fork_version(std::string&& loc, const std::string& message)
         : refresh_error(std::move(loc), message)
+      {
+      }
+
+      std::string to_string() const { return refresh_error::to_string(); }
+    };
+    //----------------------------------------------------------------------------------------------------
+    struct needs_rescan : public refresh_error
+    {
+      explicit needs_rescan(std::string&& loc)
+        : refresh_error(std::move(loc), "The wallet needs to be rescanned manually")
       {
       }
 

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -74,7 +74,6 @@ namespace tools
     //         get_out_indexes_error
     //         tx_parse_error
     //         get_tx_pool_error
-    //         reorg_before_first_block_error
     //         reorg_depth_error
     //         incorrect_fork_version
     //         needs_rescan
@@ -436,16 +435,6 @@ namespace tools
     {
       explicit get_tx_pool_error(std::string&& loc)
         : refresh_error(std::move(loc), "error getting transaction pool")
-      {
-      }
-
-      std::string to_string() const { return refresh_error::to_string(); }
-    };
-    //----------------------------------------------------------------------------------------------------
-    struct reorg_before_first_block_error : public refresh_error
-    {
-      explicit reorg_before_first_block_error(std::string&& loc)
-        : refresh_error(std::move(loc), "Reorg identified, we need to request older blocks to find the split point")
       {
       }
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -168,6 +168,7 @@ namespace
     }
     else
     {
+      // FIXME: update for FCMP++
       const uint64_t now = time(NULL);
       if (unlock_time > now)
         entry.suggested_confirmations_threshold = std::max(entry.suggested_confirmations_threshold, (unlock_time - now + DIFFICULTY_TARGET_V2 - 1) / DIFFICULTY_TARGET_V2);

--- a/tests/core_tests/wallet_tools.cpp
+++ b/tests/core_tests/wallet_tools.cpp
@@ -33,7 +33,8 @@ void wallet_accessor_test::process_parsed_blocks(tools::wallet2 * wallet, uint64
 {
   if (wallet != nullptr) {
     auto output_tracker_cache = wallet->create_output_tracker_cache();
-    wallet->process_parsed_blocks(start_height, blocks, parsed_blocks, blocks_added, output_tracker_cache);
+    const crypto::hash top_hash = parsed_blocks.size() ? parsed_blocks.back().hash : crypto::hash{};
+    wallet->process_parsed_blocks(start_height, top_hash, blocks, parsed_blocks, blocks_added, output_tracker_cache);
   }
 }
 

--- a/tests/core_tests/wallet_tools.cpp
+++ b/tests/core_tests/wallet_tools.cpp
@@ -33,8 +33,7 @@ void wallet_accessor_test::process_parsed_blocks(tools::wallet2 * wallet, uint64
 {
   if (wallet != nullptr) {
     auto output_tracker_cache = wallet->create_output_tracker_cache();
-    const crypto::hash top_hash = parsed_blocks.size() ? parsed_blocks.back().hash : crypto::hash{};
-    wallet->process_parsed_blocks(start_height, top_hash, blocks, parsed_blocks, blocks_added, output_tracker_cache);
+    wallet->process_parsed_blocks(start_height, 0/*start_parsed_block_i*/, blocks, parsed_blocks, blocks_added, output_tracker_cache);
   }
 }
 

--- a/tests/functional_tests/transfer.py
+++ b/tests/functional_tests/transfer.py
@@ -892,13 +892,13 @@ class TransferTest():
     def check_deep_reorg_recovery(self, extend_reorg = True):
         daemon = Daemon()
 
-        print("Checking wallet deep reorg recovery")
+        print("Checking wallet deep reorg recovery, extending the chain after reorg:", extend_reorg)
 
         # Disconnect daemon from peers
         daemon.out_peers(0)
 
         for reorg_size in [1, 2, 3, 4, 10, 15, 99]: # max reorg depth is 100
-            print("pop size: ", reorg_size)
+            print("Reorg size:", reorg_size)
 
             # 1. Mine n blocks
             daemon.generateblocks('44Kbx4sJ7JDRDV5aAhLJzQCjDz2ViLRduE3ijDZu3osWKBjMGkV1XPk4pfDUMqt1Aiezvephdqm6YD19GKFD9ZcXVUTp6BW', reorg_size)

--- a/tests/unit_tests/fake_pruned_blockchain.cpp
+++ b/tests/unit_tests/fake_pruned_blockchain.cpp
@@ -399,8 +399,10 @@ void fake_pruned_blockchain::init_wallet_for_starting_block(tools::wallet2 &w) c
         /*locked_outputs=*/{});
 }
 //----------------------------------------------------------------------------------------------------------------------
-uint64_t fake_pruned_blockchain::refresh_wallet(tools::wallet2 &w, const size_t start_height) const
+uint64_t fake_pruned_blockchain::refresh_wallet(tools::wallet2 &w) const
 {
+    const uint64_t start_height = w.get_blockchain_current_height();
+
     // fetch blocks data
     std::vector<cryptonote::block_complete_entry> blk_entries;
     std::vector<tools::wallet2::parsed_block> parsed_blks;

--- a/tests/unit_tests/fake_pruned_blockchain.cpp
+++ b/tests/unit_tests/fake_pruned_blockchain.cpp
@@ -389,11 +389,7 @@ void fake_pruned_blockchain::init_wallet_for_starting_block(tools::wallet2 &w) c
 
     w.set_refresh_from_block_height(m_start_block_index);
 
-    w.m_blockchain.clear();
-    for (size_t i = 0; i < m_start_block_index; ++i)
-        w.m_blockchain.push_back(crypto::null_hash);
-    w.m_blockchain.push_back(m_parsed_blocks.front().hash);
-    w.m_blockchain.trim(m_start_block_index);
+    w.m_blockchain.set_top_block(m_parsed_blocks.front().hash, m_start_block_index);
 
     w.m_tree_cache.clear();
     w.m_tree_cache.init(m_start_block_index,
@@ -413,7 +409,7 @@ uint64_t fake_pruned_blockchain::refresh_wallet(tools::wallet2 &w, const size_t 
     // wallet process blocks data
     uint64_t blocks_added;
     auto output_tracker_cache = w.create_output_tracker_cache();
-    w.process_parsed_blocks(start_height, blk_entries, parsed_blks, blocks_added, output_tracker_cache);
+    w.process_parsed_blocks(start_height, this->top_block_hash(), blk_entries, parsed_blks, blocks_added, output_tracker_cache);
 
     // collect paths_to_check
     std::vector<fcmp_pp::curve_trees::OutputPair> paths_to_check;

--- a/tests/unit_tests/fake_pruned_blockchain.cpp
+++ b/tests/unit_tests/fake_pruned_blockchain.cpp
@@ -401,8 +401,7 @@ void fake_pruned_blockchain::init_wallet_for_starting_block(tools::wallet2 &w) c
 //----------------------------------------------------------------------------------------------------------------------
 uint64_t fake_pruned_blockchain::refresh_wallet(tools::wallet2 &w) const
 {
-    // start with tip block because process_parsed_blocks expects the wallet has already synced the first provided block
-    const uint64_t start_height = w.get_blockchain_current_height() - 1;
+    const uint64_t start_height = w.get_blockchain_current_height();
 
     // fetch blocks data
     std::vector<cryptonote::block_complete_entry> blk_entries;

--- a/tests/unit_tests/fake_pruned_blockchain.cpp
+++ b/tests/unit_tests/fake_pruned_blockchain.cpp
@@ -401,7 +401,8 @@ void fake_pruned_blockchain::init_wallet_for_starting_block(tools::wallet2 &w) c
 //----------------------------------------------------------------------------------------------------------------------
 uint64_t fake_pruned_blockchain::refresh_wallet(tools::wallet2 &w) const
 {
-    const uint64_t start_height = w.get_blockchain_current_height();
+    // start with tip block because process_parsed_blocks expects the wallet has already synced the first provided block
+    const uint64_t start_height = w.get_blockchain_current_height() - 1;
 
     // fetch blocks data
     std::vector<cryptonote::block_complete_entry> blk_entries;

--- a/tests/unit_tests/fake_pruned_blockchain.cpp
+++ b/tests/unit_tests/fake_pruned_blockchain.cpp
@@ -411,7 +411,7 @@ uint64_t fake_pruned_blockchain::refresh_wallet(tools::wallet2 &w) const
     // wallet process blocks data
     uint64_t blocks_added;
     auto output_tracker_cache = w.create_output_tracker_cache();
-    w.process_parsed_blocks(start_height, this->top_block_hash(), blk_entries, parsed_blks, blocks_added, output_tracker_cache);
+    w.process_parsed_blocks(start_height, 0/*start_parsed_block_i*/, blk_entries, parsed_blks, blocks_added, output_tracker_cache);
 
     // collect paths_to_check
     std::vector<fcmp_pp::curve_trees::OutputPair> paths_to_check;

--- a/tests/unit_tests/fake_pruned_blockchain.h
+++ b/tests/unit_tests/fake_pruned_blockchain.h
@@ -65,10 +65,9 @@ public:
     /**
      * brief: refresh_wallet - pulls block data from chain and calls process_parsed_blocks()
      * param: w -
-     * param: start_height - start height to pull block data from (inclusive)
      * return: number of blocks added by process_parsed_blocks()
      */
-    uint64_t refresh_wallet(tools::wallet2 &w, const size_t start_height) const;
+    uint64_t refresh_wallet(tools::wallet2 &w) const;
 
     uint8_t hf_version() const
     {

--- a/tests/unit_tests/hashchain.cpp
+++ b/tests/unit_tests/hashchain.cpp
@@ -109,21 +109,3 @@ TEST(hashchain, crop)
   ASSERT_EQ(hashchain.genesis(), make_hash(5));
   ASSERT_EQ(hashchain.size(), 1);
 }
-
-TEST(hashchain, trim)
-{
-  tools::hashchain hashchain;
-  hashchain.push_back(make_hash(1));
-  hashchain.push_back(make_hash(2));
-  hashchain.push_back(make_hash(3));
-  ASSERT_EQ(hashchain.offset(), 0);
-  hashchain.trim(2);
-  ASSERT_EQ(hashchain.offset(), 2);
-  ASSERT_EQ(hashchain.size(), 3);
-  ASSERT_EQ(hashchain[2], make_hash(3));
-  hashchain.trim(3);
-  ASSERT_EQ(hashchain.offset(), 2); // never gets it empty
-  ASSERT_EQ(hashchain.size(), 3);
-  ASSERT_FALSE(hashchain.empty());
-  ASSERT_EQ(hashchain.genesis(), make_hash(1));
-}

--- a/tests/unit_tests/wallet_hot_cold.cpp
+++ b/tests/unit_tests/wallet_hot_cold.cpp
@@ -472,7 +472,7 @@ TEST(wallet_scanning, burned_zombie)
         bc.add_block(1, {dummy_tx}, mock::null_addr);
 
     // scan, assert balance is amount a, (NOT a + b) and get key image to received output
-    bc.refresh_wallet(w, 0);
+    bc.refresh_wallet(w);
     ASSERT_EQ(amount_a, w.balance_all(true));
     uint64_t key_image_offset;
     std::vector<std::pair<crypto::key_image, crypto::signature>> exported_key_images;
@@ -528,7 +528,7 @@ TEST(wallet_scanning, burned_zombie)
 
     // add outgoing tx to chain and wallet scans it
     bc.add_block(1, {outgoing_tx}, mock::null_addr);
-    bc.refresh_wallet(w, 0);
+    bc.refresh_wallet(w);
 
     // check that the balance drops to 0 and that all transfers are marked spent
     ASSERT_EQ(0, w.balance_all(true));

--- a/tests/unit_tests/wallet_scanning.cpp
+++ b/tests/unit_tests/wallet_scanning.cpp
@@ -294,7 +294,7 @@ TEST(wallet_scanning, positive_smallout_main_addr_all_types_outputs)
         const boost::multiprecision::int128_t old_balance = w.balance(0, true);
 
         // note: doesn't handle reorgs
-        bc.refresh_wallet(w, 0);
+        bc.refresh_wallet(w);
 
         // update refresh_height
         refresh_height = bc.height();
@@ -654,7 +654,7 @@ TEST(wallet_scanning, burned_zombie)
         bc.add_block(1, {dummy_tx}, mock::null_addr);
 
     // scan, assert balance is amount a, (NOT a + b) and get key image to received output
-    bc.refresh_wallet(w, 0);
+    bc.refresh_wallet(w);
     ASSERT_EQ(amount_a, w.balance_all(true));
     uint64_t key_image_offset;
     std::vector<std::pair<crypto::key_image, crypto::signature>> exported_key_images;
@@ -710,7 +710,7 @@ TEST(wallet_scanning, burned_zombie)
 
     // add outgoing tx to chain and wallet scans it
     bc.add_block(1, {outgoing_tx}, mock::null_addr);
-    bc.refresh_wallet(w, 0);
+    bc.refresh_wallet(w);
 
     // check that the balance drops to 0 and that all transfers are marked spent
     ASSERT_EQ(0, w.balance_all(true));

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -765,7 +765,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
 
     // 5.
     LOG_PRINT_L2("Alice's vision is filled with shadowy keys, hashes, points, rings, trees, curves, chains, all flowing in and out of one another");
-    uint64_t blocks_added = bc.refresh_wallet(alice, 0);
+    uint64_t blocks_added = bc.refresh_wallet(alice);
     ASSERT_EQ(bc.height()-1, blocks_added);
     ASSERT_EQ(2, alice.m_transfers.size());
     ASSERT_EQ(amount0 + amount1, alice.balance_all(true)); // really, we care about unlocked_balance_all() for sending, but that call uses RPC
@@ -830,7 +830,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
     // 13. 
     LOG_PRINT_L2("A great day for Bob");
     ASSERT_EQ(0, bob.balance_all(true));
-    blocks_added = bc.refresh_wallet(bob, 0);
+    blocks_added = bc.refresh_wallet(bob);
     ASSERT_EQ(bc.height()-1, blocks_added);
     ASSERT_EQ(1, bob.m_transfers.size());
     EXPECT_EQ(out_amount, bob.balance_all(true));
@@ -839,7 +839,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
     LOG_PRINT_L2("Alice obtains the fulfillment that only stems from selfless generosity");
     const rct::xmr_amount alice_old_balance = alice.balance_all(true);
     ASSERT_GE(alice_old_balance, out_amount + alicebob_tx_fee);
-    blocks_added = bc.refresh_wallet(alice, 0);
+    blocks_added = bc.refresh_wallet(alice);
     ASSERT_EQ(1, blocks_added);
     const rct::xmr_amount alice_new_balance = alice.balance_all(true);
     ASSERT_LT(alice_new_balance, alice_old_balance);


### PR DESCRIPTION
Thank you to @nahuhh for helping test pretty extensively. His testing helped lead to this PR, and he helped test this PR directly.

This is a pretty significant facelift for wallet2's refresh:

- Gets rid of the initial block hash download on restore.
  - Removes all wallet code related to `fast_refresh`.
- Correctly handles deep reorgs for the FCMP++ integration.
  - I suspect incorrect reorg handling may have been the culprit in @ComputeryPony's #45.
  - Adds a good functional test for deep reorg handling that fails without this PR.
- Enforces contiguous syncing on top of the wallet's current sync height.
  - **If a user manually sets a high restore height, and the wallet has not yet synced up to that height but *has* already synced, the wallet throws a `needs_rescan` error to indicate the wallet must be re-scanned via `rescan_blockchain`.**
    - This was proposed by @nahuhh instead of clearing the wallet cache in this case. 
  - If the manully set restore height is higher than the daemon height, refresh returns since it has nothing to do.
- The PR utilizes the existing `short_chain_history` approach to minimize data passed between wallet and daemon to handle reorgs (as proposed by @jeffro256), with some modifications.
    - Modification 1: re-syncing `short_chain_history` every loop .
        - The original approach in wallet2: on every loop to get the next set of blocks, cut off the oldest 3 blocks (skipping genesis) prior synced from `short_chain_history`, append the most recent 3 blocks, and request.
            - Caveat: wallet2 actually wouldn't even use short_chain_history in subsequent requests after first request (the daemon prioritizes the `start_height` wallet2 included in the request), but using `short_chain_history` seemed to be the goal with wallet2 (and using `start_height` has the issue of needing to make multiple trips to the daemon to handle reorgs).
        - The problem: let's say there was a 50 block reorg between loop 1 and 2. wallet2's approach would necessitate an extra trip to the daemon to get blocks starting from 50 prior (or would request more blocks than it needed to).
        - This PR's solution: on every loop, re-sync the `short_chain_history` to *always* include the max depth block the wallet can handle reorgs back to. Thus, either the daemon will serve the blocks the wallet needs to handle any possible reorg using the `short_chain_history` optimization, or the reorg will be too deep and the wallet will not be able to handle it.
    - Modification 2: a new request param to the `getblocks.bin` RPC endpoint `block_ids_skip_common_block` so the daemon **always** aims to serve **new** blocks the wallet has not yet seen.
        - The original approach: when client requests blocks via `block_ids`, the daemon would serve contiguous blocks starting from the youngest block id the client included in the list of `block_ids`.
        - The problem: the client has already seen the youngest block (otherwise it wouldn't have the block id to request it), and so the daemon is serving an extra block that the client doesn't need.
        - This PR's solution: the client can set `block_ids_skip_common_block` to true, and the daemon will serve contiguous blocks where the first block's `prev_id` points to the youngest block id the client included in the list of `block_ids`. Thus, the client can still make sure the daemon's served blocks are contiguous to the client's already synced blocks, without needing the extra block.
    - Modification 3: if the client includes too high a height to the `on_getblockhash` RPC endpoint, the daemon serves the expected error resp.
        - The original: the daemon would serve a success response with empty hash tied to high height.
        - The problem: this is clearly a bug.. the handler should be returning false so that the daemon knows to serve the error resp.
        - This PR's solution: return false so the client will pick up on the `CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT` error and handle it accordingly.
- Establishes a mutex for the main `refresh()` loop.
    - Uhh, this should have been there from the start.