### PR TITLE
carrot+fcmp: set subtractable flag in make_carrot_transaction_proposals_wallet2_transfer

### DIFF
--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -364,8 +364,10 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
 
     const carrot::input_selection_policy_t isp = &carrot::ispolicy::select_greedy_aging;
 
+    //! @TODO: check flags make sense
     const std::uint32_t input_selection_flags = carrot::InputSelectionFlags::ALLOW_EXTERNAL_INPUTS_IN_NORMAL_TRANSFERS
-        | carrot::InputSelectionFlags::ALLOW_PRE_CARROT_INPUTS_IN_NORMAL_TRANSFERS; //! @TODO: check flags make sense
+        | carrot::InputSelectionFlags::ALLOW_PRE_CARROT_INPUTS_IN_NORMAL_TRANSFERS
+        | (carrot::InputSelectionFlags::IS_KNOWN_FEE_SUBTRACTABLE * !subtract_fee_from_outputs.empty());
 
     // change spec
     const crypto::public_key change_address_spend_pubkey


### PR DESCRIPTION
Fixes input selection bug with fee-subtractable txs where a fee-subtractable tx has enough funds to cover outputs, but a non-fee-subtractable tx wouldn't. An early error is thrown when it should have succeeded b/c the higher calling code didn't set the subtractable flag for input selection.

Thanks to @nahuhh for finding the bug!