### PR TITLE
remove dead seed

### DIFF
--- a/src/p2p/net_node.inl
+++ b/src/p2p/net_node.inl
@@ -732,7 +732,6 @@ namespace nodetool
     {
       full_addrs.insert("185.141.216.177:28180");
       full_addrs.insert("208.123.187.228:28080");
-      full_addrs.insert("185.141.216.147:28080");
     }
     else if (m_nettype == cryptonote::STAGENET)
     {


### PR DESCRIPTION
> I've shut down stressnet seed node 185.141.216.147 . I need to run a mainnet node on it. The machine doesn't have enough storage & RAM for both a stressnet node and a mainnet node. 208.123.187.228 , my other seed node, is still up.

from rucknium