### PR TITLE
fcmp++: Reorganize curve trees db logic

### DIFF
--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -602,8 +602,8 @@ uint64_t BlockchainDB::get_path_by_global_output_id(const std::vector<uint64_t> 
         continue;
 
       CHECK_AND_ASSERT_THROW_MES(path.layer_chunks.at(i).chunk_bytes.size(), "get_path_by_global_output_id: empty layer in path");
-      CHECK_AND_ASSERT_THROW_MES(path.layer_chunks.at(i).chunk_bytes.size() != last_path.second.layer_chunks.at(i).chunk_bytes.size(),
-        "get_path_by_global_output_id: empty layer in last path");
+      CHECK_AND_ASSERT_THROW_MES(path.layer_chunks.at(i).chunk_bytes.size() == last_path.second.layer_chunks.at(i).chunk_bytes.size(),
+        "get_path_by_global_output_id: unexpected size of last path");
 
       path.layer_chunks.at(i).chunk_bytes.back() = last_path.second.layer_chunks.at(i).chunk_bytes.back();
     }

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -349,6 +349,12 @@ void BlockchainDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curve_
 
   MDEBUG("Growing tree usable once block " << blk_idx << " is in the chain");
 
+  // Get the number of leaf tuples that exist in the current tree
+  const uint64_t old_n_leaf_tuples = this->get_n_leaf_tuples();
+
+  if (blk_idx == 0)
+    CHECK_AND_ASSERT_THROW_MES(old_n_leaf_tuples == 0, "Tree is not empty at blk idx 0");
+
   // Get the prev block's tree edge (i.e. the current tree edge before growing)
   std::vector<crypto::ec_point> prev_tree_edge;
   uint64_t prev_blk_idx = 0;
@@ -364,11 +370,6 @@ void BlockchainDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curve_
 
     prev_tree_edge = this->get_tree_edge(prev_blk_idx);
   }
-
-  // Get the number of leaf tuples that exist in the current tree
-  const uint64_t old_n_leaf_tuples = this->get_n_leaf_tuples();
-
-  CHECK_AND_ASSERT_THROW_MES(blk_idx == 0 && old_n_leaf_tuples != 0, "Tree is not empty at blk idx 0");
 
   // We re-save the prev tree edge at this next block if the tree doesn't grow
   const auto save_prev_tree_edge = [&, this]() { this->save_tree_meta(blk_idx, old_n_leaf_tuples, prev_tree_edge); };

--- a/src/blockchain_db/blockchain_db.cpp
+++ b/src/blockchain_db/blockchain_db.cpp
@@ -310,6 +310,309 @@ uint64_t BlockchainDB::add_block( const std::pair<block, blobdata>& blck
   return ++prev_height;
 }
 
