### PR TITLE
wallet: only create output cache one time where needed

### DIFF
--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -1404,6 +1404,7 @@ private:
         const bool miner_tx,
         const bool pool,
         const bool double_spend_seen,
+        std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache,
         const bool ignore_callbacks = false);
     void process_new_scanned_transaction(
         const crypto::hash &txid,


### PR DESCRIPTION
Fixes https://github.com/seraphis-migration/monero/issues/151

Tested opening a newly created wallet, and tested opening @nahuhh's wallet that has a ton of outputs. Before this PR it takes the latter way longer to open. After this PR the wallets open in a comparable amount of time.