### PR TITLE
carrot+fcmp: misc refactors of tx_builder b4 hot/cold support

### DIFF
--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -44,6 +44,7 @@
 #include "common/apply_permutation.h"
 #include "common/perf_timer.h"
 #include "common/threadpool.h"
+#include "crypto/generators.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "cryptonote_core/blockchain.h"
 #include "fcmp_pp/fcmp_pp_types.h"
@@ -245,7 +246,210 @@ static carrot::InputCandidate make_input_candidate(const wallet2_basic::transfer
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-static std::unordered_map<crypto::public_key, size_t> collect_non_burned_transfers_by_onetime_address(
+std::vector<cryptonote::tx_destination_entry> finalized_destinations_ref(const tx_reconstruct_variant_t &v,
+    const carrot::view_incoming_key_device &k_view_dev)
+{
+    struct finalized_destinations_ref_visitor
+    {
+        std::vector<cryptonote::tx_destination_entry> operator()(const PreCarrotTransactionProposal &p) const
+        {
+            return p.splitted_dsts;
+        }
+
+        std::vector<cryptonote::tx_destination_entry> operator()(const carrot::CarrotTransactionProposalV1 &p) const
+        {
+            std::vector<cryptonote::tx_destination_entry> res;
+            res.reserve(p.normal_payment_proposals.size() + p.selfsend_payment_proposals.size());
+            for (const auto &normal_payment_proposal : p.normal_payment_proposals)
+                res.push_back(make_tx_destination_entry(normal_payment_proposal));
+            for (const auto &selfsend_payment_proposal : p.selfsend_payment_proposals)
+                res.push_back(make_tx_destination_entry(selfsend_payment_proposal, k_view_dev));
+            return res;
+        }
+
+        const carrot::view_incoming_key_device &k_view_dev;
+    };
+    return std::visit(finalized_destinations_ref_visitor{k_view_dev}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+cryptonote::tx_destination_entry change_destination_ref(const tx_reconstruct_variant_t &v,
+    const carrot::view_incoming_key_device &k_view_dev)
+{
+    struct change_destination_ref_visitor
+    {
+        cryptonote::tx_destination_entry operator()(const PreCarrotTransactionProposal &p) const
+        {
+            return p.change_dts;
+        }
+
+        cryptonote::tx_destination_entry operator()(const carrot::CarrotTransactionProposalV1 &p) const
+        {
+            std::vector<crypto::key_image> fake_key_images(p.input_proposals.size());
+            return make_pending_carrot_tx(p, fake_key_images, k_view_dev).change_dts;
+        }
+
+        const carrot::view_incoming_key_device &k_view_dev;
+    };
+    return std::visit(change_destination_ref_visitor{k_view_dev}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+rct::xmr_amount fee_ref(const tx_reconstruct_variant_t &v)
+{
+    struct fee_ref_visitor
+    {
+        rct::xmr_amount operator()(const PreCarrotTransactionProposal &p) const
+        {
+            rct::xmr_amount fee = 0;
+            for (const cryptonote::tx_source_entry &i: p.sources) fee += i.amount;
+            for (const cryptonote::tx_destination_entry &i: p.splitted_dsts) fee -= i.amount;
+            return fee;
+        }
+
+        rct::xmr_amount operator()(const carrot::CarrotTransactionProposalV1 &p) const
+        {
+            return p.fee;
+        }
+    };
+    return std::visit(fee_ref_visitor{}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::optional<crypto::hash8> short_payment_id_ref(const tx_reconstruct_variant_t &v)
+{
+    struct short_payment_id_ref_visitor
+    {
+        std::optional<crypto::hash8> operator()(const PreCarrotTransactionProposal &p) const
+        {
+            std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+            if (!cryptonote::parse_tx_extra(p.extra, tx_extra_fields))
+                return std::nullopt;
+            cryptonote::tx_extra_nonce extra_nonce;
+            if (!cryptonote::find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+                return std::nullopt;
+            crypto::hash8 pid8;
+            if (!cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, pid8))
+                return std::nullopt;
+            return pid8;
+        }
+
+        std::optional<crypto::hash8> operator()(const carrot::CarrotTransactionProposalV1 &p) const
+        {
+            for (const carrot::CarrotPaymentProposalV1 &normal_payment_proposal : p.normal_payment_proposals)
+                if (normal_payment_proposal.destination.payment_id != carrot::null_payment_id)
+                    return carrot::raw_byte_convert<crypto::hash8>(normal_payment_proposal.destination.payment_id);
+            return std::nullopt;
+        }
+    };
+    return std::visit(short_payment_id_ref_visitor{}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::optional<crypto::hash> long_payment_id_ref(const tx_reconstruct_variant_t &v)
+{
+    const PreCarrotTransactionProposal *p = std::get_if<PreCarrotTransactionProposal>(&v);
+    if (nullptr == p)
+        return std::nullopt;
+    std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+    if (!cryptonote::parse_tx_extra(p->extra, tx_extra_fields))
+        return std::nullopt;
+    cryptonote::tx_extra_nonce extra_nonce;
+    if (!cryptonote::find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
+        return std::nullopt;
+    crypto::hash pid32;
+    if (!cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce.nonce, pid32))
+        return std::nullopt;
+    return pid32;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::vector<crypto::public_key> spent_onetime_addresses_ref(const tx_reconstruct_variant_t &v)
+{
+    struct spent_onetime_addresses_ref_visitor
+    {
+        std::vector<crypto::public_key> operator()(const PreCarrotTransactionProposal &tcd) const
+        {
+            std::vector<crypto::public_key> res;
+            res.reserve(tcd.sources.size());
+            for (const cryptonote::tx_source_entry &source : tcd.sources)
+                res.push_back(rct::rct2pk(source.outputs.at(source.real_output).second.dest));
+            return res;
+        }
+
+        std::vector<crypto::public_key> operator()(const carrot::CarrotTransactionProposalV1 &carrot_tx_proposal) const
+        {
+            std::vector<crypto::public_key> res;
+            res.reserve(carrot_tx_proposal.input_proposals.size());
+            for (const carrot::InputProposalV1 &input_proposal : carrot_tx_proposal.input_proposals)
+                res.push_back(onetime_address_ref(input_proposal));
+            return res;
+        }
+    };
+
+    return std::visit(spent_onetime_addresses_ref_visitor{}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+boost::multiprecision::uint128_t input_amount_total_ref(const tx_reconstruct_variant_t &v)
+{
+    struct input_amount_total_ref_visitor
+    {
+        boost::multiprecision::uint128_t operator()(const PreCarrotTransactionProposal &p) const
+        {
+            boost::multiprecision::uint128_t res = 0;
+            for (const cryptonote::tx_source_entry &src : p.sources)
+                res += src.amount;
+            return res;
+        }
+
+        boost::multiprecision::uint128_t operator()(const carrot::CarrotTransactionProposalV1 &p) const
+        {
+            boost::multiprecision::uint128_t res = p.fee;
+            for (const auto &normal_payment_proposal : p.normal_payment_proposals)
+                res += normal_payment_proposal.amount;
+            for (const auto &selfsend_payment_proposals : p.selfsend_payment_proposals)
+                res += selfsend_payment_proposals.proposal.amount;
+            return res;
+        }
+    };
+    return std::visit(input_amount_total_ref_visitor{}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::vector<std::uint64_t> ring_sizes_ref(const tx_reconstruct_variant_t &v)
+{
+    struct ring_sizes_ref_visitor
+    {
+        std::vector<std::uint64_t> operator()(const PreCarrotTransactionProposal &p) const
+        {
+            std::vector<std::uint64_t> res;
+            res.reserve(p.sources.size());
+            for (const cryptonote::tx_source_entry &src : p.sources)
+                res.push_back(src.outputs.size());
+            return res;
+        }
+
+        std::vector<std::uint64_t> operator()(const carrot::CarrotTransactionProposalV1 &p) const
+        {
+            return std::vector<std::uint64_t>(p.input_proposals.size());
+        }
+    };
+    return std::visit(ring_sizes_ref_visitor{}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::uint64_t unlock_time_ref(const tx_reconstruct_variant_t &v)
+{
+    const PreCarrotTransactionProposal *p = std::get_if<PreCarrotTransactionProposal>(&v);
+    return p ? p->unlock_time : 0;
+}
+//-------------------------------------------------------------------------------------------------------------------
+const std::vector<std::uint8_t> &extra_ref(const tx_reconstruct_variant_t &v)
+{
+    struct extra_ref_visitor
+    {
+        const std::vector<std::uint8_t> &operator()(const PreCarrotTransactionProposal &p) const
+        { return p.extra; }
+        const std::vector<std::uint8_t> &operator()(const carrot::CarrotTransactionProposalV1 &p) const
+        { return p.extra; }
+    };
+    return std::visit(extra_ref_visitor{}, v);
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unordered_map<crypto::public_key, size_t> collect_non_burned_transfers_by_onetime_address(
     const wallet2_basic::transfer_container &transfers)
 {
     std::unordered_set<crypto::public_key> spent;
@@ -277,7 +481,6 @@ static std::unordered_map<crypto::public_key, size_t> collect_non_burned_transfe
     }
     return best_transfer_by_ota;
 }
-//-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
 std::vector<carrot::InputCandidate> collect_carrot_input_candidate_list(
     const wallet2_basic::transfer_container &transfers,
@@ -540,16 +743,16 @@ carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(con
         CHECK_AND_ASSERT_THROW_MES(carrot::try_load_carrot_extra_v1(td.m_tx.extra,
                 enote_ephemeral_pubkeys,
                 encrypted_payment_id),
-            __func__ << ": failed to parse carrot tx extra");
+            "failed to parse carrot tx extra");
         CHECK_AND_ASSERT_THROW_MES(!enote_ephemeral_pubkeys.empty(),
-            __func__ << ": BUG: missing ephemeral pubkeys");
+            "BUG: missing ephemeral pubkeys");
 
         const size_t ephemeral_pubkey_index = std::min<size_t>(td.m_internal_output_index,
             enote_ephemeral_pubkeys.size() - 1);
         const mx25519_pubkey &enote_ephemeral_pubkey = enote_ephemeral_pubkeys.at(ephemeral_pubkey_index);
 
         CHECK_AND_ASSERT_THROW_MES(!td.m_tx.vin.empty(),
-            __func__ << ": carrot tx prefix missing inputs");
+            "carrot tx prefix missing inputs");
         const cryptonote::txin_v &first_in = td.m_tx.vin.at(0);
 
         CARROT_CHECK_AND_THROW(td.m_internal_output_index < td.m_tx.vout.size(),
@@ -560,7 +763,7 @@ carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(con
         const bool is_coinbase = cryptonote::is_coinbase(td.m_tx);
         const rct::xmr_amount expected_cleartext_amount = is_coinbase ? td.amount() : 0;
         CHECK_AND_ASSERT_THROW_MES(out.amount == expected_cleartext_amount,
-            __func__ << ": output cleartext amount mismatch");
+            "output cleartext amount mismatch");
 
         if (is_coinbase)
         {
@@ -582,7 +785,7 @@ carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(con
         else // !is_coinbase
         {
             CHECK_AND_ASSERT_THROW_MES(first_in.type() == typeid(cryptonote::txin_to_key),
-                __func__ << ": unrecognized input type for carrot v1 tx");
+                "unrecognized input type for carrot v1 tx");
             const crypto::key_image &tx_first_key_image = boost::get<cryptonote::txin_to_key>(first_in).k_image;
 
             // recreate amount parts of the enote and pass as non-coinbase carrot enote v1
@@ -628,22 +831,38 @@ carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(con
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_transaction_proposal_from_transfer_details(
+std::vector<std::size_t> collect_selected_transfer_indices(const tx_reconstruct_variant_t &tx_construction_data,
+    const wallet2_basic::transfer_container &transfers)
+{
+    const auto best_transfer_by_ota = collect_non_burned_transfers_by_onetime_address(transfers);
+
+    const std::vector<crypto::public_key> spent_onetime_addresses = spent_onetime_addresses_ref(tx_construction_data);
+    std::vector<std::size_t> selected_transfer_indices;
+    selected_transfer_indices.reserve(spent_onetime_addresses.size());
+    for (const crypto::public_key &spent_onetime_address : spent_onetime_addresses)
+    {
+        const auto ota_it = best_transfer_by_ota.find(spent_onetime_address);
+        CARROT_CHECK_AND_THROW(ota_it != best_transfer_by_ota.cend(),
+            carrot::missing_components, "missing proposed spent onetime address in transfers list");
+        selected_transfer_indices.push_back(ota_it->second);
+    }
+
+    return selected_transfer_indices;
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_transaction_proposal(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
-    const wallet2_basic::transfer_container &transfers,
-    const cryptonote::account_keys &acc_keys)
+    const carrot::cryptonote_hierarchy_address_device &addr_dev,
+    const crypto::secret_key &k_spend)
 {
     const size_t n_inputs = tx_proposal.input_proposals.size();
     CHECK_AND_ASSERT_THROW_MES(rerandomized_outputs.size() == n_inputs,
-        __func__ << ": wrong size for rerandomized_outputs");
+        "wrong size for rerandomized_outputs");
 
     //! @TODO: carrot hierarchy
-    const carrot::cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        acc_keys.m_account_address.m_spend_public_key,
-        acc_keys.m_view_secret_key);
     const carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);
-    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(acc_keys.m_spend_secret_key);
+    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(k_spend);
     const carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
         hybrid_addr_dev,
         nullptr,
@@ -665,7 +884,7 @@ std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_trans
         carrot::make_sal_proof_any_to_legacy_v1(signable_tx_hash,
             rerandomized_outputs.at(input_idx),
             tx_proposal.input_proposals.at(input_idx),
-            acc_keys.m_spend_secret_key,
+            k_spend,
             addr_dev,
             sal_proof,
             actual_key_image);
@@ -675,68 +894,27 @@ std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_trans
     return sal_proofs_by_ki;
 }
 //-------------------------------------------------------------------------------------------------------------------
-cryptonote::transaction finalize_all_proofs_from_transfer_details(
-    const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const wallet2_basic::transfer_container &transfers,
+cryptonote::transaction finalize_fcmps_and_range_proofs(
+    const std::vector<crypto::key_image> &sorted_input_key_images,
+    const std::vector<FcmpRerandomizedOutputCompressed> &sorted_rerandomized_outputs,
+    const std::vector<fcmp_pp::FcmpPpSalProof> &sorted_sal_proofs,
+    const std::vector<carrot::RCTOutputEnoteProposal> &output_enote_proposals,
+    const carrot::encrypted_payment_id_t &encrypted_payment_id,
+    const rct::xmr_amount fee,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
-    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const cryptonote::account_keys &acc_keys)
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees)
 {
-    const size_t n_inputs = tx_proposal.input_proposals.size();
-    const size_t n_outputs = tx_proposal.normal_payment_proposals.size()
-        + tx_proposal.selfsend_payment_proposals.size();
-    CHECK_AND_ASSERT_THROW_MES(n_inputs, __func__ << ": no inputs");
+    const size_t n_inputs = sorted_input_key_images.size();
+    const size_t n_outputs = output_enote_proposals.size();
+    CARROT_CHECK_AND_THROW(n_inputs, carrot::too_few_inputs, "no inputs");
+    CARROT_CHECK_AND_THROW(sorted_rerandomized_outputs.size() == n_inputs,
+        carrot::component_out_of_order, "wrong number of rerandomized outputs");
+    CARROT_CHECK_AND_THROW(sorted_sal_proofs.size() == n_inputs,
+        carrot::component_out_of_order, "wrong number of SA/L proofs");
 
-    LOG_PRINT_L2(__func__ << ": make all proofs for transaction proposal: "
-        << n_inputs << "-in " << n_outputs << "-out, with "
-        << tx_proposal.normal_payment_proposals.size() << " normal payment proposals, "
-        << tx_proposal.selfsend_payment_proposals.size() << " self-send payment proposals, and a fee of "
-        << tx_proposal.fee << " pXMR");
-
-    // collect core selfsend proposals
-    std::vector<carrot::CarrotPaymentProposalSelfSendV1> selfsend_payment_proposal_cores;
-    selfsend_payment_proposal_cores.reserve(tx_proposal.selfsend_payment_proposals.size());
-    for (const auto &selfsend_payment_proposal : tx_proposal.selfsend_payment_proposals)
-        selfsend_payment_proposal_cores.push_back(selfsend_payment_proposal.proposal);
-
-    //! @TODO: carrot hierarchy / HW device
-    const carrot::cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        acc_keys.m_account_address.m_spend_public_key,
-        acc_keys.m_view_secret_key);
-    const carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);
-    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(acc_keys.m_spend_secret_key);
-    const carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
-        hybrid_addr_dev,
-        nullptr,
-        &addr_dev);
-
-    // finalize key images
-    std::vector<crypto::key_image> sorted_input_key_images;
-    std::vector<std::size_t> key_image_order;
-    carrot::get_sorted_input_key_images_from_proposal_v1(tx_proposal,
-        key_image_dev,
-        sorted_input_key_images,
-        &key_image_order);
-
-    // finalize enotes
-    LOG_PRINT_L3("Getting output enote proposals");
-    std::vector<carrot::RCTOutputEnoteProposal> output_enote_proposals;
-    carrot::encrypted_payment_id_t encrypted_payment_id;
-    carrot::get_output_enote_proposals(tx_proposal.normal_payment_proposals,
-        selfsend_payment_proposal_cores,
-        tx_proposal.dummy_encrypted_payment_id,
-        /*s_view_balance_dev=*/nullptr, //! @TODO: internal
-        &addr_dev,
-        sorted_input_key_images.at(0),
-        output_enote_proposals,
-        encrypted_payment_id);
-    CHECK_AND_ASSERT_THROW_MES(output_enote_proposals.size() == n_outputs,
-        __func__ << ": unexpected number of output enote proposals");
-
-    // collect all non-burned inputs owned by wallet
-    const auto best_transfers_by_ota = collect_non_burned_transfers_by_onetime_address(transfers);
-    LOG_PRINT_L3("Did a burning bug pass, eliminated " << (transfers.size() - best_transfers_by_ota.size())
-        << " eligible transfers");
+    LOG_PRINT_L2("Making FCMPs and BP+ proofs for transaction proposal: "
+        << n_inputs << "-in " << n_outputs << "-out, with fee of "
+        << cryptonote::print_money(fee));
 
     // collect output amount blinding factors
     std::vector<rct::key> output_amount_blinding_factors;
@@ -744,64 +922,54 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     for (const carrot::RCTOutputEnoteProposal &output_enote_proposal : output_enote_proposals)
         output_amount_blinding_factors.push_back(rct::sk2rct(output_enote_proposal.amount_blinding_factor));
 
-    // collect input onetime addresses, amount commitments, and blinding factors
-    std::vector<crypto::public_key> input_onetime_addresses;
-    std::vector<rct::key> input_amount_commitments;
-    std::vector<rct::key> input_amount_blinding_factors;
-    input_onetime_addresses.reserve(n_inputs);
-    input_amount_commitments.reserve(n_inputs);
-    input_amount_blinding_factors.reserve(n_inputs);
-    for (const std::size_t &input_proposal_idx : key_image_order)
+    // collect (O, C) input pairs in key image order
+    std::vector<fcmp_pp::curve_trees::OutputPair> spent_input_pairs;
+    spent_input_pairs.reserve(n_inputs);
+    for (const FcmpRerandomizedOutputCompressed &rerandomized_output : sorted_rerandomized_outputs)
     {
-        const carrot::InputProposalV1 &input_proposal = tx_proposal.input_proposals.at(input_proposal_idx);
-        const auto ota_it = best_transfers_by_ota.find(onetime_address_ref(input_proposal));
-        CHECK_AND_ASSERT_THROW_MES(ota_it != best_transfers_by_ota.cend(),
-            __func__ << ": cannot find transfer by onetime address");
-        const size_t transfer_idx = ota_it->second;
-        CHECK_AND_ASSERT_THROW_MES(transfer_idx < transfers.size(),
-            __func__ << ": transfer index out of range");
-        const wallet2_basic::transfer_details &td = transfers.at(transfer_idx);
-        const fcmp_pp::curve_trees::OutputPair input_pair = td.get_output_pair();
-        input_onetime_addresses.push_back(input_pair.output_pubkey);
-        input_amount_commitments.push_back(input_pair.commitment);
-        input_amount_blinding_factors.push_back(td.m_mask);
+        rct::key O_tilde, C_tilde, r_o, r_c;
+        memcpy(&O_tilde, rerandomized_output.input.O_tilde, sizeof(O_tilde));
+        memcpy(&C_tilde, rerandomized_output.input.C_tilde, sizeof(C_tilde));
+        memcpy(&r_o, rerandomized_output.r_o, sizeof(r_o));
+        memcpy(&r_c, rerandomized_output.r_c, sizeof(r_c));
+
+        // O = O~ - r_o T
+        rct::key O;
+        rct::scalarmultKey(O, rct::pk2rct(crypto::get_T()), r_o);
+        rct::subKeys(O, O_tilde, O);
+
+        // C = C~ - r_c G
+        rct::key C;
+        rct::scalarmultBase(C, r_c);
+        rct::subKeys(C, C_tilde, C);
+
+        spent_input_pairs.push_back({rct::rct2pk(O), C});
     }
 
-    // make rerandomized outputs
-    std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
-    carrot::make_carrot_rerandomized_outputs_nonrefundable(input_onetime_addresses,
-        input_amount_commitments,
-        input_amount_blinding_factors,
-        output_amount_blinding_factors,
-        rerandomized_outputs);
-    
     // collect FCMP paths
     std::vector<fcmp_pp::curve_trees::CurveTreesV1::Path> fcmp_paths;
     fcmp_paths.reserve(n_inputs);
-    for (size_t i = 0; i < n_inputs; ++i)
+    for (const fcmp_pp::curve_trees::OutputPair input_pair : spent_input_pairs)
     {
-        const fcmp_pp::curve_trees::OutputPair input_pair{input_onetime_addresses.at(i),
-            input_amount_commitments.at(i)};
-
         MDEBUG("Requesting FCMP path from tree cache for onetime address " << input_pair.output_pubkey);
         fcmp_pp::curve_trees::CurveTreesV1::Path &fcmp_path = fcmp_paths.emplace_back();
         CHECK_AND_ASSERT_THROW_MES(tree_cache.get_output_path(input_pair, fcmp_path),
-            "finalize_all_proofs_from_transfer_details: failed to get FCMP path from tree cache");
-        CHECK_AND_ASSERT_THROW_MES(!fcmp_path.empty(), "finalize_all_proofs_from_transfer_details: FCMP path is empty");
+            "failed to get FCMP path from tree cache");
+        CHECK_AND_ASSERT_THROW_MES(!fcmp_path.empty(), "FCMP path is empty");
         assert(curve_trees.audit_path(fcmp_path, input_pair, tree_cache.get_n_leaf_tuples()));
     }
 
     // assert dimension properties of FCMP paths
-    CHECK_AND_ASSERT_THROW_MES(fcmp_paths.size(), "finalize_all_proofs_from_transfer_details: missing FCMP paths");
+    CHECK_AND_ASSERT_THROW_MES(fcmp_paths.size(), "missing FCMP paths");
     const auto &first_fcmp_path = fcmp_paths.at(0);
     for (const auto &fcmp_path : fcmp_paths)
     {
         CHECK_AND_ASSERT_THROW_MES(!fcmp_path.c1_layers.empty(),
-            "finalize_all_proofs_from_transfer_details: missing hashes");
+            "missing hashes");
         CHECK_AND_ASSERT_THROW_MES(fcmp_path.c1_layers.size() == first_fcmp_path.c1_layers.size(),
-            "finalize_all_proofs_from_transfer_details: FCMP path c1 layers mismatch");
+            "FCMP path c1 layers mismatch");
         CHECK_AND_ASSERT_THROW_MES(fcmp_path.c2_layers.size() == first_fcmp_path.c2_layers.size(),
-            "finalize_all_proofs_from_transfer_details: FCMP path c2 layers mismatch");
+            "FCMP path c2 layers mismatch");
     }
     const size_t n_tree_layers = first_fcmp_path.c1_layers.size() + first_fcmp_path.c2_layers.size();
     const bool root_is_c1 = n_tree_layers % 2 == 1;
@@ -828,7 +996,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     std::vector<fcmp_pp::HeliosBranchBlind> flat_helios_branch_blinds(num_c2_blinds * n_inputs);
     for (size_t i = 0; i < n_inputs; ++i)
     {
-        const FcmpRerandomizedOutputCompressed &rerandomized_output = rerandomized_outputs.at(i);
+        const FcmpRerandomizedOutputCompressed &rerandomized_output = sorted_rerandomized_outputs.at(i);
         tpool.submit(&pre_membership_waiter, [&rerandomized_output, &blinded_o_blinds, i]() {
             PERF_TIMER(blind_o_blind);
             blinded_o_blinds[i] = fcmp_pp::blind_o_blind(fcmp_pp::o_blind(rerandomized_output));});
@@ -866,39 +1034,9 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         bpp = rct::bulletproof_plus_PROVE(output_amounts, output_amount_blinding_factors);
     });
 
-    // Submit SA/L jobs
-    //! @TODO: parallelize jobs
-    std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs(n_inputs);
-    tpool.submit(&pre_membership_waiter, 
-        [&tx_proposal, &sorted_input_key_images, &rerandomized_outputs, &transfers, &acc_keys, &sal_proofs, &key_image_order]() {
-            // hacky: permutate tx proposal input proposals in key image order
-            carrot::CarrotTransactionProposalV1 tx_proposal_sorted_ins = tx_proposal;
-            tools::apply_permutation(key_image_order, tx_proposal_sorted_ins.input_proposals);
-
-            PERF_TIMER(sign_carrot_transaction_proposal_from_transfer_details);
-            std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sal_proofs_by_ki =
-                sign_carrot_transaction_proposal_from_transfer_details(
-                    tx_proposal_sorted_ins, rerandomized_outputs, transfers, acc_keys);
-
-            CHECK_AND_ASSERT_THROW_MES(sal_proofs.size() == sorted_input_key_images.size(),
-                __func__ << ": bad SA/L result buffer size");
-
-            for (size_t i = 0; i < sal_proofs.size(); ++i)
-            {
-                const crypto::key_image &ki = sorted_input_key_images.at(i);
-                const auto sal_it = sal_proofs_by_ki.find(ki);
-                CHECK_AND_ASSERT_THROW_MES(sal_it != sal_proofs_by_ki.end(),
-                    __func__ << ": missing SA/L proof");
-                CHECK_AND_ASSERT_THROW_MES(sal_it->second.size() == FCMP_PP_SAL_PROOF_SIZE_V1,
-                    __func__ << ": unexpected SA/L proof size");
-                sal_proofs[i] = std::move(sal_it->second);
-                sal_proofs_by_ki.erase(sal_it);
-            }
-        });
-
     const uint64_t n_tree_synced_blocks = tree_cache.n_synced_blocks();
     CHECK_AND_ASSERT_THROW_MES(n_tree_synced_blocks > 0,
-        "finalize_all_proofs_from_transfer_details: no reference block");
+        "no reference block");
     const uint64_t reference_block = n_tree_synced_blocks - 1;
 
     // collect Rust API paths
@@ -907,8 +1045,7 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     for (size_t i = 0; i < n_inputs; ++i)
     {
         const fcmp_pp::curve_trees::CurveTreesV1::Path &fcmp_path = fcmp_paths.at(i);
-        const fcmp_pp::curve_trees::OutputPair output_pair = {input_onetime_addresses.at(i),
-            input_amount_commitments.at(i)};
+        const fcmp_pp::curve_trees::OutputPair output_pair = spent_input_pairs.at(i);
         const auto output_tuple = fcmp_pp::curve_trees::output_to_tuple(output_pair);
 
         const auto path_for_proof = curve_trees.path_for_proof(fcmp_path, output_tuple);
@@ -934,13 +1071,13 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
     // serialize transaction
     cryptonote::transaction tx = carrot::store_carrot_to_transaction_v1(enotes,
         sorted_input_key_images,
-        tx_proposal.fee,
+        fee,
         encrypted_payment_id);
 
     // wait for pre-membership jobs to complete
     LOG_PRINT_L3("Waiting on jobs...");
     CHECK_AND_ASSERT_THROW_MES(pre_membership_waiter.wait(),
-        "finalize_all_proofs_from_transfer_details: some prove jobs failed");
+        "some prove jobs failed");
 
     // collect FCMP Rust API proving structures
     std::vector<fcmp_pp::FcmpPpProveMembershipInput> membership_proving_inputs;
@@ -981,48 +1118,34 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         n_tree_layers);
     PERF_TIMER_PAUSE(prove_membership);
     CHECK_AND_ASSERT_THROW_MES(membership_proof.size() == fcmp_pp::membership_proof_len(n_inputs, n_tree_layers),
-        "finalize_all_proofs_from_transfer_details: unexpected FCMP membership proof length");
+        "unexpected FCMP membership proof length");
 
     // store proofs
     tx.rct_signatures.p = carrot::store_fcmp_proofs_to_rct_prunable_v1(std::move(bpp),
-        rerandomized_outputs,
-        sal_proofs,
+        sorted_rerandomized_outputs,
+        sorted_sal_proofs,
         membership_proof,
         reference_block,
         n_tree_layers);
     tx.pruned = false;
     CHECK_AND_ASSERT_THROW_MES(tx.rct_signatures.p.fcmp_pp.size() == fcmp_pp::fcmp_pp_proof_len(n_inputs, n_tree_layers),
-        "finalize_all_proofs_from_transfer_details: unexpected FCMP++ combined proof length");
+        "unexpected FCMP++ combined proof length");
 
     // get FCMP tree root from provided path
-    //! @TODO: make this a method of TreeCacheV1
-    LOG_PRINT_L3("Making tree root from tree cache");
-    fcmp_pp::TreeRootShared fcmp_tree_root;
-    if (n_tree_layers % 2 == 0)
-    {
-        CHECK_AND_ASSERT_THROW_MES(!first_fcmp_path.c2_layers.empty(), "missing c2 layers");
-        const auto &last_layer = first_fcmp_path.c2_layers.back();
-        CHECK_AND_ASSERT_THROW_MES(last_layer.size() == 1, "unexpected n elems in c2 root");
-        fcmp_tree_root = fcmp_pp::helios_tree_root(last_layer.back());
-    }
-    else
-    {
-        CHECK_AND_ASSERT_THROW_MES(!first_fcmp_path.c1_layers.empty(), "missing c1 layers");
-        const auto &last_layer = first_fcmp_path.c1_layers.back();
-        CHECK_AND_ASSERT_THROW_MES(last_layer.size() == 1, "unexpected n elems in c1 root");
-        fcmp_tree_root = fcmp_pp::selene_tree_root(last_layer.back());
-    }
+    crypto::ec_point fcmp_tree_root_pt;
+    tree_cache.get_tree_root(fcmp_tree_root_pt);
+    const fcmp_pp::TreeRootShared fcmp_tree_root = curve_trees.get_tree_root_from_bytes(n_tree_layers, fcmp_tree_root_pt);
 
     // expand tx
     LOG_PRINT_L3("Expanding newly signed transaction");
     CHECK_AND_ASSERT_THROW_MES(cryptonote::expand_transaction_1(tx, /*base_only=*/false),
-        "finalize_all_proofs_from_transfer_details: failed to perform transaction expansion phase 1");
+        "failed to perform transaction expansion phase 1");
     const crypto::hash tx_prefix_hash = cryptonote::get_transaction_prefix_hash(tx);
     CHECK_AND_ASSERT_THROW_MES(cryptonote::Blockchain::expand_transaction_2(tx,
             tx_prefix_hash,
             /*pubkeys=*/{},
             fcmp_tree_root),
-        "finalize_all_proofs_from_transfer_details: failed to perform transaction expansion phase 2");
+        "failed to perform transaction expansion phase 2");
 
     // verify consensus rules against cached tree root
     {
@@ -1030,39 +1153,163 @@ cryptonote::transaction finalize_all_proofs_from_transfer_details(
         PERF_TIMER(ver_non_input_consensus);
         cryptonote::tx_verification_context tvc{};
         CHECK_AND_ASSERT_THROW_MES(cryptonote::ver_non_input_consensus(tx, tvc, HF_VERSION_FCMP_PLUS_PLUS + 1),
-            "finalize_all_proofs_from_transfer_details: ver_non_input_consensus() failed");
+            "ver_non_input_consensus() failed");
         CHECK_AND_ASSERT_THROW_MES(!tvc.m_verifivation_failed,
-            "finalize_all_proofs_from_transfer_details: ver_non_input_consensus() -> true && tvc.m_verifivation_failed");
+            "ver_non_input_consensus() -> true && tvc.m_verifivation_failed");
     }
     {
         LOG_PRINT_L3("Verifying SA/L transaction proofs");
         PERF_TIMER(verify_sal);
-        const crypto::hash signable_tx_hash =
-            rct::rct2hash(rct::get_pre_mlsag_hash(tx.rct_signatures, acc_keys.get_device()));
+        const rct::key signable_tx_hash = rct::get_pre_mlsag_hash(tx.rct_signatures, hw::get_device("default"));
         for (size_t i = 0; i < n_inputs; ++i)
         {
-            CHECK_AND_ASSERT_THROW_MES(fcmp_pp::verify_sal(signable_tx_hash,
-                    rerandomized_outputs.at(i).input,
+            CHECK_AND_ASSERT_THROW_MES(fcmp_pp::verify_sal(rct::rct2hash(signable_tx_hash),
+                    sorted_rerandomized_outputs.at(i).input,
                     sorted_input_key_images.at(i),
-                    sal_proofs.at(i)),
-                "finalize_all_proofs_from_transfer_details: SA/L proof verification failed");
+                    sorted_sal_proofs.at(i)),
+                "SA/L proof verification failed");
         }
     }
     {
         LOG_PRINT_L3("Verifying input transaction consensus rules");
         PERF_TIMER(verRctNonSemanticsSimple);
         CHECK_AND_ASSERT_THROW_MES(rct::verRctNonSemanticsSimple(tx.rct_signatures),
-            "finalize_all_proofs_from_transfer_details: verRctNonSemanticsSimple() failed");
+            "verRctNonSemanticsSimple() failed");
     }
 
     return tx;
 }
 //-------------------------------------------------------------------------------------------------------------------
+cryptonote::transaction finalize_all_fcmp_pp_proofs(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
+    const cryptonote::account_keys &acc_keys)
+{
+    const size_t n_inputs = tx_proposal.input_proposals.size();
+    const size_t n_outputs = tx_proposal.normal_payment_proposals.size()
+        + tx_proposal.selfsend_payment_proposals.size();
+    CHECK_AND_ASSERT_THROW_MES(n_inputs, "no inputs");
+
+    LOG_PRINT_L2("make all proofs for transaction proposal: "
+        << n_inputs << "-in " << n_outputs << "-out, with "
+        << tx_proposal.normal_payment_proposals.size() << " normal payment proposals, "
+        << tx_proposal.selfsend_payment_proposals.size() << " self-send payment proposals, and a fee of "
+        << tx_proposal.fee << " pXMR");
+
+    //! @TODO: carrot hierarchy / HW device
+    const carrot::cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
+        acc_keys.m_account_address.m_spend_public_key,
+        acc_keys.m_view_secret_key);
+    const carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);
+    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(acc_keys.m_spend_secret_key);
+    const carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
+        hybrid_addr_dev,
+        nullptr,
+        &addr_dev);
+    const crypto::public_key main_address_spend_pubkey = addr_dev.get_cryptonote_account_spend_pubkey();
+
+    // finalize key images
+    std::vector<crypto::key_image> sorted_input_key_images;
+    std::vector<std::size_t> key_image_order;
+    carrot::get_sorted_input_key_images_from_proposal_v1(tx_proposal,
+        key_image_dev,
+        sorted_input_key_images,
+        &key_image_order);
+
+    // collect core selfsend proposals
+    std::vector<carrot::CarrotPaymentProposalSelfSendV1> selfsend_payment_proposal_cores;
+    selfsend_payment_proposal_cores.reserve(tx_proposal.selfsend_payment_proposals.size());
+    for (const auto &selfsend_payment_proposal : tx_proposal.selfsend_payment_proposals)
+        selfsend_payment_proposal_cores.push_back(selfsend_payment_proposal.proposal);
+
+    // finalize enotes
+    LOG_PRINT_L3("Getting output enote proposals");
+    std::vector<carrot::RCTOutputEnoteProposal> output_enote_proposals;
+    carrot::encrypted_payment_id_t encrypted_payment_id;
+    carrot::get_output_enote_proposals(tx_proposal.normal_payment_proposals,
+        selfsend_payment_proposal_cores,
+        tx_proposal.dummy_encrypted_payment_id,
+        /*s_view_balance_dev=*/nullptr, //! @TODO: internal
+        &addr_dev,
+        sorted_input_key_images.at(0),
+        output_enote_proposals,
+        encrypted_payment_id);
+    CHECK_AND_ASSERT_THROW_MES(output_enote_proposals.size() == n_outputs,
+        "unexpected number of output enote proposals");
+
+    // collect input (K_o, C_a, k_a)
+    std::vector<crypto::public_key> input_onetime_addresses;
+    std::vector<rct::key> input_amount_commitments;
+    std::vector<rct::key> input_amount_blinding_factors;
+    input_onetime_addresses.reserve(n_inputs);
+    input_amount_commitments.reserve(n_inputs);
+    input_amount_blinding_factors.reserve(n_inputs);
+    for (const carrot::InputProposalV1 &input_proposal : tx_proposal.input_proposals)
+    {
+        input_onetime_addresses.push_back(onetime_address_ref(input_proposal));
+        input_amount_commitments.push_back(amount_commitment_ref(input_proposal));
+
+        rct::xmr_amount amount;
+        carrot::try_scan_opening_hint_amount(input_proposal,
+            {&main_address_spend_pubkey, 1},
+            &addr_dev,
+            nullptr,
+            amount,
+            input_amount_blinding_factors.emplace_back());
+    }
+
+    // collect output k_a
+    std::vector<rct::key> output_amount_blinding_factors;
+    output_amount_blinding_factors.reserve(n_inputs);
+    for (const carrot::RCTOutputEnoteProposal &output_enote_proposal : output_enote_proposals)
+        output_amount_blinding_factors.push_back(rct::sk2rct(output_enote_proposal.amount_blinding_factor));
+
+    // make rerandomized outputs
+    std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
+    carrot::make_carrot_rerandomized_outputs_nonrefundable(input_onetime_addresses,
+        input_amount_commitments,
+        input_amount_blinding_factors,
+        output_amount_blinding_factors,
+        rerandomized_outputs);
+
+    // do SA/L proofs for each input
+    std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
+    sal_proofs.reserve(n_inputs);
+    {
+        PERF_TIMER(sign_carrot_transaction_proposal);
+        std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sal_proofs_by_ki =
+            sign_carrot_transaction_proposal(
+                tx_proposal, rerandomized_outputs, addr_dev, acc_keys.m_spend_secret_key);
+
+        for (const crypto::key_image &ki : sorted_input_key_images)
+        {
+            const auto sal_it = sal_proofs_by_ki.find(ki);
+            CHECK_AND_ASSERT_THROW_MES(sal_it != sal_proofs_by_ki.end(),
+                "missing SA/L proof");
+            CHECK_AND_ASSERT_THROW_MES(sal_it->second.size() == FCMP_PP_SAL_PROOF_SIZE_V1,
+                "unexpected SA/L proof size");
+            sal_proofs.push_back(std::move(sal_it->second));
+            sal_proofs_by_ki.erase(sal_it);
+        }
+    }
+
+    // sort rerandomized outputs in key image order
+    tools::apply_permutation(key_image_order, rerandomized_outputs);
+
+    return finalize_fcmps_and_range_proofs(sorted_input_key_images,
+        rerandomized_outputs,
+        sal_proofs,
+        output_enote_proposals,
+        encrypted_payment_id,
+        tx_proposal.fee,
+        tree_cache,
+        curve_trees);
+}
+//-------------------------------------------------------------------------------------------------------------------
 pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const std::vector<crypto::key_image> &sorted_input_key_images,
