### PR TITLE
crypto: fix generator reproduction

### DIFF
--- a/src/crypto/generators.cpp
+++ b/src/crypto/generators.cpp
@@ -69,13 +69,13 @@ constexpr public_key G = bytes_to<public_key>({ 0x58, 0x66, 0x66, 0x66, 0x66, 0x
 //pedersen commitment generator H: toPoint(cn_fast_hash(G))
 constexpr public_key H = bytes_to<public_key>({ 0x8b, 0x65, 0x59, 0x70, 0x15, 0x37, 0x99, 0xaf, 0x2a, 0xea, 0xdc, 0x9f, 0xf1,
     0xad, 0xd0, 0xea, 0x6c, 0x72, 0x51, 0xd5, 0x41, 0x54, 0xcf, 0xa9, 0x2c, 0x17, 0x3a, 0x0d, 0xd3, 0x9c, 0x1f, 0x94 });
-//FCMP++ generator T: keccak_to_pt(keccak("Monero Generator T"))
+//FCMP++ generator T: unbiased_hash_to_ec(keccak("Monero Generator T"))
 constexpr public_key T = bytes_to<public_key>({ 97, 183, 54, 206, 147, 182, 42, 61, 55, 120, 171, 32, 77, 168, 93, 59, 76,
   220, 7, 37, 15, 93, 167, 227, 223, 38, 41, 146, 129, 52, 213, 38 });
-//FCMP++ generator U: keccak_to_pt(keccak("Monero FCMP++ Generator U"))
+//FCMP++ generator U: unbiased_hash_to_ec(keccak("Monero FCMP++ Generator U"))
 constexpr public_key U = bytes_to<public_key>({ 80, 107, 35, 246, 214, 229, 48, 153, 122, 188, 172, 198, 253, 52, 119, 52,
   177, 76, 43, 215, 155, 234, 0, 238, 176, 72, 87, 232, 234, 221, 26, 138 });
-//FCMP++ generator V: keccak_to_pt(keccak("Monero FCMP++ Generator V"))
+//FCMP++ generator V: unbiased_hash_to_ec(keccak("Monero FCMP++ Generator V"))
 constexpr public_key V = bytes_to<public_key>({ 105, 53, 244, 19, 248, 49, 9, 19, 138, 122, 20, 180, 9, 85, 45, 59, 118,
   216, 143, 202, 129, 187, 89, 39, 233, 161, 225, 48, 205, 254, 41, 249 });
 static ge_p3 G_p3;
@@ -95,9 +95,9 @@ static std::once_flag init_gens_once_flag;
 //-------------------------------------------------------------------------------------------------------------------
 // hash-to-point: H_p(x) = unbiased_hash_to_ec(x)
 //-------------------------------------------------------------------------------------------------------------------
-static void hash_to_point(const std::string_view &x, crypto::ec_point &point_out)
+static void hash_to_point(const crypto::hash &x, crypto::ec_point &point_out)
 {
-    unbiased_hash_to_ec((const unsigned char *) x.data(), x.size(), point_out);
+    unbiased_hash_to_ec((const unsigned char*)x.data, sizeof(crypto::hash), point_out);
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
@@ -149,7 +149,7 @@ static public_key reproduce_generator_T()
     // T = H_p(keccak("Monero Generator T"))
     const std::string_view T_seed{"Monero Generator T"};
     public_key reproduced_T;
-    hash_to_point(T_seed, reproduced_T);
+    hash_to_point(cn_fast_hash(T_seed.data(), T_seed.size()), reproduced_T);
 
     return reproduced_T;
 }
@@ -160,7 +160,7 @@ static public_key reproduce_generator_U()
     // U = H_p(keccak("Monero FCMP++ Generator U"))
     const std::string_view U_seed{"Monero FCMP++ Generator U"};
     public_key reproduced_U;
-    hash_to_point(U_seed, reproduced_U);
+    hash_to_point(cn_fast_hash(U_seed.data(), U_seed.size()), reproduced_U);
 
     return reproduced_U;
 }
@@ -171,7 +171,7 @@ static public_key reproduce_generator_V()
     // V = H_p(keccak("Monero FCMP++ Generator V"))
     const std::string_view V_seed{"Monero FCMP++ Generator V"};
     public_key reproduced_V;
-    hash_to_point(V_seed, reproduced_V);
+    hash_to_point(cn_fast_hash(V_seed.data(), V_seed.size()), reproduced_V);
 
     return reproduced_V;
 }


### PR DESCRIPTION
Identified by u/DataHoarder in the stressnet matrix/IRC channel.

This fixes generator reproduction (matching [`monero-oxide`](https://github.com/monero-oxide/monero-oxide/blob/02c900c43f2988610907efd98cf84f248b24eead/monero-oxide/generators/src/lib.rs#L55-L65)) and fixes the asserts triggered in debug builds.

As u/DataHoarder points out, the Carrot spec should be updated too.

______

<D​ataHoarder> 13:45:08 doesn't this not do the keccak() part? https://github.com/seraphis-migration/monero/blob/74a254f8c215986042c40e6875a0f97bd6169a1e/src/crypto/generators.cpp#L147-L177
<D​ataHoarder> 13:46:11 hash_to_point -> unbiased_hash_to_ec -> blake2b_64(str)
<D​ataHoarder> 13:47:59 also matches fcmp++-alpha-stressnet
<D​ataHoarder> I added crypto::get_G_p3(); on main to execute the init_gens in debug mode
<D​ataHoarder> (void)reproduce_generator_T; assert(reproduce_generator_T() == T);
<D​ataHoarder> fails
<D​ataHoarder> (void)reproduce_generator_U; assert(reproduce_generator_U() == U);
<D​ataHoarder> fails
<D​ataHoarder> (void)reproduce_generator_V; assert(reproduce_generator_V() == V);
<D​ataHoarder> fails
<D​ataHoarder> they don't do the keccak operation
m-relay
<D​ataHoarder> this makes the points be reproducible https://irc.gammaspectra.live/7b829a0492d51fc6/0001-add-keccak-factor-to-hash_to_point-to-make-points-re.patch
<D​ataHoarder> then it's doing blake2b(keccak(x)) effectively (as H_p(x) is doing blake2b on input data, outputting 64 bytes)
<D​ataHoarder> this part should probably be in the reproduce_generator_T / reproduce_generator_U / reproduce_generator_V part
<D​ataHoarder> though T is different than specified on carrot documentation, there it uses biased_hash_to_ec(keccak("Monero Generator T")
<D​ataHoarder> while this code has T as unbiased_hash_to_ec(keccak("Monero Generator T"))
<D​ataHoarder> seems any code calling these methods in debug mode will probably bail out on an assert without fixing the reproduction once the fork occurs