### PR TITLE
wallet2: synchronize refresh & tx construction

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10500,6 +10500,8 @@ static uint32_t get_count_above(const std::vector<wallet2::transfer_details> &tr
 // usable balance.
 std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs)
 {
+  boost::lock_guard refresh_lock(m_refresh_mutex);
+
   //ensure device is let in NONE mode in any case
   hw::device &hwdev = m_account.get_device();
   boost::unique_lock<hw::device> hwdev_lock (hwdev);
@@ -11289,6 +11291,8 @@ bool wallet2::sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, c
 
 std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices)
 {
+  boost::lock_guard refresh_lock(m_refresh_mutex);
+
   const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
   if (do_carrot_tx_construction)
   {
@@ -11383,6 +11387,8 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
 
 std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra)
 {
+  boost::lock_guard refresh_lock(m_refresh_mutex);
+
   const bool do_carrot_tx_construction = use_fork_rules(HF_VERSION_CARROT);
   if (do_carrot_tx_construction)
   {
@@ -11945,6 +11951,8 @@ std::vector<size_t> wallet2::select_available_mixable_outputs()
 //----------------------------------------------------------------------------------------------------
 std::vector<wallet2::pending_tx> wallet2::create_unmixable_sweep_transactions()
 {
+  boost::lock_guard refresh_lock(m_refresh_mutex);
+
   // From hard fork 1, we don't consider small amounts to be dust anymore
   const bool hf1_rules = use_fork_rules(2, 10); // first hard fork has version 2
   tx_dust_policy dust_policy(hf1_rules ? 0 : ::config::DEFAULT_DUST_THRESHOLD);

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -737,21 +737,7 @@ private:
      * Sweep-single-style means that 1 transaction is returned which spends the given key image
      */
     std::vector<wallet2::pending_tx> create_transactions_single(const crypto::key_image &ki, const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
-    /**
-     * brief: create_transactions_all: create "sweep-multiple" style txs (or tx proposals in hot/cold & multisig wallets)
-     * param: address - public address for all destinations in txs
-     * param: is_subaddress - true iff `address` refers to a subaddress
-     * param: outputs - the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
-     * param: unused_transfers_indices - indices into `m_transfers` of RingCT & validly-decomposed pre-RingCT inputs
-     * param: unused_dust_indices - indices into `m_transfers` of non-validly-decomposed pre-RingCT inputs
-     * param: fake_outs_count - the number of decoys per input, AKA "mixin"
-     * param: priority - fee priority level
-     * param: extra - any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
-     * return: list of "pending txs": structs which contain partially or fully formed txs and construction information
-     *
-     * Sweep-multiple-style means that transactions are added until all inputs specified by index are spent.
-     */
-    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
+
     bool sanity_check(const std::vector<wallet2::pending_tx> &ptx_vector, const std::vector<cryptonote::tx_destination_entry>& dsts, const unique_index_container& subtract_fee_from_outputs = {}) const;
     void cold_tx_aux_import(const std::vector<pending_tx>& ptx, const std::vector<std::string>& tx_device_aux);
     void cold_sign_tx(const std::vector<pending_tx>& ptx_vector, signed_tx_set &exported_txs, std::vector<cryptonote::address_parse_info> &dsts_info, std::vector<std::string> & tx_device_aux);
@@ -1432,6 +1418,21 @@ private:
     detached_blockchain_data detach_blockchain(uint64_t height,
       std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
     void handle_reorg(uint64_t height, std::map<std::pair<uint64_t, uint64_t>, size_t> &output_tracker_cache);
+   /**
+     * brief: create_transactions_all: create "sweep-multiple" style txs (or tx proposals in hot/cold & multisig wallets)
+     * param: address - public address for all destinations in txs
+     * param: is_subaddress - true iff `address` refers to a subaddress
+     * param: outputs - the minimum num of outputs to make per tx (if `address` isn't ours, a change output is included)
+     * param: unused_transfers_indices - indices into `m_transfers` of RingCT & validly-decomposed pre-RingCT inputs
+     * param: unused_dust_indices - indices into `m_transfers` of non-validly-decomposed pre-RingCT inputs
+     * param: fake_outs_count - the number of decoys per input, AKA "mixin"
+     * param: priority - fee priority level
+     * param: extra - any non-ephemeral-tx-pubkey tx.extra fields, including PIDs
+     * return: list of "pending txs": structs which contain partially or fully formed txs and construction information
+     *
+     * Sweep-multiple-style means that transactions are added until all inputs specified by index are spent.
+     */
+    std::vector<wallet2::pending_tx> create_transactions_from(const cryptonote::account_public_address &address, bool is_subaddress, const size_t outputs, std::vector<size_t> unused_transfers_indices, std::vector<size_t> unused_dust_indices, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra);
     bool clear();
     void clear_soft(bool keep_key_images=false);
     /*


### PR DESCRIPTION
This looks like the cause of #164, but regardless I figure this should be expected behavior. We don't want the wallet to be able to modify potential selected inputs while constructing a tx. There are other functions it would be valuable to grab this mutex for also, but starting here seems reasonable.

I also made `create_transactions_from` private since it's not used by external callers in the repo, and is called by the other tx creation functions. It's possible that other devs may want it exposed (@tobtoht @woodser), and we could use a recursive mutex instead.

Will open a stressnet PR if this looks good.