### PR TITLE
FFI: rm extra fcmp_proof_out_len param

### DIFF
--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -308,14 +308,12 @@ int fcmp_pp_prove_sal(const uint8_t signable_tx_hash[32],
  * param: n_tree_layers -
  * param: proof_len -
  * outparam: fcmp_proof_out - a buffer where the FCMP proof will be written to
- * outparam: fcmp_proof_out_size - the max length of the buffer fcmp_proof_out, is set to written proof size
  * return: an error on failure, nothing otherwise
  */
 int fcmp_pp_prove_membership(const struct FcmpPpProveMembershipInputSliceUnsafe fcmp_pp_prove_inputs,
                                              uintptr_t n_tree_layers,
                                              uintptr_t proof_len,
-                                             uint8_t fcmp_proof_out[],
-                                             uintptr_t *fcmp_proof_out_len);
+                                             uint8_t fcmp_proof_out[]);
 
 // The following proof_size functions are tabled through proof_len.h. Use
 // those functions instead.

--- a/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
+++ b/src/fcmp_pp/fcmp_pp_rust/fcmp++.h
@@ -198,15 +198,15 @@ void helios_point_to_bytes(const struct HeliosPoint *helios_point, uint8_t bytes
 
 void selene_point_to_bytes(const struct SelenePoint *selene_point, uint8_t bytes_out[32]);
 
-struct HeliosPoint helios_point_from_bytes(const uint8_t *helios_point_bytes);
+int helios_point_from_bytes(const uint8_t *helios_point_bytes, struct HeliosPoint *helios_point_out);
 
-struct SelenePoint selene_point_from_bytes(const uint8_t *selene_point_bytes);
+int selene_point_from_bytes(const uint8_t *selene_point_bytes, struct SelenePoint *selene_point_out);
 
-struct SeleneScalar selene_scalar_from_bytes(const uint8_t *selene_scalar_bytes);
+int selene_scalar_from_bytes(const uint8_t *selene_scalar_bytes, struct SeleneScalar *selene_scalar_out);
 
-struct HeliosScalar selene_point_to_helios_scalar(struct SelenePoint selene_point);
+int selene_point_to_helios_scalar(struct SelenePoint selene_point, struct HeliosScalar *helios_scalar_out);
 
-struct SeleneScalar helios_point_to_selene_scalar(struct HeliosPoint helios_point);
+int helios_point_to_selene_scalar(struct HeliosPoint helios_point, struct SeleneScalar *selene_scalar_out);
 
 struct HeliosScalar helios_zero_scalar(void);
 

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -901,18 +901,12 @@ pub unsafe extern "C" fn fcmp_pp_prove_membership(
     n_tree_layers: usize,
     proof_len: usize,
     fcmp_proof_out: *mut u8,
-    fcmp_proof_out_len: *mut usize,
 ) -> c_int {
     let inputs: &[*const FcmpPpProveMembershipInput] = inputs.into();
-    let capacity = fcmp_proof_out_len.read();
     debug_assert_eq!(
         proof_len,
         _slow_membership_proof_size(inputs.len(), n_tree_layers)
     );
-    if capacity < proof_len {
-        return -1;
-    }
-    fcmp_proof_out_len.write(proof_len);
     let mut buf_out = core::slice::from_raw_parts_mut(fcmp_proof_out, proof_len);
 
     match prove_membership_native(inputs, n_tree_layers) {
@@ -920,7 +914,7 @@ pub unsafe extern "C" fn fcmp_pp_prove_membership(
             Ok(_) => 0,
             Err(_) => -2,
         },
-        None => -3,
+        None => -1,
     }
 }
 

--- a/src/fcmp_pp/prove.cpp
+++ b/src/fcmp_pp/prove.cpp
@@ -244,13 +244,10 @@ FcmpMembershipProof prove_membership(const std::vector<FcmpPpProveMembershipInpu
     const int r = ::fcmp_pp_prove_membership(fcmp_pp_prove_inputs_slice,
         n_tree_layers,
         proof_len,
-        &p[0],
-        &proof_size);
+        &p[0]);
 
     if (r < 0)
         throw std::runtime_error("prove_membership failed with code: " + std::to_string(r));
-
-    p.resize(proof_size);
 
     // No `free()` since result type `()` is zero-sized
 

--- a/src/fcmp_pp/tower_cycle.cpp
+++ b/src/fcmp_pp/tower_cycle.cpp
@@ -36,6 +36,9 @@ namespace tower_cycle
 {
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
+#define CHECK_FFI_RES \
+    CHECK_AND_ASSERT_THROW_MES(r == 0, __func__ << " failed with error code " << r);
+//----------------------------------------------------------------------------------------------------------------------
 Selene::Point Selene::hash_init_point() const
 {
     return ::selene_hash_init_point();
@@ -48,12 +51,18 @@ Helios::Point Helios::hash_init_point() const
 //----------------------------------------------------------------------------------------------------------------------
 Selene::CycleScalar Selene::point_to_cycle_scalar(const Selene::Point &point) const
 {
-    return ::selene_point_to_helios_scalar(point);
+    Selene::CycleScalar helios_scalar;
+    int r = ::selene_point_to_helios_scalar(point, &helios_scalar);
+    CHECK_FFI_RES;
+    return helios_scalar;
 }
 //----------------------------------------------------------------------------------------------------------------------
 Helios::CycleScalar Helios::point_to_cycle_scalar(const Helios::Point &point) const
 {
-    return ::helios_point_to_selene_scalar(point);
+    Helios::CycleScalar selene_scalar;
+    int r = ::helios_point_to_selene_scalar(point, &selene_scalar);
+    CHECK_FFI_RES;
+    return selene_scalar;
 }
 //----------------------------------------------------------------------------------------------------------------------
 Selene::Point Selene::hash_grow(
@@ -63,13 +72,13 @@ Selene::Point Selene::hash_grow(
     const Selene::Chunk &new_children) const
 {
     Selene::Point hash;
-    int res = ::hash_grow_selene(
+    int r = ::hash_grow_selene(
         existing_hash,
         offset,
         existing_child_at_offset,
         new_children,
         &hash);
-    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow selene with error code " << res);
+    CHECK_FFI_RES;
     return hash;
 }
 //----------------------------------------------------------------------------------------------------------------------
@@ -80,13 +89,13 @@ Helios::Point Helios::hash_grow(
     const Helios::Chunk &new_children) const
 {
     Helios::Point hash;
-    int res = ::hash_grow_helios(
+    int r = ::hash_grow_helios(
         existing_hash,
         offset,
         existing_child_at_offset,
         new_children,
         &hash);
-    CHECK_AND_ASSERT_THROW_MES(res == 0, "Failed to hash grow helios with error code " << res);
+    CHECK_FFI_RES;
     return hash;
 }
 //----------------------------------------------------------------------------------------------------------------------
@@ -130,12 +139,18 @@ crypto::ec_point Helios::to_bytes(const Helios::Point &point) const
 //----------------------------------------------------------------------------------------------------------------------
 Selene::Point Selene::from_bytes(const crypto::ec_point &bytes) const
 {
-    return ::selene_point_from_bytes(reinterpret_cast<const uint8_t*>(&bytes));
+    Selene::Point selene_point;
+    int r = ::selene_point_from_bytes(reinterpret_cast<const uint8_t*>(&bytes), &selene_point);
+    CHECK_FFI_RES;
+    return selene_point;
 }
 //----------------------------------------------------------------------------------------------------------------------
 Helios::Point Helios::from_bytes(const crypto::ec_point &bytes) const
 {
-    return ::helios_point_from_bytes(reinterpret_cast<const uint8_t*>(&bytes));
+    Helios::Point helios_point;
+    int r = ::helios_point_from_bytes(reinterpret_cast<const uint8_t*>(&bytes), &helios_point);
+    CHECK_FFI_RES;
+    return helios_point;
 }
 //----------------------------------------------------------------------------------------------------------------------
 std::string Selene::to_string(const typename Selene::Scalar &scalar) const
@@ -163,7 +178,10 @@ std::string Helios::to_string(const typename Helios::Point &point) const
 //----------------------------------------------------------------------------------------------------------------------
 SeleneScalar selene_scalar_from_bytes(const rct::key &scalar)
 {
-    return ::selene_scalar_from_bytes(scalar.bytes);
+    SeleneScalar selene_scalar;
+    int r = ::selene_scalar_from_bytes(scalar.bytes, &selene_scalar);
+    CHECK_FFI_RES;
+    return selene_scalar;
 }
 //----------------------------------------------------------------------------------------------------------------------
 template<typename C>


### PR DESCRIPTION
Depends on #90 and #91 

This doesn't seem necessary since the proof len should be determined by the given fn