### PR TITLE
fcmp++ rust: ASAN support

### DIFF
--- a/src/fcmp_pp/fcmp_pp_rust/CMakeLists.txt
+++ b/src/fcmp_pp/fcmp_pp_rust/CMakeLists.txt
@@ -84,9 +84,16 @@ else()
 endif()
 
 set(RUST_TARGET "${RUST_ARCH}-${RUST_PLATFORM}${RUST_TOOLCHAIN}")
+message(STATUS "Using Rust target ${RUST_TARGET}")
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CARGO_CMD cargo build --target "${RUST_TARGET}")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  if(SANITIZE)
+    message(STATUS "Using Rust ASAN")
+    # Rust ASAN is an experimental feature included in nightly at time of writing
+    set(CARGO_CMD RUSTFLAGS=-Zsanitizer=address cargo +nightly build --target "${RUST_TARGET}")
+  else()
+    set(CARGO_CMD cargo build --target "${RUST_TARGET}")
+  endif()
   set(TARGET_DIR "debug")
 else ()
   set(CARGO_CMD cargo build --target "${RUST_TARGET}" --release)


### PR DESCRIPTION
https://doc.rust-lang.org/beta/unstable-book/compiler-flags/sanitizer.html

@vtnerd gave me the idea to do this by raising the point that Rust wouldn't support asan out of the box.

You can see if you add:

```rust
            let xs = [0, 1, 2, 3];
            let _y = unsafe { *xs.as_ptr().offset(4) };
```

to something like `point_to_cycle_scalar` in `lib.rs`, it'll abort and point out the out of bounds access. ASAN doesn't identify the issue without this PR's change.

Unfortunately (or fortunately) this didn't pick up any unexpected issues after running overnight that might explain #202 (just the usual smaller randomx memory leaks).