-    const wallet2_basic::transfer_container &transfers,
-    const crypto::secret_key &k_view,
-    hw::device &hwdev)
+    const carrot::view_incoming_key_device &k_view_incoming_dev)
 {
     const std::size_t n_inputs = tx_proposal.input_proposals.size();
     const std::size_t n_outputs = tx_proposal.normal_payment_proposals.size() +
@@ -1071,32 +1318,18 @@ pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_
 
     CARROT_CHECK_AND_THROW(n_inputs >= 1, carrot::too_few_inputs, "carrot tx proposal missing inputs");
     CARROT_CHECK_AND_THROW(n_outputs >= 2, carrot::too_few_outputs, "carrot tx proposal missing outputs");
-    CARROT_CHECK_AND_THROW(sorted_input_key_images.size() == tx_proposal.input_proposals.size(),
-        carrot::missing_components, "Wrong number of key images for this tx proposal");
+    CARROT_CHECK_AND_THROW(sorted_input_key_images.empty() || sorted_input_key_images.size() == n_inputs,
+        carrot::missing_components, "wrong number of key images for this tx proposal");
 
-    // collect non-burned transfers
-    const auto best_transfer_by_ota = collect_non_burned_transfers_by_onetime_address(transfers);
-
-    // collect selected_transfers and key_images string
-    std::vector<std::size_t> selected_transfers;
-    selected_transfers.reserve(n_inputs);
+    // collect key_images string
     std::stringstream key_images_string;
-    for (size_t i = 0; i < n_inputs; ++i)
+    for (std::size_t i = 0; i < sorted_input_key_images.size(); ++i)
     {
-        const crypto::public_key onetime_address = onetime_address_ref(tx_proposal.input_proposals.at(i));
-        const auto ota_it = best_transfer_by_ota.find(onetime_address);
-        CHECK_AND_ASSERT_THROW_MES(ota_it != best_transfer_by_ota.cend(),
-            "make_pending_carrot_tx: unrecognized key image in transfers list");
-        selected_transfers.push_back(ota_it->second);
+        const crypto::key_image &ki = sorted_input_key_images.at(i);
         if (i)
             key_images_string << ' ';
-        key_images_string << sorted_input_key_images.at(i);
+        key_images_string << ki;
     }
-
-    //! @TODO: HW device
-    carrot::view_incoming_key_ram_borrowed_device k_view_dev(k_view);
-
-    const crypto::key_image &tx_first_key_image = sorted_input_key_images.at(0);
 
     // calculate change_dst index based whether 2-out tx has a dummy output
     // change_dst is set to dummy in 2-out self-send, otherwise last self-send
@@ -1106,18 +1339,14 @@ pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_
     CHECK_AND_ASSERT_THROW_MES(!tx_proposal.selfsend_payment_proposals.empty(),
         "make_pending_carrot_tx: carrot tx proposal missing a self-send proposal");
 
-    // collect destinations and private tx keys for normal enotes
+    // collect destinations
     //! @TODO: payment proofs for special self-send, perhaps generate d_e deterministically
     cryptonote::tx_destination_entry change_dts;
     std::vector<cryptonote::tx_destination_entry> dests;
-    std::vector<crypto::secret_key> ephemeral_privkeys;
     dests.reserve(n_outputs);
-    ephemeral_privkeys.reserve(n_outputs);
     for (const carrot::CarrotPaymentProposalV1 &normal_payment_proposal : tx_proposal.normal_payment_proposals)
     {
         const cryptonote::tx_destination_entry dest = make_tx_destination_entry(normal_payment_proposal);
-        ephemeral_privkeys.push_back(carrot::get_enote_ephemeral_privkey(normal_payment_proposal,
-            carrot::make_carrot_input_context(tx_first_key_image)));
         if (has_2out_dummy)
             change_dts = dest;
         else
@@ -1127,28 +1356,45 @@ pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_
     {
         const carrot::CarrotPaymentProposalVerifiableSelfSendV1 &selfsend_payment_proposal
             = tx_proposal.selfsend_payment_proposals.at(i);
-        const cryptonote::tx_destination_entry dest = make_tx_destination_entry(selfsend_payment_proposal, k_view_dev);
-        if (!shared_ephemeral_pubkey)
-            ephemeral_privkeys.push_back(crypto::null_skey);
+        const cryptonote::tx_destination_entry dest
+            = make_tx_destination_entry(selfsend_payment_proposal, k_view_incoming_dev);
         if (!has_2out_dummy && i == tx_proposal.selfsend_payment_proposals.size() - 1)
             change_dts = dest;
         else
             dests.push_back(dest);
     }
 
-    // collect subaddr account and minor indices
-    const std::uint32_t subaddr_account = transfers.at(selected_transfers.at(0)).m_subaddr_index.major;
-    std::set<std::uint32_t> subaddr_indices;
-    for (const size_t selected_transfer : selected_transfers)
+    // private tx keys
+    std::vector<crypto::secret_key> ephemeral_privkeys;
+    if (sorted_input_key_images.empty())
     {
-        const wallet2_basic::transfer_details &td = transfers.at(selected_transfer);
-        const std::uint32_t other_subaddr_account = td.m_subaddr_index.major;
+        ephemeral_privkeys = {crypto::null_skey};
+    }
+    else
+    {
+        const crypto::key_image &tx_first_key_image = sorted_input_key_images.at(0);
+        std::vector<std::pair<bool, std::size_t>> enote_order;
+        carrot::get_sender_receiver_secrets_from_proposal_v1(tx_proposal.normal_payment_proposals,
+            tx_proposal.selfsend_payment_proposals,
+            /*s_view_balance_dev=*/nullptr,
+            &k_view_incoming_dev,
+            tx_first_key_image,
+            ephemeral_privkeys,
+            enote_order);
+    }
+
+    // collect subaddr account and minor indices
+    const std::uint32_t subaddr_account = subaddress_index_ref(tx_proposal.input_proposals.at(0)).index.major;
+    std::set<std::uint32_t> subaddr_indices;
+    for (const carrot::InputProposalV1 &input_proposal : tx_proposal.input_proposals)
+    {
+        const std::uint32_t other_subaddr_account = subaddress_index_ref(input_proposal).index.major;
         if (other_subaddr_account != subaddr_account)
         {
             MWARNING("make_pending_carrot_tx: conflicting account indices: " << subaddr_account << " vs "
                 << other_subaddr_account);
         }
-        subaddr_indices.insert(td.m_subaddr_index.minor);
+        subaddr_indices.insert(subaddress_index_ref(input_proposal).index.minor);
     }
 
     pending_tx ptx;
@@ -1157,7 +1403,6 @@ pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_
     ptx.fee = tx_proposal.fee;
     ptx.dust_added_to_fee = false;
     ptx.change_dts = change_dts;
-    ptx.selected_transfers = std::move(selected_transfers);
     ptx.key_images = key_images_string.str();
     ptx.tx_key = shared_ephemeral_pubkey && !ephemeral_privkeys.empty() ? ephemeral_privkeys.at(0) : crypto::null_skey;
     if (!shared_ephemeral_pubkey)
@@ -1171,42 +1416,8 @@ pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_
     return ptx;
 }
 //-------------------------------------------------------------------------------------------------------------------
-crypto::hash8 get_pending_tx_payment_id(const pending_tx &ptx)
-{
-    struct get_pending_tx_payment_id_visitor
-    {
-        crypto::hash8 operator()(const PreCarrotTransactionProposal &prop) const
-        {
-            std::vector<cryptonote::tx_extra_field> tx_extra_fields;
-            cryptonote::parse_tx_extra(prop.extra, tx_extra_fields);
-
-            cryptonote::tx_extra_nonce extra_nonce;
-            if (!cryptonote::find_tx_extra_field_by_type(tx_extra_fields, extra_nonce))
-                return crypto::null_hash8;
-
-            crypto::hash8 pid;
-            if (!cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce.nonce, pid))
-                return crypto::null_hash8;
-
-            return pid;
-        }
-
-        crypto::hash8 operator()(const carrot::CarrotTransactionProposalV1 &prop) const
-        {
-            for (const carrot::CarrotPaymentProposalV1 &normal_payment_proposal : prop.normal_payment_proposals)
-                if (normal_payment_proposal.destination.payment_id != carrot::null_payment_id)
-                    return carrot::raw_byte_convert<crypto::hash8>(normal_payment_proposal.destination.payment_id);
-
-            return crypto::null_hash8;
-        }
-    };
-
-    return std::visit(get_pending_tx_payment_id_visitor{}, ptx.construction_data);
-}
-//-------------------------------------------------------------------------------------------------------------------
-pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
+pending_tx finalize_all_fcmp_pp_proofs_as_pending_tx(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const wallet2_basic::transfer_container &transfers,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
     const cryptonote::account_keys &acc_keys)
