### PR TITLE
Small additional v17 consensus requirements and refactorings

### DIFF
--- a/src/carrot_impl/format_utils.cpp
+++ b/src/carrot_impl/format_utils.cpp
@@ -117,7 +117,8 @@ static bool try_load_carrot_ephemeral_pubkeys_from_extra(const std::vector<crypt
 //-------------------------------------------------------------------------------------------------------------------
 bool is_carrot_transaction_v1(const cryptonote::transaction_prefix &tx_prefix)
 {
-    CARROT_CHECK_AND_THROW(tx_prefix.vout.size(), too_few_outputs, "transaction prefix contains no outputs");
+    if (tx_prefix.vout.empty())
+        return false;
     return tx_prefix.vout.at(0).target.type() == typeid(cryptonote::txout_to_carrot_v1);
 }
 //-------------------------------------------------------------------------------------------------------------------

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -1184,7 +1184,7 @@ namespace cryptonote
     const std::type_info &o_type = tx.vout.at(0).target.type();
     for (const auto &o: tx.vout)
     {
-      const std::type_info &cur_type = tx.vout.at(0).target.type();
+      const std::type_info &cur_type = o.target.type();
       CHECK_AND_ASSERT_MES(cur_type == o_type, false, "non-matching variant types: "
         << o_type.name() << " and " << cur_type.name() << ", "
         << "expected matching variant types in transaction id=" << get_transaction_hash(tx));

--- a/src/cryptonote_config.h
+++ b/src/cryptonote_config.h
@@ -200,6 +200,7 @@
 #define HF_VERSION_REJECT_UNLOCK_TIME           17
 #define HF_VERSION_REJECT_LARGE_EXTRA           17
 #define HF_VERSION_REJECT_UNMIXABLE_V1          17
+#define HF_VERSION_REJECT_MANY_MINER_OUTPUTS    17
 
 #define PER_KB_FEE_QUANTIZATION_DECIMALS        8
 #define CRYPTONOTE_SCALING_2021_FEE_ROUNDING_PLACES 2
@@ -219,6 +220,7 @@
 // https://libera.monerologs.net/no-wallet-left-behind/20250505#c523568-c523686
 #define FCMP_PLUS_PLUS_MAX_INPUTS               128
 #define FCMP_PLUS_PLUS_MAX_OUTPUTS              16
+#define FCMP_PLUS_PLUS_MAX_MINER_OUTPUTS        10000
 
 // Restricting n layers keeps the proof_len table size very small and portable
 // 12 layers means the tree can support over 100 quadrillion outputs

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1338,7 +1338,13 @@ bool Blockchain::prevalidate_miner_transaction(const block& b, uint64_t height, 
 
   // from v17, require tx.extra size be within limit
   if (hf_version >= HF_VERSION_REJECT_LARGE_EXTRA) {
-    CHECK_AND_ASSERT_MES(b.miner_tx.extra.size() <= MAX_TX_EXTRA_SIZE, "false", "miner transaction extra too big");
+    CHECK_AND_ASSERT_MES(b.miner_tx.extra.size() <= MAX_TX_EXTRA_SIZE, false, "miner transaction extra too big");
+  }
+
+  // from v17, require number of tx outputs to be within limit
+  if (hf_version >= HF_VERSION_REJECT_MANY_MINER_OUTPUTS) {
+    CHECK_AND_ASSERT_MES(b.miner_tx.vout.size() <= FCMP_PLUS_PLUS_MAX_MINER_OUTPUTS,
+      false, "too many miner transaction outputs");
   }
 
   return true;

--- a/src/cryptonote_core/tx_verification_utils.h
+++ b/src/cryptonote_core/tx_verification_utils.h
@@ -78,7 +78,17 @@ uint64_t get_transaction_weight_limit(uint8_t hf_version);
 /**
  * @brief Check whether transaction's output pubkeys are sorted in strictly increasing lexicographical order
  */
-bool are_transaction_output_pubkeys_sorted(const transaction_prefix &tx_prefix);
+bool are_transaction_output_pubkeys_sorted(const std::vector<tx_out> &vout);
+
+/**
+ * @brief Check whether transaction's output pubkeys are sorted, iff required by fork rule
+ * @param tx_prefix
+ * @param hf_version hard fork version
+ * @see are_transaction_output_pubkeys_sorted()
+ *
+ * Output pubkeys must be sorted after FCMP++ grace period or if a Carrot tx during FCMP++ grace period.
+ */
+bool check_transaction_output_pubkeys_order(const transaction_prefix &tx_prefix, std::uint8_t hf_version);
 
 /**
  * @brief Get the minimum allowed transaction version
@@ -189,6 +199,7 @@ bool batch_ver_fcmp_pp_consensus
  *     7. Passes ver_mixed_rct_semantics() [Uses batch RingCT verification when applicable]
  *     8. Check unlock time is 0 from hardfork v17
  *     9. Check extra size <= MAX_TX_EXTRA_SIZE from hardfork v17
+ *     10. Passes check_transaction_output_pubkeys_order()
  *
  * For pool_supplement input:
  * We assume the structure of the pool supplement is already correct: for each value entry, the


### PR DESCRIPTION
1. Ban >=v17 miner transactions from having non-Carrot output types
2. Ban >=v17 miner transactions from having large extra length
3. Ban >=v17 miner transactions from having more than 10,000 outputs
4. Simplify `check_output_types()`
5. Simplify output pubkey order checking
