### PR TITLE
p2p: don't request pool complement untils synced [stressnet]

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2688,6 +2688,12 @@ skip:
   template<class t_core>
   bool t_cryptonote_protocol_handler<t_core>::check_txpool_complement()
   {
+    if (!is_synchronized())
+    {
+      MDEBUG("Not ready for txpool complement");
+      return true;
+    }
+
     m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool
     {
       if(context.m_state < cryptonote_connection_context::state_synchronizing)


### PR DESCRIPTION
There is no need to request the pool complement (#177) while syncing. This is likely exacerbating sync issues reported in the stressnet channel especially with a large pool.

This is only present on stressnet because I introduced this in #177. On the plus side, this pool complement logic did push me to narrow down the issue in #204 and #205, since it made the issue stick out.