### PR TITLE
Daemon: bump fluffy block byte size limit, match new block

### DIFF
--- a/src/cryptonote_basic/connection_context.cpp
+++ b/src/cryptonote_basic/connection_context.cpp
@@ -60,7 +60,7 @@ namespace cryptonote
     case cryptonote::NOTIFY_RESPONSE_CHAIN_ENTRY::ID:
       return 1024 * 1024 * 4; // 4 MB
     case cryptonote::NOTIFY_NEW_FLUFFY_BLOCK::ID:
-      return 1024 * 1024 * 4; // 4 MB, but it does not includes transaction data
+      return 1024 * 1024 * 128; // 128 MB (max packet is a bit less than 100 MB though, fluffy blocks can be full)
     case cryptonote::NOTIFY_REQUEST_FLUFFY_MISSING_TX::ID:
       return 1024 * 1024; // 1 MB
     case cryptonote::NOTIFY_GET_TXPOOL_COMPLEMENT::ID:


### PR DESCRIPTION
The daemon might need the full fluffy block if it hasn't seen all txs, and 4mb may not be enough. This matches what the limit is/was for `NOTIFY_NEW_BLOCK`.