@@ -1229,12 +1440,9 @@ pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
 
     pending_tx ptx = make_pending_carrot_tx(tx_proposal,
         sorted_input_key_images,
-        transfers,
-        acc_keys.m_view_secret_key,
-        acc_keys.get_device());
+        addr_dev);
 
-    ptx.tx = finalize_all_proofs_from_transfer_details(tx_proposal,
-        transfers,
+    ptx.tx = finalize_all_fcmp_pp_proofs(tx_proposal,
         tree_cache,
         curve_trees,
         acc_keys);

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -246,10 +246,10 @@ static carrot::InputCandidate make_input_candidate(const wallet2_basic::transfer
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
-std::vector<cryptonote::tx_destination_entry> finalized_destinations_ref(const tx_reconstruct_variant_t &v,
+std::vector<cryptonote::tx_destination_entry> finalized_destinations(const tx_reconstruct_variant_t &v,
     const carrot::view_incoming_key_device &k_view_dev)
 {
-    struct finalized_destinations_ref_visitor
+    struct finalized_destinations_visitor
     {
         std::vector<cryptonote::tx_destination_entry> operator()(const PreCarrotTransactionProposal &p) const
         {
@@ -269,13 +269,13 @@ std::vector<cryptonote::tx_destination_entry> finalized_destinations_ref(const t
 
         const carrot::view_incoming_key_device &k_view_dev;
     };
-    return std::visit(finalized_destinations_ref_visitor{k_view_dev}, v);
+    return std::visit(finalized_destinations_visitor{k_view_dev}, v);
 }
 //-------------------------------------------------------------------------------------------------------------------
-cryptonote::tx_destination_entry change_destination_ref(const tx_reconstruct_variant_t &v,
+cryptonote::tx_destination_entry change_destination(const tx_reconstruct_variant_t &v,
     const carrot::view_incoming_key_device &k_view_dev)
 {
-    struct change_destination_ref_visitor
+    struct change_destination_visitor
     {
         cryptonote::tx_destination_entry operator()(const PreCarrotTransactionProposal &p) const
         {
@@ -290,12 +290,12 @@ cryptonote::tx_destination_entry change_destination_ref(const tx_reconstruct_var
 
         const carrot::view_incoming_key_device &k_view_dev;
     };
-    return std::visit(change_destination_ref_visitor{k_view_dev}, v);
+    return std::visit(change_destination_visitor{k_view_dev}, v);
 }
 //-------------------------------------------------------------------------------------------------------------------
-rct::xmr_amount fee_ref(const tx_reconstruct_variant_t &v)
+rct::xmr_amount fee(const tx_reconstruct_variant_t &v)
 {
-    struct fee_ref_visitor
+    struct fee_visitor
     {
         rct::xmr_amount operator()(const PreCarrotTransactionProposal &p) const
         {
@@ -310,12 +310,12 @@ rct::xmr_amount fee_ref(const tx_reconstruct_variant_t &v)
             return p.fee;
         }
     };
-    return std::visit(fee_ref_visitor{}, v);
+    return std::visit(fee_visitor{}, v);
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::optional<crypto::hash8> short_payment_id_ref(const tx_reconstruct_variant_t &v)
+std::optional<crypto::hash8> short_payment_id(const tx_reconstruct_variant_t &v)
 {
-    struct short_payment_id_ref_visitor
+    struct short_payment_id_visitor
     {
         std::optional<crypto::hash8> operator()(const PreCarrotTransactionProposal &p) const
         {
@@ -339,10 +339,10 @@ std::optional<crypto::hash8> short_payment_id_ref(const tx_reconstruct_variant_t
             return std::nullopt;
         }
     };
-    return std::visit(short_payment_id_ref_visitor{}, v);
+    return std::visit(short_payment_id_visitor{}, v);
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::optional<crypto::hash> long_payment_id_ref(const tx_reconstruct_variant_t &v)
+std::optional<crypto::hash> long_payment_id(const tx_reconstruct_variant_t &v)
 {
     const PreCarrotTransactionProposal *p = std::get_if<PreCarrotTransactionProposal>(&v);
     if (nullptr == p)
@@ -359,9 +359,9 @@ std::optional<crypto::hash> long_payment_id_ref(const tx_reconstruct_variant_t &
     return pid32;
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::vector<crypto::public_key> spent_onetime_addresses_ref(const tx_reconstruct_variant_t &v)
+std::vector<crypto::public_key> spent_onetime_addresses(const tx_reconstruct_variant_t &v)
 {
-    struct spent_onetime_addresses_ref_visitor
+    struct spent_onetime_addresses_visitor
     {
         std::vector<crypto::public_key> operator()(const PreCarrotTransactionProposal &tcd) const
         {
@@ -382,12 +382,12 @@ std::vector<crypto::public_key> spent_onetime_addresses_ref(const tx_reconstruct
         }
     };
 
-    return std::visit(spent_onetime_addresses_ref_visitor{}, v);
+    return std::visit(spent_onetime_addresses_visitor{}, v);
 }
 //-------------------------------------------------------------------------------------------------------------------
-boost::multiprecision::uint128_t input_amount_total_ref(const tx_reconstruct_variant_t &v)
+boost::multiprecision::uint128_t input_amount_total(const tx_reconstruct_variant_t &v)
 {
-    struct input_amount_total_ref_visitor
+    struct input_amount_total_visitor
     {
         boost::multiprecision::uint128_t operator()(const PreCarrotTransactionProposal &p) const
         {
@@ -407,12 +407,12 @@ boost::multiprecision::uint128_t input_amount_total_ref(const tx_reconstruct_var
             return res;
         }
     };
-    return std::visit(input_amount_total_ref_visitor{}, v);
+    return std::visit(input_amount_total_visitor{}, v);
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::vector<std::uint64_t> ring_sizes_ref(const tx_reconstruct_variant_t &v)
+std::vector<std::uint64_t> ring_sizes(const tx_reconstruct_variant_t &v)
 {
-    struct ring_sizes_ref_visitor
+    struct ring_sizes_visitor
     {
         std::vector<std::uint64_t> operator()(const PreCarrotTransactionProposal &p) const
         {
@@ -428,10 +428,10 @@ std::vector<std::uint64_t> ring_sizes_ref(const tx_reconstruct_variant_t &v)
             return std::vector<std::uint64_t>(p.input_proposals.size());
         }
     };
-    return std::visit(ring_sizes_ref_visitor{}, v);
+    return std::visit(ring_sizes_visitor{}, v);
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::uint64_t unlock_time_ref(const tx_reconstruct_variant_t &v)
+std::uint64_t unlock_time(const tx_reconstruct_variant_t &v)
 {
     const PreCarrotTransactionProposal *p = std::get_if<PreCarrotTransactionProposal>(&v);
     return p ? p->unlock_time : 0;
@@ -836,10 +836,10 @@ std::vector<std::size_t> collect_selected_transfer_indices(const tx_reconstruct_
 {
     const auto best_transfer_by_ota = collect_non_burned_transfers_by_onetime_address(transfers);
 
-    const std::vector<crypto::public_key> spent_onetime_addresses = spent_onetime_addresses_ref(tx_construction_data);
+    const std::vector<crypto::public_key> spent_otas = spent_onetime_addresses(tx_construction_data);
     std::vector<std::size_t> selected_transfer_indices;
-    selected_transfer_indices.reserve(spent_onetime_addresses.size());
-    for (const crypto::public_key &spent_onetime_address : spent_onetime_addresses)
+    selected_transfer_indices.reserve(spent_otas.size());
+    for (const crypto::public_key &spent_onetime_address : spent_otas)
     {
         const auto ota_it = best_transfer_by_ota.find(spent_onetime_address);
         CARROT_CHECK_AND_THROW(ota_it != best_transfer_by_ota.cend(),
@@ -949,7 +949,7 @@ cryptonote::transaction finalize_fcmps_and_range_proofs(
     // collect FCMP paths
     std::vector<fcmp_pp::curve_trees::CurveTreesV1::Path> fcmp_paths;
     fcmp_paths.reserve(n_inputs);
-    for (const fcmp_pp::curve_trees::OutputPair input_pair : spent_input_pairs)
+    for (const fcmp_pp::curve_trees::OutputPair &input_pair : spent_input_pairs)
     {
         MDEBUG("Requesting FCMP path from tree cache for onetime address " << input_pair.output_pubkey);
         fcmp_pp::curve_trees::CurveTreesV1::Path &fcmp_path = fcmp_paths.emplace_back();

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -29,6 +29,7 @@
 #pragma once
 
 //local headers
+#include "carrot_impl/address_device.h"
 #include "carrot_impl/input_selection.h"
 #include "fee_priority.h"
 #include "fcmp_pp/tree_cache.h"
@@ -85,6 +86,36 @@ struct PreCarrotTransactionProposal
     uint8_t construction_flags;
 };
 
+/**
+ * brief: data to reconstruct any Monero transaction's "signable transaction hash" or "pre-MLSAG hash"
+ */
+using tx_reconstruct_variant_t = std::variant<
+        PreCarrotTransactionProposal,
+        carrot::CarrotTransactionProposalV1
+    >;
+/// destinations for finalized enote (AKA split and w/ change) [requires view-incoming key]
+std::vector<cryptonote::tx_destination_entry> finalized_destinations_ref(const tx_reconstruct_variant_t&,
+    const carrot::view_incoming_key_device &k_view_dev);
+/// change destination [requires view-incoming key]
+cryptonote::tx_destination_entry change_destination_ref(const tx_reconstruct_variant_t&,
+    const carrot::view_incoming_key_device &k_view_dev);
+/// fee
+rct::xmr_amount fee_ref(const tx_reconstruct_variant_t&);
+/// short payment ID (8 bytes, pre-encryption)
+std::optional<crypto::hash8> short_payment_id_ref(const tx_reconstruct_variant_t&);
+/// long payment ID (32 bytes)
+std::optional<crypto::hash> long_payment_id_ref(const tx_reconstruct_variant_t&);
+/// "true-spend" one-time addresses in inputs (in proposal order, not final tx order)
+std::vector<crypto::public_key> spent_onetime_addresses_ref(const tx_reconstruct_variant_t&);
+/// sum total of input amounts
+boost::multiprecision::uint128_t input_amount_total_ref(const tx_reconstruct_variant_t&);
+/// ring sizes (in proposal order, not final tx order)
+std::vector<std::uint64_t> ring_sizes_ref(const tx_reconstruct_variant_t&);
+/// unlock time
+std::uint64_t unlock_time_ref(const tx_reconstruct_variant_t&);
+/// extra tx fields (includes PIDs and enote ephemeral pubkeys in pre-Carrot ONLY)
+const std::vector<std::uint8_t> &extra_ref(const tx_reconstruct_variant_t&);
+
 // The convention for destinations is:
 // dests does not include change
 // splitted_dsts (in construction_data) does
@@ -104,15 +135,17 @@ struct pending_tx
     uint32_t subaddr_account;            // subaddress account of your wallet to be used in this transfer
     std::set<uint32_t> subaddr_indices;  // set of address indices used as inputs in this transfer
 
-    using tx_reconstruct_variant_t = std::variant<
-        PreCarrotTransactionProposal,
-        carrot::CarrotTransactionProposalV1
-        >;
     tx_reconstruct_variant_t construction_data;
 };
 
 /**
- * brief: collect_carrot_input_candidate_list - filter and convert wallet2 transfer contain into carrot input candidates
+ * brief: index transfers by OTA, including a burning bug filter
+ * param: transfers -
+ */
+std::unordered_map<crypto::public_key, size_t> collect_non_burned_transfers_by_onetime_address(
+    const wallet2_basic::transfer_container &transfers);
+/**
+ * brief: filter and convert wallet2 transfer contain into carrot input candidates
  * param: transfers - wallet2 incoming transfers list
  * param: from_subaddr_account - ignore transfers not addressed to this major account index
  * param: from_subaddr_indices - ignore transfers not addressed to one of these minor account indices, empty means all
@@ -128,7 +161,23 @@ std::vector<carrot::InputCandidate> collect_carrot_input_candidate_list(
     const rct::xmr_amount ignore_above,
     const rct::xmr_amount ignore_below,
     const std::uint64_t top_block_index);
-
+/**
+ * brief: create "transfer" style Carrot/FCMP++ transaction proposals
+ * param: transfers - transfers list to perform input selection from
+ * param: subaddress_map -
+ * param: dsts - list of (address, amount) payment outlays to fulfill
+ * param: fee_per_weight - ratio of pXMR / vB to set fee at
+ * param: extra - truly "extra" fields to be included in tx_extra, doesn't include ephemeral tx pubkeys or PIDs
+ * param: subaddr_account - the only account (AKA major) index for which input selection should pull inputs from
+ * param: subaddr_indices - if non-empty, the only minor indices for which input selection should pull inputs from
+ * param: ignore_above - if the enote's amount is greater than this amount, exclude it from input selection
+ * param: ignore_below - if the enote's amount is less than this amount, exclude it from input selection
+ * param: subtract_fee_from_outputs - indices into `dsts` which are "fee-subtractable"
+ * param: top_block_index - the block index of the current top block inside the blockchain
+ * return: list of carrot transaction proposals
+ *
+ * Transfer-style means that transactions are added until all payment outlays are fulfilled.
+ */
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_transfer(
     const wallet2_basic::transfer_container &transfers,
     const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
@@ -141,7 +190,21 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const rct::xmr_amount ignore_below,
     std::set<std::uint32_t> subtract_fee_from_outputs,
     const std::uint64_t top_block_index);
-
+/**
+ * brief: create "sweep-multiple" style Carrot/FCMP++ transaction proposals
+ * param: transfers - transfers list to perform input selection from
+ * param: subaddress_map -
+ * param: input_key_images - key images of inputs to spend
+ * param: address - public address for all destinations in txs
+ * param: is_subaddress - true iff `address` refers to a subaddress
+ * param: n_dests_per_tx - the min num of outputs to make per tx (if `address` isn't ours, a change output is included)
+ * param: fee_per_weight - ratio of pXMR / vB to set fee at
+ * param: extra - truly "extra" fields to be included in tx_extra, doesn't include ephemeral tx pubkeys or PIDs
+ * param: top_block_index - the block index of the current top block inside the blockchain
+ * return: list of carrot transaction proposals
+ *
+ * Sweep-multiple-style means that transactions are added until all inputs specified by index are spent.
+ */
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
     const wallet2_basic::transfer_container &transfers,
     const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
@@ -152,7 +215,23 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const rct::xmr_amount fee_per_weight,
     std::vector<uint8_t> extra,
     const std::uint64_t top_block_index);
-
+/**
+ * brief: create "sweep-all" style Carrot/FCMP++ transaction proposals
+ * param: transfers - transfers list to perform input selection from
+ * param: subaddress_map -
+ * param: only_below - if the enote's amount is greater than this amount, exclude it from input selection (unless 0)
+ * param: address - public address for all destinations in txs
+ * param: is_subaddress - true iff `address` refers to a subaddress
+ * param: n_dests_per_tx - the min num of outputs to make per tx (if `address` isn't ours, a change output is included)
+ * param: fee_per_weight - ratio of pXMR / vB to set fee at
+ * param: extra - truly "extra" fields to be included in tx_extra, doesn't include ephemeral tx pubkeys or PIDs
+ * param: subaddr_account - the only account (AKA major) index for which input selection should pull inputs from
+ * param: subaddr_indices - if non-empty, the only minor indices for which input selection should pull inputs from
+ * param: top_block_index - the block index of the current top block inside the blockchain
+ * return: list of carrot transaction proposals
+ *
+ * Sweep-all-style means that transactions are added until all inputs <= amount `only_below` are spent.
+ */
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep_all(
     const wallet2_basic::transfer_container &transfers,
     const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
@@ -165,34 +244,93 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const std::uint32_t subaddr_account,
     const std::set<uint32_t> &subaddr_indices,
     const std::uint64_t top_block_index);
-
+/**
+ * brief: convert a `wallet2_basic::transfer_details` into a output opening hint
+ * param: td -
+ * return: output opening hint
+ */
 carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(const wallet2_basic::transfer_details &td);
-
-std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_transaction_proposal_from_transfer_details(
+/**
+ * brief: get index into transfers list of spent enotes in a potential transaction
+ * param: tx_construction_data -
+ * param: transfers -
+ * return: list of spent input enotes indices in construction-specified order, not necessarily final transaction order
+ *
+ * WARNING: The indices returned assumes the best case scenario for burning bugs for pre-Carrot
+ * transactions. If the transfers list contains multiple pre-Carrot enotes with the same onetime
+ * address, this function returns the index of the best of the duplicates. If you do not trust the
+ * originating source of this construction data, then this is not safe. Validating the amounts
+ * actually line up with the best case, instead of trusting, would require tx_reconstruct_variant_t
+ * to store openings for the pseudo output amount commitments. This isn't an issue w/ spending
+ * Carrot enotes since Carrot mitigates the burning bug statelessly.
+ */
+std::vector<std::size_t> collect_selected_transfer_indices(const tx_reconstruct_variant_t &tx_construction_data,
+    const wallet2_basic::transfer_container &transfers);
+/**
+ * brief: sign all Carrot transaction proposal inputs given rerandomized outputs
+ * param: tx_proposal -
+ * param: rerandomized_outputs - rerandomized outputs in order of input proposals in `tx_proposal`
+ * param: addr_dev -
+ * param: k_spend - k_s
+ * return: valid SA/L proofs by key image
+ */
+std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_transaction_proposal(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
-    const wallet2_basic::transfer_container &transfers,
-    const cryptonote::account_keys &acc_keys);
-
-//! @TODO: accept already-calculated rerandomized outputs and their blinds
-cryptonote::transaction finalize_all_proofs_from_transfer_details(
+    const carrot::cryptonote_hierarchy_address_device &addr_dev,
+    const crypto::secret_key &k_spend);
+/**
+ * brief: finalize FCMPs and BP+ range proofs for output amounts for Carrot/FCMP++ txs
+ * param: sorted_input_key_images - key images in input order
+ * param: sorted_rerandomized_outputs - rerandomized outputs in key image order
+ * param: sorted_sal_proofs - SA/L proofs in key image order
+ * param: encrypted_payment_id - pid_enc
+ * param: fee -
+ * param: tree_cache - FCMP tree cache to draw enote paths from
+ * param: curve_trees -
+ */
+cryptonote::transaction finalize_fcmps_and_range_proofs(
+    const std::vector<crypto::key_image> &sorted_input_key_images,
+    const std::vector<FcmpRerandomizedOutputCompressed> &sorted_rerandomized_outputs,
+    const std::vector<fcmp_pp::FcmpPpSalProof> &sorted_sal_proofs,
+    const std::vector<carrot::RCTOutputEnoteProposal> &output_enote_proposals,
+    const carrot::encrypted_payment_id_t &encrypted_payment_id,
+    const rct::xmr_amount fee,
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees);
+/**
+ * brief: finalize FCMPs, BP+ range proofs for outputs amounts, and SA/L proofs for Carrot/FCMP++ txs
+ * param: tx_proposal -
+ * param: tree_cache - FCMP tree cache to draw enote paths from
+ * param: curve_trees -
+ * param: acc_keys -
+ * return: a fully proved FCMP++ transaction corresponding to the transaction proposal
+ */
+cryptonote::transaction finalize_all_fcmp_pp_proofs(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const wallet2_basic::transfer_container &transfers,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
     const cryptonote::account_keys &acc_keys);
-
+/**
+ * brief: fill out a `pending_tx` from a Carrot transaction proposal, excluding the transaction itself
+ * param: tx_proposal -
+ * param: sorted_input_key_images - key images in input order
+ * param: k_view_incoming_dev - k_v
+ * return: `pending_tx` representing the Carrot transaction proposal 
+ */
 pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const std::vector<crypto::key_image> &sorted_input_key_images,
-    const wallet2_basic::transfer_container &transfers,
-    const crypto::secret_key &k_view,
-    hw::device &hwdev);
-
-crypto::hash8 get_pending_tx_payment_id(const pending_tx &ptx);
-
-pending_tx finalize_all_proofs_from_transfer_details_as_pending_tx(
+    const carrot::view_incoming_key_device &k_view_incoming_dev);
+/**
+ * brief: finalize FCMPs, BP+ range proofs, and SA/Ls, proofs for Carrot/FCMP++ txs into a `pending_tx`
+ * param: tx_proposal -
+ * param: tree_cache - FCMP tree cache to draw enote paths from
+ * param: curve_trees -
+ * param: acc_keys -
+ * return: `pending_tx` representing the Carrot transaction proposal, including a fully proved FCMP++ transaction
+ */
+pending_tx finalize_all_fcmp_pp_proofs_as_pending_tx(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const wallet2_basic::transfer_container &transfers,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
     const cryptonote::account_keys &acc_keys);

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -87,32 +87,32 @@ struct PreCarrotTransactionProposal
 };
 
 /**
- * brief: data to reconstruct any Monero transaction's "signable transaction hash" or "pre-MLSAG hash"
+ * brief: data to reconstruct any non-coinbase Monero transaction's "signable transaction hash" or "pre-MLSAG hash"
  */
 using tx_reconstruct_variant_t = std::variant<
         PreCarrotTransactionProposal,
         carrot::CarrotTransactionProposalV1
     >;
 /// destinations for finalized enote (AKA split and w/ change) [requires view-incoming key]
-std::vector<cryptonote::tx_destination_entry> finalized_destinations_ref(const tx_reconstruct_variant_t&,
+std::vector<cryptonote::tx_destination_entry> finalized_destinations(const tx_reconstruct_variant_t&,
     const carrot::view_incoming_key_device &k_view_dev);
 /// change destination [requires view-incoming key]
-cryptonote::tx_destination_entry change_destination_ref(const tx_reconstruct_variant_t&,
+cryptonote::tx_destination_entry change_destination(const tx_reconstruct_variant_t&,
     const carrot::view_incoming_key_device &k_view_dev);
 /// fee
-rct::xmr_amount fee_ref(const tx_reconstruct_variant_t&);
+rct::xmr_amount fee(const tx_reconstruct_variant_t&);
 /// short payment ID (8 bytes, pre-encryption)
-std::optional<crypto::hash8> short_payment_id_ref(const tx_reconstruct_variant_t&);
+std::optional<crypto::hash8> short_payment_id(const tx_reconstruct_variant_t&);
 /// long payment ID (32 bytes)
-std::optional<crypto::hash> long_payment_id_ref(const tx_reconstruct_variant_t&);
+std::optional<crypto::hash> long_payment_id(const tx_reconstruct_variant_t&);
 /// "true-spend" one-time addresses in inputs (in proposal order, not final tx order)
-std::vector<crypto::public_key> spent_onetime_addresses_ref(const tx_reconstruct_variant_t&);
+std::vector<crypto::public_key> spent_onetime_addresses(const tx_reconstruct_variant_t&);
 /// sum total of input amounts
-boost::multiprecision::uint128_t input_amount_total_ref(const tx_reconstruct_variant_t&);
+boost::multiprecision::uint128_t input_amount_total(const tx_reconstruct_variant_t&);
 /// ring sizes (in proposal order, not final tx order)
-std::vector<std::uint64_t> ring_sizes_ref(const tx_reconstruct_variant_t&);
+std::vector<std::uint64_t> ring_sizes(const tx_reconstruct_variant_t&);
 /// unlock time
-std::uint64_t unlock_time_ref(const tx_reconstruct_variant_t&);
+std::uint64_t unlock_time(const tx_reconstruct_variant_t&);
 /// extra tx fields (includes PIDs and enote ephemeral pubkeys in pre-Carrot ONLY)
 const std::vector<std::uint8_t> &extra_ref(const tx_reconstruct_variant_t&);
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -7635,7 +7635,7 @@ void wallet2::commit_tx(pending_tx& ptx)
   uint64_t amount_in = 0;
   if (store_tx_info())
   {
-    const crypto::hash8 payment_id_8 = wallet::short_payment_id_ref(ptx.construction_data).value_or(crypto::null_hash8);
+    const crypto::hash8 payment_id_8 = wallet::short_payment_id(ptx.construction_data).value_or(crypto::null_hash8);
     memcpy(&payment_id, &payment_id_8, sizeof(crypto::hash8));
     dests = ptx.dests;
     for(size_t idx: ptx.selected_transfers)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -937,12 +937,13 @@ static tools::wallet::pending_tx finalize_all_proofs_from_transfer_details_as_pe
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const tools::wallet2 &w)
 {
-  return tools::wallet::finalize_all_proofs_from_transfer_details_as_pending_tx(
+  tools::wallet::pending_tx ptx = tools::wallet::finalize_all_fcmp_pp_proofs_as_pending_tx(
     tx_proposal,
-    get_transfers(w),
     w.get_tree_cache_ref(),
     w.get_curve_trees_ref(),
     w.get_account().get_keys());
+  ptx.selected_transfers = tools::wallet::collect_selected_transfer_indices(ptx.construction_data, get_transfers(w));
+  return ptx;
 }
 
 static const tools::wallet2::tx_construction_data &get_construction_data(const tools::wallet2::pending_tx &ptx)
@@ -7634,7 +7635,7 @@ void wallet2::commit_tx(pending_tx& ptx)
   uint64_t amount_in = 0;
   if (store_tx_info())
   {
-    const crypto::hash8 payment_id_8 = wallet::get_pending_tx_payment_id(ptx);
+    const crypto::hash8 payment_id_8 = wallet::short_payment_id_ref(ptx.construction_data).value_or(crypto::null_hash8);
     memcpy(&payment_id, &payment_id_8, sizeof(crypto::hash8));
     dests = ptx.dests;
     for(size_t idx: ptx.selected_transfers)

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -787,7 +787,6 @@ private:
      * param: address - public address for all destinations in txs
      * param: is_subaddress - true iff `address` refers to a subaddress
      * param: outputs - the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
-     * param: payment_id - short payment ID
      * param: unused_transfers_indices - indices into `m_transfers` of RingCT & validly-decomposed pre-RingCT inputs
      * param: unused_dust_indices - indices into `m_transfers` of non-validly-decomposed pre-RingCT inputs
      * param: fake_outs_count - the number of decoys per input, AKA "mixin"

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -407,8 +407,7 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
       n_synced_blocks - 1);
   CHECK_AND_ASSERT_MES(tx_proposals.size() == 1, false, "Expected 1 tx proposal");
 
-  rct_txes.back() = tools::wallet::finalize_all_proofs_from_transfer_details(tx_proposals.front(),
-      {wallet2_td},
+  rct_txes.back() = tools::wallet::finalize_all_fcmp_pp_proofs(tx_proposals.front(),
       tree_cache,
       *fcmp_pp::curve_trees::curve_trees_v1(),
       miner_account.get_keys());

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -792,8 +792,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
 
     // 7.
     LOG_PRINT_L2("Alice has something to prove");
-    tx = tools::wallet::finalize_all_proofs_from_transfer_details(tx_proposal,
-        alice.m_transfers,
+    tx = tools::wallet::finalize_all_fcmp_pp_proofs(tx_proposal,
         alice.m_tree_cache,
         *alice.m_curve_trees,
         alice_keys);


### PR DESCRIPTION
* info fetchers for `tx_reconstruct_variant_t`
* expose `collect_non_burned_transfers_by_onetime_address()`
* add `collect_selected_transfer_indices()`
* document and cleanup `sign_carrot_transaction_proposal()`
* finalize proofs in `finalize_all_proofs_from_transfer_details()` with transfer details
* `make_pending_carrot_tx()` without transfers list or `hw::device` needed
* remove `get_pending_tx_payment_id()` in favor in `short_payment_id_ref()` for tx construction data
* rename `finalize_all_proofs_from_transfer_details()`
* document all functions in `tx_builder.h`

Prereq for #52