### PR TITLE
Blockchain: scale coinbase extra limit by number of outputs

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1337,12 +1337,16 @@ bool Blockchain::prevalidate_miner_transaction(const block& b, uint64_t height, 
     false, "FCMP++ miner transaction has unsorted outputs in block " << get_block_hash(b));
 
   // from v17, require tx.extra size be within limit
-  if (hf_version >= HF_VERSION_REJECT_LARGE_EXTRA) {
-    CHECK_AND_ASSERT_MES(b.miner_tx.extra.size() <= MAX_TX_EXTRA_SIZE, false, "miner transaction extra too big");
+  if (hf_version >= HF_VERSION_REJECT_LARGE_EXTRA)
+  {
+    // Scale extra limit by number of outputs since Carrot requires 1 32-byte ephemeral pubkey per output (for Janus).
+    const std::size_t max_extra_size = MAX_TX_EXTRA_SIZE + b.miner_tx.vout.size() * 32;
+    CHECK_AND_ASSERT_MES(b.miner_tx.extra.size() < max_extra_size, false, "miner transaction extra too big");
   }
 
   // from v17, require number of tx outputs to be within limit
-  if (hf_version >= HF_VERSION_REJECT_MANY_MINER_OUTPUTS) {
+  if (hf_version >= HF_VERSION_REJECT_MANY_MINER_OUTPUTS)
+  {
     CHECK_AND_ASSERT_MES(b.miner_tx.vout.size() <= FCMP_PLUS_PLUS_MAX_MINER_OUTPUTS,
       false, "too many miner transaction outputs");
   }


### PR DESCRIPTION
The strict limit was preventing high-output p2pool from functioning in the stressnet.