### PR TITLE
fcmp++: fast pop blocks in wallet + fix tree cache ref counter + better logging

### DIFF
--- a/src/fcmp_pp/tree_cache.h
+++ b/src/fcmp_pp/tree_cache.h
@@ -224,6 +224,9 @@ public:
     // The pruning feature of the cache gets rid of all refs we don't need anymore
     void shrink_to_reorg_depth();
 
+    // Enable popping back to a specific block efficiently
+    bool pop_to_block(const uint64_t new_top_blk_idx, const crypto::hash &new_top_hash);
+
     // Clear all state
     void clear();
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11741,7 +11741,7 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks)
   if (close_enough)
     LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
   else
-    LOG_PRINT_L2("Not using v" << (unsigned)version << " rules");
+    LOG_PRINT_L3("Not using v" << (unsigned)version << " rules");
   return close_enough;
 }
 //----------------------------------------------------------------------------------------------------

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -11737,7 +11737,7 @@ bool wallet2::use_fork_rules(uint8_t version, int64_t early_blocks)
   if (close_enough)
     LOG_PRINT_L2("Using v" << (unsigned)version << " rules");
   else
-    LOG_PRINT_L3("Not using v" << (unsigned)version << " rules");
+    LOG_PRINT_L2("Not using v" << (unsigned)version << " rules");
   return close_enough;
 }
 //----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Builds on #81.

1) **Fast pop blocks in tree cache:** If we know which block we're popping back to, we only need to re-hash the last chunk one time, rather than do it for every block we pop.

2) **Fix tree cache ref counter:** Assume the tree grows and we add a new layer (i.e. a new root). We would then need to add a ref to the new root for every registered and assigned leaf. This was a lingering FIXME in `tree_cache.cpp`.

3) **Better logging:** More metadata to help explain what's happening in error logs and log statements.

_______

Recall how the scanner identifies received outputs in parallel to building the curve tree.

If using the CLI and the wallet prompts for a password because the scanner identified a received output, then the user inputs their password incorrectly and the scanner throws, the tree cache must pop blocks back to maintain parity with the scanner.

This PR makes sure the popping is done quickly, by only re-hashing the right-most tree edge one time in `pop_to_block`, as opposed to once for every block popped.

Note: to improve UX even further, https://github.com/monero-project/monero/pull/9917 is useful to ensure that while the CLI waits for the user to input their password, the wallet can continue building the curve tree in another thread(s). Without 9917, this [first waiter](https://github.com/seraphis-migration/monero/blob/90ce152ba79b5aaf42729405b2a8d6d8e650a209/src/fcmp_pp/curve_trees.cpp#L1551) gets stuck waiting for the user to input their password. Presumably 9917 should have an even larger impact on scanning perf because I would think that tree builder waiter can get stuck potentially waiting on scan tasks to complete.