### PR TITLE
Wallet API: persist first refresh restore height set by daemon

### DIFF
--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -2515,6 +2515,7 @@ bool WalletImpl::doInit(const string &daemon_address, const std::string &proxy_a
     if (isNewWallet() && daemonSynced()) {
         LOG_PRINT_L2(__FUNCTION__ << ":New Wallet - fast refresh until " << daemonBlockChainHeight());
         m_wallet->set_refresh_from_block_height(daemonBlockChainHeight());
+        m_wallet->rewrite(m_wallet->get_wallet_file(), m_password);
     }
 
     if (m_rebuildWalletCache)


### PR DESCRIPTION
Reported by @ComputeryPony in #129

### Context

1. The GUI wallet creates a new wallet without a functioning connection to the daemon, causing the initial restore height to be set higher than the chain height from [this offline estimate](https://github.com/monero-project/monero/blob/8e9ab9677f90492bca3c7555a246f2a8677bd570/src/wallet/wallet2.cpp#L5678).
2. Then the GUI initializes the wallet, establishes a connection to the daemon, and manually overrides the restore height using daemon height [here](https://github.com/monero-project/monero/blob/8e9ab9677f90492bca3c7555a246f2a8677bd570/src/wallet/api/wallet.cpp#L2509-L2517). The first refresh then works fine, restore height is set using daemon height, but this restore height isn't persisted to the keys file.
3. Next wallet open, the wallet tries to refresh from the restore height that *was* persisted to the keys file (the estimate that was higher than the daemon height from step 1). This triggers the `needs_rescan` error reported in #129.

### Solution

Persist the refresh height from step 2 to the keys file so that maintains.

I also don't like that the wallet is at any point using an estimate that could end up too high, that seems dangerous and error-prone...