+void BlockchainDB::advance_tree(const uint64_t blk_idx, const std::vector<fcmp_pp::curve_trees::OutputContext> &known_new_outputs)
+{
+  LOG_PRINT_L3("BlockchainDB::" << __func__);
+
+  // Get the earliest possible last locked block of outputs created in blk_idx
+  const uint64_t earliest_last_locked_block = cryptonote::get_default_last_locked_block_index(blk_idx);
+
+  // If we're advancing the genesis block, make sure to initialize the tree
+  if (blk_idx == 0)
+  {
+    // Expected: tree meta table is currently empty
+
+    // We grow the first blocks with empty outputs, since no outputs in this range should be spendable yet
+    for (uint64_t new_blk_idx = blk_idx; new_blk_idx < earliest_last_locked_block; ++new_blk_idx)
+    {
+      this->grow_tree(new_blk_idx, {});
+    }
+  }
+  // Expected: earliest_last_locked_block == last block idx + 1 in tree meta
+
+  // Now we can advance the tree 1 block
+  auto unlocked_outputs = this->get_outs_at_last_locked_block_idx(earliest_last_locked_block);
+
+  // Include known new outputs if provided
+  unlocked_outputs.insert(unlocked_outputs.end(), known_new_outputs.begin(), known_new_outputs.end());
+
+  // Grow the tree with outputs that are spendable once the earliest_last_locked_block is in the chain
+  this->grow_tree(earliest_last_locked_block, std::move(unlocked_outputs));
+
+  // Now that we've used the unlocked leaves to grow the tree, we delete them from the locked outputs table
+  this->del_locked_outs_at_block_idx(earliest_last_locked_block);
+}
+
+void BlockchainDB::grow_tree(const uint64_t blk_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs)
+{
+  LOG_PRINT_L3("BlockchainDB::" << __func__);
+
+  MDEBUG("Growing tree usable once block " << blk_idx << " is in the chain");
+
+  // Get the prev block's tree edge (i.e. the current tree edge before growing)
+  std::vector<crypto::ec_point> prev_tree_edge;
+  uint64_t prev_blk_idx = 0;
+  if (blk_idx > 0)
+  {
+    prev_blk_idx = blk_idx - 1;
+
+    // Make sure tree tip lines up to expected block
+    const uint64_t tree_block_idx = this->get_tree_block_idx();
+
+    CHECK_AND_ASSERT_THROW_MES(tree_block_idx == prev_blk_idx,
+      "Unexpected tree block idx mismatch to prev block (" + std::to_string(tree_block_idx) + " vs " + std::to_string(prev_blk_idx) + ")");
+
+    prev_tree_edge = this->get_tree_edge(prev_blk_idx);
+  }
+
+  // Get the number of leaf tuples that exist in the current tree
+  const uint64_t old_n_leaf_tuples = this->get_n_leaf_tuples();
+
+  CHECK_AND_ASSERT_THROW_MES(blk_idx == 0 && old_n_leaf_tuples != 0, "Tree is not empty at blk idx 0");
+
+  // We re-save the prev tree edge at this next block if the tree doesn't grow
+  const auto save_prev_tree_edge = [&, this]() { this->save_tree_meta(blk_idx, old_n_leaf_tuples, prev_tree_edge); };
+  if (new_outputs.empty())
+  {
+    save_prev_tree_edge();
+    return;
+  }
+
+  // Set the tree's existing last hashes from the existing edge
+  const auto last_hashes = m_curve_trees->tree_edge_to_last_hashes(prev_tree_edge);
+
+  // Use the number of leaf tuples and the existing last hashes to get a struct we can use to extend the tree
+  auto tree_extension = m_curve_trees->get_tree_extension(old_n_leaf_tuples, last_hashes, {std::move(new_outputs)}, false/*use_fast_torsion_check*/);
+  if (tree_extension.leaves.tuples.empty())
+  {
+    save_prev_tree_edge();
+    return;
+  }
+
+  const uint64_t new_n_leaf_tuples = tree_extension.leaves.tuples.size() + old_n_leaf_tuples;
+  const auto tree_edge = this->grow_with_tree_extension(tree_extension);
+  this->save_tree_meta(blk_idx, new_n_leaf_tuples, tree_edge);
+}
+
+void BlockchainDB::trim_block()
+{
+  LOG_PRINT_L3("BlockchainDB::" << __func__);
+
+  const uint64_t n_blocks = this->height();
+  if (n_blocks == 0)
+    return;
+
+  const uint64_t removing_block_idx = n_blocks - 1;
+
+  // Get the earliest possible last locked block of outputs created in removing_block_idx
+  const uint64_t default_last_locked_block = cryptonote::get_default_last_locked_block_index(removing_block_idx);
+  const uint64_t tree_block_idx = this->get_tree_block_idx();
+
+  CHECK_AND_ASSERT_THROW_MES(tree_block_idx > 0, "tree block idx must be >0");
+  CHECK_AND_ASSERT_THROW_MES(tree_block_idx == default_last_locked_block,
+    "Unexpected tree block idx mismatch (" + std::to_string(tree_block_idx) + " vs " + std::to_string(default_last_locked_block) + ")");
+
+  const uint64_t prev_tree_block_idx = tree_block_idx - 1;
+
+  MDEBUG("Trimming tree to block " << prev_tree_block_idx << " (removing block " << removing_block_idx << ")");
+
+  // Read n leaf tuples from the prev tree block to see how how many leaves
+  // should remain in the tree after trimming a block from the tree.
+  const uint64_t new_n_leaf_tuples = this->get_block_n_leaf_tuples(prev_tree_block_idx);
+
+  // Trim the tree to the new n leaf tuples
+  this->trim_tree(new_n_leaf_tuples, tree_block_idx);
+}
+
+void BlockchainDB::trim_tree(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_idx)
+{
+  LOG_PRINT_L3("BlockchainDB::" << __func__);
+
+  // Delete this tree meta upon exiting
+  epee::misc_utils::auto_scope_leave_caller del_tree_meta = epee::misc_utils::create_scope_leave_handler([this, trim_block_idx](){
+    this->del_tree_meta(trim_block_idx);
+  });
+
+  const uint64_t old_n_leaf_tuples = this->trim_leaves(new_n_leaf_tuples, trim_block_idx);
+
+  // If nothing to trim, return
+  if (old_n_leaf_tuples == new_n_leaf_tuples)
+    return;
+
+  if (new_n_leaf_tuples == 0)
+  {
+    // Empty the tree
+    this->trim_layers(new_n_leaf_tuples, {}/*n_elems_per_layer*/, {}/*prev_tree_edge*/, 0/*expected_root_idx*/);
+    return;
+  }
+
+  // Trim the expected layers
+  const auto n_elems_per_layer = m_curve_trees->n_elems_per_layer(new_n_leaf_tuples);
+  const auto prev_tree_edge = this->get_tree_edge(trim_block_idx - 1);
+  const uint64_t expected_root_idx = m_curve_trees->n_layers(new_n_leaf_tuples) - 1;
+  this->trim_layers(new_n_leaf_tuples, n_elems_per_layer, prev_tree_edge, expected_root_idx);
+}
+
+std::pair<uint64_t, fcmp_pp::curve_trees::PathBytes> BlockchainDB::get_last_path(const uint64_t block_idx) const
+{
+  LOG_PRINT_L3("BlockchainDB::" << __func__);
+
+  db_rtxn_guard rtxn_guard(this);
+
+  // See how many leaves were in the tree at the given block
+  const uint64_t block_n_leaf_tuples = this->get_block_n_leaf_tuples(block_idx);
+  if (block_n_leaf_tuples == 0)
+    return { 0, {} };
+
+  // Get path elems from the block's last path (gets *current* path elem state)
+  const auto last_path_indexes = m_curve_trees->get_path_indexes(block_n_leaf_tuples, block_n_leaf_tuples - 1);
+  auto path = this->get_path(last_path_indexes);
+
+  // See what the last hashes at every layer for the provided block were (gets *old* path elem state)
+  const std::vector<crypto::ec_point> tree_edge = this->get_tree_edge(block_idx);
+  CHECK_AND_ASSERT_THROW_MES(tree_edge.size(), "get_last_path: empty tree edge");
+  CHECK_AND_ASSERT_THROW_MES(tree_edge.size() == path.layer_chunks.size(), "get_last_path: mismatched tree edge size to path layer chunks");
+
+  // Use tree edge at the provided block to set the last hash for each layer (so path state reflects old state)
+  for (std::size_t i = 0; i < path.layer_chunks.size(); ++i)
+  {
+    CHECK_AND_ASSERT_THROW_MES(path.layer_chunks[i].chunk_bytes.size(), "get_last_path: empty path");
+    path.layer_chunks[i].chunk_bytes.back() = tree_edge[i];
+  }
+
+  return { block_n_leaf_tuples, path };
+}
+
+uint64_t BlockchainDB::get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
+  const uint64_t as_of_n_blocks,
+  std::vector<uint64_t> &leaf_idxs_out,
+  std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const
+{
+  LOG_PRINT_L3("BlockchainDB::" << __func__);
+
+  db_rtxn_guard rtxn_guard(this);
+
+  // Initialize result vectors with 0 values. If outptut is not in the tree,
+  // result vectors kept as 0 values
+  leaf_idxs_out = std::vector<uint64_t>(global_output_ids.size(), 0);
+  paths_out = std::vector<fcmp_pp::curve_trees::PathBytes>(global_output_ids.size(), fcmp_pp::curve_trees::PathBytes{});
+
+  if (global_output_ids.empty())
+    return 0;
+
+  const uint64_t cur_n_blocks = this->height();
+  if (cur_n_blocks == 0)
+    return 0;
+
+  // We're getting path data assuming chain tip is as_of_block_idx
+  const uint64_t as_of_block_idx = as_of_n_blocks ? (as_of_n_blocks - 1) : (cur_n_blocks - 1);
+
+  CHECK_AND_ASSERT_THROW_MES(as_of_block_idx <= this->get_tree_block_idx(), "get_path_by_global_output_id: as_of_block_idx is higher than highest tree block idx");
+
+  // TODO: de-duplicate db reads where possible (steps 1, 2, 3, 5, 6 can all be de-dup'd especially 6)
+  // TODO: return consolidated path
+  // Note: a table mapping output id -> leaf idx would allow skipping to step 5
+
+  // 1. Read DB for tx out indexes with global output id
+  std::vector<tx_out_index> tois;
+  tois.reserve(global_output_ids.size());
+  for (const auto &goi : global_output_ids)
+  {
+      // Throws if output not found
+    tois.emplace_back(this->get_output_tx_and_index_from_global(goi));
+  }
+
+  // 2. Read DB for output metadata {unlock_time, created block idx}
+  std::vector<outkey> out_keys;
+  out_keys.reserve(global_output_ids.size());
+  for (const auto &tois : tois)
+  {
+    cryptonote::transaction _;
+    const auto tx_out_keys = this->get_tx_output_data(tois.first, _);
+    CHECK_AND_ASSERT_THROW_MES(tois.second < tx_out_keys.size(), "get_path_by_global_output_id: tx out keys too small");
+    out_keys.emplace_back(tx_out_keys.at(tois.second));
+  }
+
+  // 3. Determine each output's last locked block
+  std::vector<uint64_t> last_locked_block_idxs;
+  last_locked_block_idxs.reserve(out_keys.size());
+  for (const auto &outkey : out_keys)
+  {
+    const uint64_t last_locked_block_idx = cryptonote::get_last_locked_block_index(outkey.data.unlock_time, outkey.data.height);
+    last_locked_block_idxs.emplace_back(last_locked_block_idx);
+  }
+
+  // 4. Get n leaf tuples at output's last locked block and next block
+  std::vector<std::pair<uint64_t, uint64_t>> n_leaf_tuple_ranges;
+  std::vector<bool> not_expected_in_tree;
+  n_leaf_tuple_ranges.reserve(last_locked_block_idxs.size());
+  not_expected_in_tree.reserve(last_locked_block_idxs.size());
+  for (const uint64_t block_idx : last_locked_block_idxs)
+  {
+    if (block_idx > as_of_block_idx)
+    {
+      not_expected_in_tree.push_back(true);
+      n_leaf_tuple_ranges.push_back({0, 0});
+      continue;
+    }
+
+    const uint64_t n_leaf_tuples = this->get_block_n_leaf_tuples(block_idx);
+
+    const uint64_t next_block_idx = block_idx + 1;
+    const uint64_t next_n_leaf_tuples = this->get_block_n_leaf_tuples(next_block_idx);
+
+    n_leaf_tuple_ranges.push_back({n_leaf_tuples, next_n_leaf_tuples});
+
+    // Output is still locked if there are no leaf tuples for the block it's in
+    not_expected_in_tree.push_back(n_leaf_tuples == 0 && next_n_leaf_tuples == 0);
+  }
+
+  // 5. Find leaf idxs by output id, using leaf tuple ranges to narrow search
+  for (std::size_t i = 0; i < out_keys.size(); ++i)
+  {
+    // If the output is still expected locked, then it won't have a leaf idx
+    if (not_expected_in_tree.at(i))
+      continue;
+    const uint64_t output_id = out_keys.at(i).output_id;
+    const auto tuple_range = n_leaf_tuple_ranges.at(i);
+    leaf_idxs_out.at(i) = this->find_leaf_idx_by_output_id_bounded_search(output_id, tuple_range.first, tuple_range.second);
+  }
+
+  // 6. Use leaf idxs to get paths
+  const uint64_t n_leaf_tuples = this->get_block_n_leaf_tuples(as_of_block_idx);
+  const auto last_path_idxs = m_curve_trees->get_path_indexes(n_leaf_tuples, n_leaf_tuples - 1);
+  const auto last_path = this->get_last_path(as_of_block_idx);
+  for (std::size_t i = 0; i < leaf_idxs_out.size(); ++i)
+  {
+    if (not_expected_in_tree.at(i))
+      continue;
+
+    // Read path from the db using path indexes
+    const auto path_idxs = m_curve_trees->get_path_indexes(n_leaf_tuples, leaf_idxs_out.at(i));
+    auto path = this->get_path(path_idxs);
+
+    CHECK_AND_ASSERT_THROW_MES(path.leaves.size() && path.layer_chunks.size(), "get_path_by_global_output_id: empty path");
+
+    // If the path is part of the last path, then we'll need to update the last
+    // elem in each layer
+    for (uint8_t i = 0; i < path_idxs.layers.size(); ++i)
+    {
+      if (last_path_idxs.layers.at(i).second != path_idxs.layers.at(i).second)
+        continue;
+
+      CHECK_AND_ASSERT_THROW_MES(path.layer_chunks.at(i).chunk_bytes.size(), "get_path_by_global_output_id: empty layer in path");
+      CHECK_AND_ASSERT_THROW_MES(path.layer_chunks.at(i).chunk_bytes.size() != last_path.second.layer_chunks.at(i).chunk_bytes.size(),
+        "get_path_by_global_output_id: empty layer in last path");
+
+      path.layer_chunks.at(i).chunk_bytes.back() = last_path.second.layer_chunks.at(i).chunk_bytes.back();
+    }
+
+    paths_out.at(i) = std::move(path);
+  }
+
+  return n_leaf_tuples;
+}
+
 void BlockchainDB::set_hard_fork(HardFork* hf)
 {
   m_hardfork = hf;

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -553,6 +553,35 @@ private:
    */
   virtual void remove_spent_key(const crypto::key_image& k_image) = 0;
 
+  //
+  // Curve tree related db calls (private)
+  //
+
+  // TODO: descriptions
+  virtual std::vector<fcmp_pp::curve_trees::OutputContext> get_outs_at_last_locked_block_idx(uint64_t block_id) const = 0;
+
+  virtual void del_locked_outs_at_block_idx(uint64_t block_idx) = 0;
+
+  virtual uint64_t get_tree_block_idx() const = 0;
+
+  virtual std::vector<crypto::ec_point> get_tree_edge(uint64_t block_id) const = 0;
+
+  virtual uint64_t trim_leaves(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_idx) = 0;
+
+  virtual void trim_layers(const uint64_t new_n_leaf_tuples,
+    const std::vector<uint64_t> &n_elems_per_layer,
+    const std::vector<crypto::ec_point> &prev_tree_edge,
+    const uint64_t expected_root_idx) = 0;
+
+  virtual void save_tree_meta(const uint64_t block_idx, const uint64_t n_leaf_tuples, const std::vector<crypto::ec_point> &tree_edge) = 0;
+
+  virtual void del_tree_meta(const uint64_t block_idx) = 0;
+
+  virtual std::vector<crypto::ec_point> grow_with_tree_extension(const fcmp_pp::curve_trees::CurveTreesV1::TreeExtension &tree_extension) = 0;
+
+  virtual fcmp_pp::curve_trees::PathBytes get_path(const fcmp_pp::curve_trees::PathIndexes &path_indexes) const = 0;
+
+  virtual uint64_t find_leaf_idx_by_output_id_bounded_search(uint64_t output_id, uint64_t leaf_idx_start, uint64_t leaf_idx_end) const = 0;
 
   /*********************************************************************
    * private concrete members
@@ -1818,6 +1847,26 @@ public:
    */
   virtual bool for_all_alt_blocks(std::function<bool(const crypto::hash &blkid, const alt_block_data_t &data, const cryptonote::blobdata_ref *blob)> f, bool include_blob = false) const = 0;
 
+  //
+  // Curve tree related db calls (public)
+  //
+
+  // TODO: descriptions
+  void advance_tree(const uint64_t block_idx, const std::vector<fcmp_pp::curve_trees::OutputContext> &known_new_outputs);
+
+  void grow_tree(const uint64_t block_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs);
+
+  void trim_block();
+
+  void trim_tree(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_idx);
+
+  std::pair<uint64_t, fcmp_pp::curve_trees::PathBytes> get_last_path(const uint64_t block_idx) const;
+
+  uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
+    const uint64_t as_of_n_blocks,
+    std::vector<uint64_t> &leaf_idxs_out,
+    std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const;
+
   /**
    * @brief add outs to locked outputs tables
    *
@@ -1830,16 +1879,7 @@ public:
    */
   virtual void add_locked_outs(const fcmp_pp::curve_trees::OutsByLastLockedBlock& outs_by_last_locked_block, const std::unordered_map<uint64_t/*output_id*/, uint64_t/*last locked block_id*/>& timelocked_outputs) = 0;
 
-  virtual void advance_tree(const uint64_t block_idx, const std::vector<fcmp_pp::curve_trees::OutputContext> &known_new_outputs) = 0;
-
-  // TODO: description and make private
-  virtual void grow_tree(const uint64_t block_id, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs) = 0;
-
-  virtual void trim_tree(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_id) = 0;
-
-  virtual std::pair<uint64_t, fcmp_pp::curve_trees::PathBytes> get_last_path(const uint64_t block_idx) const = 0;
-
-  // TODO: description
+  // TODO: descriptions
   virtual bool audit_tree(const uint64_t expected_n_leaf_tuples) const = 0;
   virtual uint64_t get_n_leaf_tuples() const = 0;
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const = 0;
@@ -1880,12 +1920,6 @@ public:
    * @return custom timelocked outputs grouped by last locked block
    */
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const = 0;
-
-  // TODO: description
-  virtual uint64_t get_path_by_global_output_id(const std::vector<uint64_t> &global_output_ids,
-    const uint64_t as_of_n_blocks,
-    std::vector<uint64_t> &leaf_idxs_out,
-    std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const = 0;
 
   //
   // Hard fork related storage

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1968,22 +1968,14 @@ public:
 
 };  // class BlockchainDB
 
-class db_txn_guard
+class db_rtxn_guard
 {
 public:
-  db_txn_guard(BlockchainDB *db, bool readonly): db(db), readonly(readonly), active(false)
+  db_rtxn_guard(const BlockchainDB *db): db(db), active(false)
   {
-    if (readonly)
-    {
-      active = db->block_rtxn_start();
-    }
-    else
-    {
-      db->block_wtxn_start();
-      active = true;
-    }
+    active = db->block_rtxn_start();
   }
-  virtual ~db_txn_guard()
+  virtual ~db_rtxn_guard()
   {
     stop();
   }
@@ -1991,30 +1983,51 @@ public:
   {
     if (active)
     {
-      if (readonly)
-        db->block_rtxn_stop();
-      else
-        db->block_wtxn_stop();
+      db->block_rtxn_stop();
       active = false;
     }
   }
   void abort()
   {
-    if (readonly)
-      db->block_rtxn_abort();
-    else
-      db->block_wtxn_abort();
+    db->block_rtxn_abort();
+    active = false;
+  }
+
+private:
+  const BlockchainDB *db;
+  bool active;
+};
+
+class db_wtxn_guard
+{
+public:
+  db_wtxn_guard(BlockchainDB *db): db(db), active(false)
+  {
+    db->block_wtxn_start();
+    active = true;
+  }
+  virtual ~db_wtxn_guard()
+  {
+    stop();
+  }
+  void stop()
+  {
+    if (active)
+    {
+      db->block_wtxn_stop();
+      active = false;
+    }
+  }
+  void abort()
+  {
+    db->block_wtxn_abort();
     active = false;
   }
 
 private:
   BlockchainDB *db;
-  bool readonly;
   bool active;
 };
-
-class db_rtxn_guard: public db_txn_guard { public: db_rtxn_guard(BlockchainDB *db): db_txn_guard(db, true) {} };
-class db_wtxn_guard: public db_txn_guard { public: db_wtxn_guard(BlockchainDB *db): db_txn_guard(db, false) {} };
 
 BlockchainDB *new_db();
 

--- a/src/blockchain_db/blockchain_db.h
+++ b/src/blockchain_db/blockchain_db.h
@@ -1852,7 +1852,7 @@ public:
   //
 
   // TODO: descriptions
-  void advance_tree(const uint64_t block_idx, const std::vector<fcmp_pp::curve_trees::OutputContext> &known_new_outputs);
+  virtual void advance_tree(const uint64_t block_idx, const std::vector<fcmp_pp::curve_trees::OutputContext> &known_new_outputs);
 
   void grow_tree(const uint64_t block_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs);
 

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -122,6 +122,7 @@ public:
   virtual void remove_spent_key(const crypto::key_image& k_image) override {}
 
   virtual void add_locked_outs(const fcmp_pp::curve_trees::OutsByLastLockedBlock& outs_by_last_locked_block, const std::unordered_map<uint64_t/*output_id*/, uint64_t/*last locked block_id*/>& timelocked_outputs) override {};
+  virtual void advance_tree(const uint64_t block_idx, const std::vector<fcmp_pp::curve_trees::OutputContext> &known_new_outputs) override {};
   virtual std::vector<fcmp_pp::curve_trees::OutputContext> get_outs_at_last_locked_block_idx(uint64_t block_id) const override { return std::vector<fcmp_pp::curve_trees::OutputContext>{}; };
   virtual void del_locked_outs_at_block_idx(uint64_t block_idx) override {};
   virtual uint64_t get_tree_block_idx() const override { return 0; };

--- a/src/blockchain_db/testdb.h
+++ b/src/blockchain_db/testdb.h
@@ -120,17 +120,24 @@ public:
   virtual void add_tx_amount_output_indices(const uint64_t tx_index, const std::vector<uint64_t>& amount_output_indices) override {}
   virtual void add_spent_key(const crypto::key_image& k_image) override {}
   virtual void remove_spent_key(const crypto::key_image& k_image) override {}
+
   virtual void add_locked_outs(const fcmp_pp::curve_trees::OutsByLastLockedBlock& outs_by_last_locked_block, const std::unordered_map<uint64_t/*output_id*/, uint64_t/*last locked block_id*/>& timelocked_outputs) override {};
-  virtual void advance_tree(const uint64_t block_idx, const std::vector<fcmp_pp::curve_trees::OutputContext> &known_new_outputs) override {}
-  virtual void grow_tree(const uint64_t block_idx, std::vector<fcmp_pp::curve_trees::OutputContext> &&new_outputs) override {};
-  virtual std::pair<uint64_t, fcmp_pp::curve_trees::PathBytes> get_last_path(const uint64_t block_idx) const override { return {0, fcmp_pp::curve_trees::PathBytes{}}; };
-  virtual void trim_tree(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_id) override {};
+  virtual std::vector<fcmp_pp::curve_trees::OutputContext> get_outs_at_last_locked_block_idx(uint64_t block_id) const override { return std::vector<fcmp_pp::curve_trees::OutputContext>{}; };
+  virtual void del_locked_outs_at_block_idx(uint64_t block_idx) override {};
+  virtual uint64_t get_tree_block_idx() const override { return 0; };
+  virtual std::vector<crypto::ec_point> get_tree_edge(uint64_t block_id) const override { return {}; };
+  virtual void save_tree_meta(const uint64_t block_idx, const uint64_t n_leaf_tuples, const std::vector<crypto::ec_point> &tree_edge) override {};
+  virtual void del_tree_meta(const uint64_t block_idx) override {};
+  virtual std::vector<crypto::ec_point> grow_with_tree_extension(const fcmp_pp::curve_trees::CurveTreesV1::TreeExtension &tree_extension) override { return std::vector<crypto::ec_point>{}; };
+  virtual fcmp_pp::curve_trees::PathBytes get_path(const fcmp_pp::curve_trees::PathIndexes &path_indexes) const override { return fcmp_pp::curve_trees::PathBytes{}; };
+  virtual uint64_t find_leaf_idx_by_output_id_bounded_search(uint64_t output_id, uint64_t leaf_idx_start, uint64_t leaf_idx_end) const override { return 0; };
+  virtual uint64_t trim_leaves(const uint64_t new_n_leaf_tuples, const uint64_t trim_block_idx) override { return 0; };
+  virtual void trim_layers(const uint64_t new_n_leaf_tuples, const std::vector<uint64_t> &n_elems_per_layer, const std::vector<crypto::ec_point> &prev_tree_edge, const uint64_t expected_root_idx) override {};
   virtual bool audit_tree(const uint64_t expected_n_leaf_tuples) const override { return false; };
   virtual uint8_t get_tree_root_at_blk_idx(const uint64_t blk_idx, crypto::ec_point &tree_root_out) const override { return {}; };
   virtual uint64_t get_n_leaf_tuples() const override { return 0; };
   virtual uint64_t get_block_n_leaf_tuples(const uint64_t block_idx) const override { return 0; };
   virtual fcmp_pp::curve_trees::OutsByLastLockedBlock get_custom_timelocked_outputs(uint64_t start_block_idx) const override { return {{}}; };
-  virtual uint64_t get_path_by_global_output_id( const std::vector<uint64_t> &global_output_ids, const uint64_t as_of_n_blocks, std::vector<uint64_t> &leaf_idxs_out, std::vector<fcmp_pp::curve_trees::PathBytes> &paths_out) const override { return 0; };
 
   virtual bool for_all_key_images(std::function<bool(const crypto::key_image&)>) const override { return true; }
   virtual bool for_blocks_range(const uint64_t&, const uint64_t&, std::function<bool(uint64_t, const crypto::hash&, const cryptonote::block&)>) const override { return true; }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -457,8 +457,15 @@ bool Blockchain::init(BlockchainDB* db, const network_type nettype, bool offline
     recalculate_difficulties(difficulty_recalc_height);
   }
 
+  if (m_db->is_read_only())
   {
-    db_txn_guard txn_guard(m_db, m_db->is_read_only());
+    db_rtxn_guard txn_guard(m_db);
+    if (!update_next_cumulative_weight_limit())
+      return false;
+  }
+  else
+  {
+    db_wtxn_guard txn_guard(m_db);
     if (!update_next_cumulative_weight_limit())
       return false;
   }

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -634,6 +634,11 @@ namespace cryptonote
   //------------------------------------------------------------------------------------------------------------------------------
   static bool set_init_tree_sync_data(const uint64_t init_block_idx, const crypto::hash &init_hash, const core &m_core, COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t &init_tree_sync_data)
   {
+    db_rtxn_guard txn_guard(&m_core.get_blockchain_storage().get_db());
+
+    CHECK_AND_ASSERT_MES(m_core.get_blockchain_storage().get_db().get_block_height(init_hash) == init_block_idx, false,
+      "set_init_tree_sync_data: mismatched init_hash to init_block_idx");
+
     init_tree_sync_data = COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t{};
     init_tree_sync_data.init_block_idx = init_block_idx;
     init_tree_sync_data.init_block_hash = init_hash;

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -636,6 +636,8 @@ namespace cryptonote
   {
     db_rtxn_guard txn_guard(&m_core.get_blockchain_storage().get_db());
 
+    CHECK_AND_ASSERT_MES(m_core.get_blockchain_storage().get_db().height() > init_block_idx, false,
+      "set_init_tree_sync_data: init_block_idx expected less than current chain height");
     CHECK_AND_ASSERT_MES(m_core.get_blockchain_storage().get_db().get_block_hash_from_height(init_block_idx) == init_hash, false,
       "set_init_tree_sync_data: mismatched init_hash to init_block_idx");
 

--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -636,7 +636,7 @@ namespace cryptonote
   {
     db_rtxn_guard txn_guard(&m_core.get_blockchain_storage().get_db());
 
-    CHECK_AND_ASSERT_MES(m_core.get_blockchain_storage().get_db().get_block_height(init_hash) == init_block_idx, false,
+    CHECK_AND_ASSERT_MES(m_core.get_blockchain_storage().get_db().get_block_hash_from_height(init_block_idx) == init_hash, false,
       "set_init_tree_sync_data: mismatched init_hash to init_block_idx");
 
     init_tree_sync_data = COMMAND_RPC_GET_BLOCKS_FAST::init_tree_sync_data_t{};


### PR DESCRIPTION
Moves the vast majority of curve trees specific business logic
out of db_lmdb.cpp, and up into blockchain_db.cpp. This more
cleanly separates strict db read/write ops from curve trees
logic that is tied to consensus. "blockchain_db" now is
responsible for doing heavy lifting on curve trees specific
logic, calling respective db functions necessary to execute
the curve trees functions.

"blockchain_db" felt like a good place for 2 reasons:

1) the migrate_5_6 function still benefits from being able to
call advance_tree and not duplicating that logic up in the
cryptonote core lib.
2) "blockchain" felt relevant to "curve trees" specific logic,
especially more relevant than "db_lmdb"

I feel this is a much cleaner structure that is easier to parse
and understand logically.

Note: I also relied on `db_rtxn_guard` to guarantee consistent db reads for the duration of function calls where it seemed appropriate. There's a commit separating `db_rtxn_guard` from `db_wtxn_guard` to enable passing in a const ref to the db in `core_rpc_server` when using `db_rtxn_guard`.