### PR TITLE
carrot_impl: device overhaul

### DIFF
--- a/src/carrot_impl/CMakeLists.txt
+++ b/src/carrot_impl/CMakeLists.txt
@@ -35,6 +35,7 @@ set(carrot_impl_sources
   key_image_device_precomputed.cpp
   multi_tx_proposal_utils.cpp
   output_opening_types.cpp
+  spend_device_ram_borrowed.cpp
   tx_builder_inputs.cpp
   tx_builder_outputs.cpp
   tx_proposal_utils.cpp

--- a/src/carrot_impl/CMakeLists.txt
+++ b/src/carrot_impl/CMakeLists.txt
@@ -36,6 +36,7 @@ set(carrot_impl_sources
   multi_tx_proposal_utils.cpp
   output_opening_types.cpp
   spend_device_ram_borrowed.cpp
+  subaddress_map_legacy.cpp
   tx_builder_inputs.cpp
   tx_builder_outputs.cpp
   tx_proposal_utils.cpp

--- a/src/carrot_impl/CMakeLists.txt
+++ b/src/carrot_impl/CMakeLists.txt
@@ -27,6 +27,7 @@
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(carrot_impl_sources
+  address_device_hierarchies.cpp
   address_device_ram_borrowed.cpp
   address_utils.cpp
   format_utils.cpp

--- a/src/carrot_impl/address_device.h
+++ b/src/carrot_impl/address_device.h
@@ -42,64 +42,33 @@ namespace carrot
 {
 static constexpr const int E_UNSUPPORTED_ADDRESS_TYPE = 1;
 
-struct cryptonote_hierarchy_address_device: virtual public view_incoming_key_device
+struct address_device
 {
     /**
-     * brief: get_cryptonote_account_spend_pubkey - K_s
-     * return: K_s
+     * brief: get K^j_s given j
+     * param: subaddr_index - j
+     * outparam: address_spend_pubkey_out - K^j_s
      */
-    virtual crypto::public_key get_cryptonote_account_spend_pubkey() const = 0;
+    virtual void get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out) const = 0;
 
     /**
-     * brief: make_legacy_subaddress_extension - k^j_subext
-     *   k^j_subext = ScalarDeriveLegacy("SubAddr" || IntToBytes8(0) || k_v || IntToBytes32(j_major) || IntToBytes32(j_minor))
-     * param: major_index - j_major
-     * param: minor_index - j_minor
-     * outparam: legacy_subaddress_extension_out - k^j_subext
-     * throw: std::invalid_argument if major_index == minor_index == 0
+     * brief: get (K^j_s, K^j_v) given j
+     * param: subaddr_index - j
+     * outparam: address_spend_pubkey_out - K^j_s
+     * outparam: address_view_pubkey_out - K^j_v
      */
-    virtual void make_legacy_subaddress_extension(const std::uint32_t major_index,
-        const std::uint32_t minor_index,
-        crypto::secret_key &legacy_subaddress_extension_out) const = 0;
-};
-
-struct carrot_hierarchy_address_device: public generate_address_secret_device
-{
-    /**
-     * brief: get_carrot_account_spend_pubkey - K_s = K^0_s
-     * return: K_s = K^0_s
-     */
-    virtual crypto::public_key get_carrot_account_spend_pubkey() const = 0;
+    virtual void get_address_pubkeys(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out,
+        crypto::public_key &address_view_pubkey_out) const = 0;
 
     /**
-     * brief: get_carrot_account_view_pubkey - K_v
-     * return: K_v
+     * get (k^j_subext, k^j_subscalar) given j s.t. K^j_s = k^j_subscalar K_s + k^j_subext G
      */
-    virtual crypto::public_key get_carrot_account_view_pubkey() const = 0;
+    virtual void get_address_openings(const subaddress_index_extended &subaddr_index,
+        crypto::secret_key &address_extension_g_out,
+        crypto::secret_key &address_scalar_out) const = 0;
 
-    /**
-     * brief: get_carrot_main_address_view_pubkey - K^0_v
-     * return: K^0_v
-     */
-    virtual crypto::public_key get_carrot_main_address_view_pubkey() const = 0;
-};
-
-struct hybrid_hierarchy_address_device
-{
-    virtual bool supports_address_derivation_type(AddressDeriveType derive_type) const = 0;
-
-    virtual const cryptonote_hierarchy_address_device &access_cryptonote_hierarchy_device() const = 0;
-
-    virtual const carrot_hierarchy_address_device &access_carrot_hierarchy_device() const = 0;
-
-    virtual ~hybrid_hierarchy_address_device() = default;
-};
-
-struct interactive_address_device
-{
-    virtual void request_explicit_on_device_address_confirmation(
-        const subaddress_index_extended &index) = 0;
-
-    virtual ~interactive_address_device() = default;
+    virtual ~address_device() = default;
 };
 } //namespace carrot

--- a/src/carrot_impl/address_device_hierarchies.cpp
+++ b/src/carrot_impl/address_device_hierarchies.cpp
@@ -1,0 +1,345 @@
+// Copyright (c) 2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//paired header
+#include "address_device_hierarchies.h"
+
+//local headers
+#include "carrot_core/address_utils.h"
+#include "carrot_core/exceptions.h"
+extern "C"
+{
+#include "crypto/crypto-ops.h"
+}
+#include "misc_log_ex.h"
+
+//third party headers
+
+//standard headers
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "carrot_impl"
+
+namespace
+{
+static void assert_single_derive_type(const carrot::AddressDeriveType expected_derive_type,
+    const carrot::AddressDeriveType actual_derive_type,
+    const char * const dev_model,
+    const char * const func_called)
+{
+    const auto make_error = [dev_model, func_called](std::string msg)
+    {
+        return carrot::device_error(std::string("Default"),
+            std::string(dev_model),
+            std::string(func_called),
+            std::move(msg),
+            carrot::E_UNSUPPORTED_ADDRESS_TYPE);
+    };
+
+    if (actual_derive_type != expected_derive_type && actual_derive_type != carrot::AddressDeriveType::Auto)
+    {
+        CARROT_THROW(make_error, "Expected derive type " << static_cast<int>(expected_derive_type)
+            << ", got derive type " << static_cast<int>(actual_derive_type));
+    }
+}
+} //anonymous namespace
+
+namespace carrot
+{
+//-------------------------------------------------------------------------------------------------------------------
+cryptonote_hierarchy_address_device::cryptonote_hierarchy_address_device(
+    std::shared_ptr<cryptonote_view_incoming_key_device> k_view_incoming_dev,
+    const crypto::public_key &cryptonote_account_spend_pubkey)
+:
+    m_k_view_incoming_dev(std::move(k_view_incoming_dev)),
+    m_cryptonote_account_spend_pubkey(cryptonote_account_spend_pubkey)
+{
+    assert(this->m_k_view_incoming_dev);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void cryptonote_hierarchy_address_device::get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
+    crypto::public_key &address_spend_pubkey_out) const
+{
+    this->assert_derive_type(subaddr_index, "get_address_spend_pubkey");
+
+    if (!subaddr_index.index.is_subaddress())
+    {
+        address_spend_pubkey_out = this->m_cryptonote_account_spend_pubkey;
+        return;
+    }
+
+    // k^j_subext = ScalarDeriveLegacy("SubAddr" || IntToBytes8(0) || k_v || IntToBytes32(j_major) || IntToBytes32(j_minor))
+    crypto::secret_key k_subaddress_extension;
+    this->m_k_view_incoming_dev->make_legacy_subaddress_extension(subaddr_index.index.major,
+        subaddr_index.index.minor, k_subaddress_extension);
+
+    // K^j_subext = k^j_subext G
+    ge_p3 subaddress_extension_p3;
+    ge_scalarmult_base(&subaddress_extension_p3, to_bytes(k_subaddress_extension));
+
+    // decompress K_S
+    ge_p3 account_spend_pubkey_p3;
+    ge_frombytes_vartime(&account_spend_pubkey_p3, to_bytes(this->m_cryptonote_account_spend_pubkey)); // discard result
+    ge_cached account_spend_pubkey_cached;
+    ge_p3_to_cached(&account_spend_pubkey_cached, &account_spend_pubkey_p3);
+
+    // K^j_s = K_s + K^j_subext
+    ge_p1p1 address_spend_pubkey_p1p1;
+    ge_add(&address_spend_pubkey_p1p1, &subaddress_extension_p3, &account_spend_pubkey_cached);
+    ge_p2 address_spend_pubkey_p2;
+    ge_p1p1_to_p2(&address_spend_pubkey_p2, &address_spend_pubkey_p1p1);
+    ge_tobytes(to_bytes(address_spend_pubkey_out), &address_spend_pubkey_p2);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void cryptonote_hierarchy_address_device::get_address_pubkeys(const subaddress_index_extended &subaddr_index,
+    crypto::public_key &address_spend_pubkey_out,
+    crypto::public_key &address_view_pubkey_out) const
+{
+    this->assert_derive_type(subaddr_index, "get_address_pubkeys");
+    this->get_address_spend_pubkey(subaddr_index, address_spend_pubkey_out);
+    this->m_k_view_incoming_dev->view_key_scalar_mult_ed25519(address_spend_pubkey_out, address_view_pubkey_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void cryptonote_hierarchy_address_device::get_address_openings(const subaddress_index_extended &subaddr_index,
+    crypto::secret_key &address_extension_g_out,
+    crypto::secret_key &address_scalar_out) const
+{
+    this->assert_derive_type(subaddr_index, "get_address_openings");
+
+    if (subaddr_index.index.is_subaddress())
+    {
+        // k^j_subext = ScalarDeriveLegacy("SubAddr" || IntToBytes8(0) || k_v || IntToBytes32(j_major) || IntToBytes32(j_minor))
+        this->m_k_view_incoming_dev->make_legacy_subaddress_extension(subaddr_index.index.major,
+            subaddr_index.index.minor,
+            address_extension_g_out);
+    }
+    else // main address
+    {
+        // k^j_subext = 0
+        address_extension_g_out = crypto::null_skey;
+    }
+
+    // k^j_subscal = 1
+    address_scalar_out = crypto::secret_key{{1}};
+}
+//-------------------------------------------------------------------------------------------------------------------
+const cryptonote_view_incoming_key_device &cryptonote_hierarchy_address_device::get_view_incoming_key_device() const
+{
+    return *this->m_k_view_incoming_dev;
+}
+//-------------------------------------------------------------------------------------------------------------------
+void cryptonote_hierarchy_address_device::assert_derive_type(const subaddress_index_extended &subaddr_index,
+    const char * const func_called) const
+{
+    assert_single_derive_type(AddressDeriveType::PreCarrot, subaddr_index.derive_type,
+        "cryptonote_hierarchy_address_device", func_called);
+}
+//-------------------------------------------------------------------------------------------------------------------
+carrot_hierarchy_address_device::carrot_hierarchy_address_device(
+    std::shared_ptr<generate_address_secret_device> s_generate_address_dev,
+    const crypto::public_key &carrot_account_spend_pubkey,
+    const crypto::public_key &carrot_account_view_pubkey)
+:
+    m_s_generate_address_dev(std::move(s_generate_address_dev)),
+    m_carrot_account_spend_pubkey(carrot_account_spend_pubkey),
+    m_carrot_account_view_pubkey(carrot_account_view_pubkey)
+{
+    assert(this->m_s_generate_address_dev);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void carrot_hierarchy_address_device::get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
+    crypto::public_key &address_spend_pubkey_out) const
+{
+    this->assert_derive_type(subaddr_index, "get_address_spend_pubkey");
+
+    if (!subaddr_index.index.is_subaddress())
+    {
+        address_spend_pubkey_out = this->m_carrot_account_spend_pubkey;
+        return;
+    }
+
+    const crypto::secret_key subaddress_scalar = this->get_subaddress_scalar(subaddr_index.index);
+
+    // decompress K_s
+    ge_p3 account_spend_pubkey_p3;
+    ge_frombytes_vartime(&account_spend_pubkey_p3, to_bytes(this->m_carrot_account_spend_pubkey));
+
+    // K^j_s = k^j_subscal K_s
+    ge_p2 tmp_p2;
+    ge_scalarmult(&tmp_p2, to_bytes(subaddress_scalar), &account_spend_pubkey_p3);
+    ge_tobytes(to_bytes(address_spend_pubkey_out), &tmp_p2);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void carrot_hierarchy_address_device::get_address_pubkeys(const subaddress_index_extended &subaddr_index,
+    crypto::public_key &address_spend_pubkey_out,
+    crypto::public_key &address_view_pubkey_out) const
+{
+    this->assert_derive_type(subaddr_index, "get_address_pubkeys");
+
+    if (!subaddr_index.index.is_subaddress())
+    {
+        address_spend_pubkey_out = this->m_carrot_account_spend_pubkey;
+        return;
+    }
+
+    const crypto::secret_key subaddress_scalar = this->get_subaddress_scalar(subaddr_index.index);
+
+    // decompress K_s
+    ge_p3 tmp_p3;
+    ge_frombytes_vartime(&tmp_p3, to_bytes(this->m_carrot_account_spend_pubkey));
+
+    // K^j_s = k^j_subscal K_s
+    ge_p2 tmp_p2;
+    ge_scalarmult(&tmp_p2, to_bytes(subaddress_scalar), &tmp_p3);
+    ge_tobytes(to_bytes(address_spend_pubkey_out), &tmp_p2);
+
+    // decompress K_v
+    ge_frombytes_vartime(&tmp_p3, to_bytes(this->m_carrot_account_view_pubkey));
+
+    // K^j_v = k^j_subscal K_v
+    ge_scalarmult(&tmp_p2, to_bytes(subaddress_scalar), &tmp_p3);
+    ge_tobytes(to_bytes(address_view_pubkey_out), &tmp_p2);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void carrot_hierarchy_address_device::get_address_openings(const subaddress_index_extended &subaddr_index,
+    crypto::secret_key &address_extension_g_out,
+    crypto::secret_key &address_scalar_out) const
+{
+    this->assert_derive_type(subaddr_index, "get_address_openings");
+
+    // k^j_subext = 0
+    address_extension_g_out = crypto::null_skey;
+
+    // [main]       k^j_subscal = 1
+    // [subaddress] k^j_subscal = H_n[s^j_gen](K_s, K_v, j_major, j_minor)
+    address_scalar_out = this->get_subaddress_scalar(subaddr_index.index);
+}
+//-------------------------------------------------------------------------------------------------------------------
+crypto::secret_key carrot_hierarchy_address_device::get_subaddress_scalar(const subaddress_index &subaddr_index) const
+{
+    if (subaddr_index.is_subaddress())
+    {
+        // s^j_gen = H_32[s_ga](j_major, j_minor)
+        crypto::secret_key res;
+        this->m_s_generate_address_dev->make_index_extension_generator(subaddr_index.major,
+            subaddr_index.minor,
+            res);
+
+        // k^j_subscal = H_n[s^j_gen](K_s, K_v, j_major, j_minor)
+        make_carrot_subaddress_scalar(this->m_carrot_account_spend_pubkey,
+            this->m_carrot_account_view_pubkey,
+            res,
+            subaddr_index.major,
+            subaddr_index.minor,
+            res);
+
+        return res;
+    }
+    else // main address
+    {
+        // k^j_subscal = 1
+        return crypto::secret_key{{1}};
+    }
+}
+//-------------------------------------------------------------------------------------------------------------------
+void carrot_hierarchy_address_device::assert_derive_type(const subaddress_index_extended &subaddr_index,
+    const char * const func_called) const
+{
+    assert_single_derive_type(AddressDeriveType::Carrot, subaddr_index.derive_type,
+        "carrot_hierarchy_address_device", func_called);
+}
+//-------------------------------------------------------------------------------------------------------------------
+hybrid_hierarchy_address_device::hybrid_hierarchy_address_device(std::shared_ptr<address_device> carrot_addr_dev,
+    std::shared_ptr<address_device> cryptonote_addr_dev)
+:
+    m_carrot_addr_dev(std::move(carrot_addr_dev)),
+    m_cryptonote_addr_dev(std::move(cryptonote_addr_dev))
+{}
+//-------------------------------------------------------------------------------------------------------------------
+void hybrid_hierarchy_address_device::get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
+    crypto::public_key &address_spend_pubkey_out) const
+{
+    this->resolve_address_device(subaddr_index.derive_type, "get_address_spend_pubkey")
+        .get_address_spend_pubkey(subaddr_index, address_spend_pubkey_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void hybrid_hierarchy_address_device::get_address_pubkeys(const subaddress_index_extended &subaddr_index,
+    crypto::public_key &address_spend_pubkey_out,
+    crypto::public_key &address_view_pubkey_out) const
+{
+    this->resolve_address_device(subaddr_index.derive_type, "get_address_pubkeys")
+        .get_address_pubkeys(subaddr_index, address_spend_pubkey_out, address_view_pubkey_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void hybrid_hierarchy_address_device::get_address_openings(const subaddress_index_extended &subaddr_index,
+    crypto::secret_key &address_extension_g_out,
+    crypto::secret_key &address_scalar_out) const
+{
+    this->resolve_address_device(subaddr_index.derive_type, "get_address_openings")
+        .get_address_openings(subaddr_index, address_extension_g_out, address_scalar_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+const address_device& hybrid_hierarchy_address_device::resolve_address_device(const AddressDeriveType derive_type,
+    const char * const func_called) const
+{
+    const auto make_error = [func_called](std::string msg)
+    {
+        return carrot::device_error("Default",
+            "hybrid_hierarchy_address_device",
+            func_called,
+            std::move(msg),
+            E_UNSUPPORTED_ADDRESS_TYPE);
+    };
+
+    const address_device *p_resolved_addr_dev = nullptr;
+    switch (derive_type)
+    {
+    case AddressDeriveType::Auto:
+        if (this->m_carrot_addr_dev)
+            p_resolved_addr_dev = this->m_carrot_addr_dev.get();
+        else
+            p_resolved_addr_dev = this->m_cryptonote_addr_dev.get();
+        break;
+    case AddressDeriveType::PreCarrot:
+        p_resolved_addr_dev = this->m_cryptonote_addr_dev.get();
+        break;
+    case AddressDeriveType::Carrot:
+        p_resolved_addr_dev = this->m_carrot_addr_dev.get();
+        break;
+    default:
+        CARROT_THROW(make_error, "unrecognized derive type: " << static_cast<int>(derive_type));
+        break;
+    };
+
+    CARROT_CHECK_AND_THROW(p_resolved_addr_dev,
+        make_error, "Derive type not supported for this hybrid address device: " << static_cast<int>(derive_type));
+
+    return *p_resolved_addr_dev;
+}
+//-------------------------------------------------------------------------------------------------------------------
+} //namespace carrot

--- a/src/carrot_impl/address_device_hierarchies.cpp
+++ b/src/carrot_impl/address_device_hierarchies.cpp
@@ -148,9 +148,40 @@ void cryptonote_hierarchy_address_device::get_address_openings(const subaddress_
     address_scalar_out = crypto::secret_key{{1}};
 }
 //-------------------------------------------------------------------------------------------------------------------
-const cryptonote_view_incoming_key_device &cryptonote_hierarchy_address_device::get_view_incoming_key_device() const
+bool cryptonote_hierarchy_address_device::view_key_scalar_mult_ed25519(const crypto::public_key &P,
+    crypto::public_key &kvP) const
 {
-    return *this->m_k_view_incoming_dev;
+    return this->m_k_view_incoming_dev->view_key_scalar_mult_ed25519(P, kvP);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool cryptonote_hierarchy_address_device::view_key_scalar_mult8_ed25519(const crypto::public_key &P,
+    crypto::public_key &kv8P) const
+{
+    return this->m_k_view_incoming_dev->view_key_scalar_mult8_ed25519(P, kv8P);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool cryptonote_hierarchy_address_device::view_key_scalar_mult_x25519(const mx25519_pubkey &D,
+    mx25519_pubkey &kvD) const
+{
+    return this->view_key_scalar_mult_x25519(D, kvD);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void cryptonote_hierarchy_address_device::make_janus_anchor_special(const mx25519_pubkey &enote_ephemeral_pubkey,
+    const input_context_t &input_context,
+    const crypto::public_key &onetime_address,
+    janus_anchor_t &anchor_special_out) const
+{
+    return this->m_k_view_incoming_dev->make_janus_anchor_special(enote_ephemeral_pubkey, input_context,
+        onetime_address, anchor_special_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void cryptonote_hierarchy_address_device::make_legacy_subaddress_extension(
+    const std::uint32_t major_index,
+    const std::uint32_t minor_index,
+    crypto::secret_key &legacy_subaddress_extension_out) const
+{
+    return this->m_k_view_incoming_dev->make_legacy_subaddress_extension(major_index, minor_index,
+        legacy_subaddress_extension_out);
 }
 //-------------------------------------------------------------------------------------------------------------------
 void cryptonote_hierarchy_address_device::assert_derive_type(const subaddress_index_extended &subaddr_index,

--- a/src/carrot_impl/address_device_hierarchies.h
+++ b/src/carrot_impl/address_device_hierarchies.h
@@ -58,7 +58,7 @@ struct cryptonote_view_incoming_key_device: virtual public view_incoming_key_dev
 
 /// @brief takes a CN k_v device and K_s to derive addresses in Cryptonote style
 /// @note will fail if passed derive type is not ::PreCarrot or ::Auto
-class cryptonote_hierarchy_address_device: public address_device
+class cryptonote_hierarchy_address_device: public address_device, public cryptonote_view_incoming_key_device
 {
 public:
 //constructor
@@ -78,8 +78,22 @@ public:
         crypto::secret_key &address_extension_g_out,
         crypto::secret_key &address_scalar_out) const override;
 
-//member functions
-    const cryptonote_view_incoming_key_device &get_view_incoming_key_device() const;
+//cryptonote_view_incoming_key_device
+    bool view_key_scalar_mult_ed25519(const crypto::public_key &P, crypto::public_key &kvP) const override;
+
+    bool view_key_scalar_mult8_ed25519(const crypto::public_key &P, crypto::public_key &kv8P) const override;
+
+    bool view_key_scalar_mult_x25519(const mx25519_pubkey &D, mx25519_pubkey &kvD) const override;
+
+    void make_janus_anchor_special(const mx25519_pubkey &enote_ephemeral_pubkey,
+        const input_context_t &input_context,
+        const crypto::public_key &onetime_address,
+        janus_anchor_t &anchor_special_out) const override;
+
+    void make_legacy_subaddress_extension(
+        const std::uint32_t major_index,
+        const std::uint32_t minor_index,
+        crypto::secret_key &legacy_subaddress_extension_out) const override;
 
 protected:
 //member fields

--- a/src/carrot_impl/address_device_hierarchies.h
+++ b/src/carrot_impl/address_device_hierarchies.h
@@ -1,0 +1,163 @@
+// Copyright (c) 2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+#include "address_device.h"
+
+//third party headers
+
+//standard headers
+#include <memory>
+
+//forward declarations
+
+namespace carrot
+{
+/// @brief extends the k_v device to allow Cryptonote-style address derivation
+struct cryptonote_view_incoming_key_device: virtual public view_incoming_key_device
+{
+    /**
+     * brief: make_legacy_subaddress_extension - k^j_subext
+     *   k^j_subext = ScalarDeriveLegacy("SubAddr" || IntToBytes8(0) || k_v || IntToBytes32(j_major) || IntToBytes32(j_minor))
+     * param: major_index - j_major
+     * param: minor_index - j_minor
+     * outparam: legacy_subaddress_extension_out - k^j_subext
+     */
+    virtual void make_legacy_subaddress_extension(
+        const std::uint32_t major_index,
+        const std::uint32_t minor_index,
+        crypto::secret_key &legacy_subaddress_extension_out) const = 0;
+};
+
+/// @brief takes a CN k_v device and K_s to derive addresses in Cryptonote style
+/// @note will fail if passed derive type is not ::PreCarrot or ::Auto
+class cryptonote_hierarchy_address_device: public address_device
+{
+public:
+//constructor
+    cryptonote_hierarchy_address_device(
+        std::shared_ptr<cryptonote_view_incoming_key_device> k_view_incoming_dev,
+        const crypto::public_key &cryptonote_account_spend_pubkey);
+
+//address_device
+    void get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out) const override;
+
+    void get_address_pubkeys(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out,
+        crypto::public_key &address_view_pubkey_out) const override;
+
+    void get_address_openings(const subaddress_index_extended &subaddr_index,
+        crypto::secret_key &address_extension_g_out,
+        crypto::secret_key &address_scalar_out) const override;
+
+//member functions
+    const cryptonote_view_incoming_key_device &get_view_incoming_key_device() const;
+
+protected:
+//member fields
+    std::shared_ptr<cryptonote_view_incoming_key_device> m_k_view_incoming_dev;
+    crypto::public_key m_cryptonote_account_spend_pubkey;
+
+private:
+//member functions
+    void assert_derive_type(const subaddress_index_extended &subaddr_index,
+        const char * const func_called) const;
+};
+
+/// @brief takes a s_ga device and (K_s, K_v) to derive addresses in Carrot style
+/// @note will fail if passed derive type is not ::Carrot or ::Auto
+class carrot_hierarchy_address_device: public address_device
+{
+public:
+//constructor
+    carrot_hierarchy_address_device(
+        std::shared_ptr<generate_address_secret_device> s_generate_address_dev,
+        const crypto::public_key &carrot_account_spend_pubkey,
+        const crypto::public_key &carrot_account_view_pubkey);
+
+//address_device
+    void get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out) const override;
+
+    void get_address_pubkeys(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out,
+        crypto::public_key &address_view_pubkey_out) const override;
+
+    void get_address_openings(const subaddress_index_extended &subaddr_index,
+        crypto::secret_key &address_extension_g_out,
+        crypto::secret_key &address_scalar_out) const override;
+
+protected:
+//member fields
+    std::shared_ptr<generate_address_secret_device> m_s_generate_address_dev;
+    crypto::public_key m_carrot_account_spend_pubkey;
+    crypto::public_key m_carrot_account_view_pubkey;
+
+private:
+//member functions
+    crypto::secret_key get_subaddress_scalar(const subaddress_index &subaddr_index) const;
+
+    void assert_derive_type(const subaddress_index_extended &subaddr_index,
+        const char * const func_called) const;
+};
+
+/// @brief takes a CN and/or a Carrot address device and dispatches derivation according to the passed derive type
+/// @note resolves to Carrot on ::Auto derive type if available
+class hybrid_hierarchy_address_device: public address_device
+{
+public:
+//constructor
+    hybrid_hierarchy_address_device(std::shared_ptr<address_device> carrot_addr_dev,
+        std::shared_ptr<address_device> cryptonote_addr_dev);
+
+//address_device
+    void get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out) const override;
+
+    void get_address_pubkeys(const subaddress_index_extended &subaddr_index,
+        crypto::public_key &address_spend_pubkey_out,
+        crypto::public_key &address_view_pubkey_out) const override;
+
+    void get_address_openings(const subaddress_index_extended &subaddr_index,
+        crypto::secret_key &address_extension_g_out,
+        crypto::secret_key &address_scalar_out) const override;
+
+protected:
+//member fields
+    std::shared_ptr<address_device> m_carrot_addr_dev;
+    std::shared_ptr<address_device> m_cryptonote_addr_dev;
+
+private:
+//member functions
+    const address_device& resolve_address_device(const AddressDeriveType derive_type,
+        const char * const func_called) const;
+};
+} //namespace carrot

--- a/src/carrot_impl/address_device_ram_borrowed.cpp
+++ b/src/carrot_impl/address_device_ram_borrowed.cpp
@@ -31,7 +31,6 @@
 
 //local headers
 #include "address_utils.h"
-#include "carrot_core/address_utils.h"
 
 //third party headers
 
@@ -43,99 +42,21 @@
 namespace carrot
 {
 //-------------------------------------------------------------------------------------------------------------------
-void cryptonote_hierarchy_address_device_ram_borrowed::make_legacy_subaddress_extension(
+cryptonote_view_incoming_key_ram_borrowed_device::cryptonote_view_incoming_key_ram_borrowed_device(
+    const crypto::secret_key &k_view_incoming)
+:
+    view_incoming_key_ram_borrowed_device(k_view_incoming)
+{}
+//-------------------------------------------------------------------------------------------------------------------
+void cryptonote_view_incoming_key_ram_borrowed_device::make_legacy_subaddress_extension(
     const std::uint32_t major_index,
     const std::uint32_t minor_index,
     crypto::secret_key &legacy_subaddress_extension_out) const
 {
-    return carrot::make_legacy_subaddress_extension(m_k_view_incoming,
+    carrot::make_legacy_subaddress_extension(m_k_view_incoming,
         major_index,
         minor_index,
         legacy_subaddress_extension_out);
-}
-//-------------------------------------------------------------------------------------------------------------------
-carrot_hierarchy_address_device_ram_borrowed::carrot_hierarchy_address_device_ram_borrowed(
-        const crypto::public_key &account_spend_pubkey,
-        const crypto::public_key &account_view_pubkey,
-        const crypto::public_key &main_address_view_pubkey,
-        const crypto::secret_key &s_generate_address)
-    :
-        m_account_spend_pubkey(account_spend_pubkey),
-        m_account_view_pubkey(account_view_pubkey),
-        m_main_address_view_pubkey(main_address_view_pubkey),
-        m_s_generate_address(s_generate_address)
-{}
-//-------------------------------------------------------------------------------------------------------------------
-void carrot_hierarchy_address_device_ram_borrowed::make_index_extension_generator(const std::uint32_t major_index,
-    const std::uint32_t minor_index,
-    crypto::secret_key &address_generator_out) const
-{
-    make_carrot_index_extension_generator(m_s_generate_address, major_index, minor_index, address_generator_out);
-}
-//-------------------------------------------------------------------------------------------------------------------
-crypto::public_key carrot_hierarchy_address_device_ram_borrowed::get_carrot_account_spend_pubkey() const
-{
-    return m_account_spend_pubkey;
-}
-//-------------------------------------------------------------------------------------------------------------------
-crypto::public_key carrot_hierarchy_address_device_ram_borrowed::get_carrot_account_view_pubkey() const
-{
-    return m_account_view_pubkey;
-}
-//-------------------------------------------------------------------------------------------------------------------
-crypto::public_key carrot_hierarchy_address_device_ram_borrowed::get_carrot_main_address_view_pubkey() const
-{
-    return m_main_address_view_pubkey;
-}
-//-------------------------------------------------------------------------------------------------------------------
-hybrid_hierarchy_address_device_composed::hybrid_hierarchy_address_device_composed(
-        const cryptonote_hierarchy_address_device *cn_addr_dev,
-        const carrot_hierarchy_address_device *carrot_addr_dev)
-    :
-        m_cn_addr_dev(cn_addr_dev),
-        m_carrot_addr_dev(carrot_addr_dev)
-{}
-//-------------------------------------------------------------------------------------------------------------------
-bool hybrid_hierarchy_address_device_composed::supports_address_derivation_type(AddressDeriveType derive_type) const
-{
-    switch (derive_type)
-    {
-        case AddressDeriveType::PreCarrot:
-            return m_cn_addr_dev;
-        case AddressDeriveType::Carrot:
-            return m_carrot_addr_dev;
-        case AddressDeriveType::Auto:
-            return m_cn_addr_dev || m_carrot_addr_dev;
-        default:
-            throw device_error("Default",
-                "hybrid_hierarchy_address_device_composed",
-                "supports_address_derivation_type",
-                "unrecognized derive type", -1);
-    }
-}
-//-------------------------------------------------------------------------------------------------------------------
-const cryptonote_hierarchy_address_device &hybrid_hierarchy_address_device_composed::access_cryptonote_hierarchy_device() const
-{
-    if (!m_cn_addr_dev)
-    {
-        throw device_error("Default",
-            "hybrid_hierarchy_address_device_composed",
-            "access_cryptonote_hierarchy_device",
-            "cryptonote sub-device unavailable", -1);
-    }
-    return *m_cn_addr_dev;
-}
-//-------------------------------------------------------------------------------------------------------------------
-const carrot_hierarchy_address_device &hybrid_hierarchy_address_device_composed::access_carrot_hierarchy_device() const
-{
-    if (!m_carrot_addr_dev)
-    {
-        throw device_error("Default",
-            "hybrid_hierarchy_address_device_composed",
-            "access_carrot_hierarchy_device",
-            "carrot sub-device unavailable", -1);
-    }
-    return *m_carrot_addr_dev;
 }
 //-------------------------------------------------------------------------------------------------------------------
 } //namespace carrot

--- a/src/carrot_impl/address_device_ram_borrowed.h
+++ b/src/carrot_impl/address_device_ram_borrowed.h
@@ -29,7 +29,7 @@
 #pragma once
 
 //local headers
-#include "address_device.h"
+#include "address_device_hierarchies.h"
 #include "carrot_core/device_ram_borrowed.h"
 
 //third party headers
@@ -40,70 +40,16 @@
 
 namespace carrot
 {
-struct cryptonote_hierarchy_address_device_ram_borrowed:
-    public cryptonote_hierarchy_address_device,
-    public view_incoming_key_ram_borrowed_device
+class cryptonote_view_incoming_key_ram_borrowed_device:
+    virtual public cryptonote_view_incoming_key_device,
+    virtual public view_incoming_key_ram_borrowed_device
 {
-    cryptonote_hierarchy_address_device_ram_borrowed(
-        const crypto::public_key &cryptonote_account_spend_pubkey,
-        const crypto::secret_key &k_view_incoming):
-        view_incoming_key_ram_borrowed_device(k_view_incoming),
-        m_cryptonote_account_spend_pubkey(cryptonote_account_spend_pubkey)
-    {}
+public:
+    cryptonote_view_incoming_key_ram_borrowed_device(const crypto::secret_key &k_view_incoming);
 
-    crypto::public_key get_cryptonote_account_spend_pubkey() const override
-    {
-        return m_cryptonote_account_spend_pubkey;
-    }
-
-    void make_legacy_subaddress_extension(const std::uint32_t major_index,
+    void make_legacy_subaddress_extension(
+        const std::uint32_t major_index,
         const std::uint32_t minor_index,
         crypto::secret_key &legacy_subaddress_extension_out) const override;
-
-protected:
-    const crypto::public_key &m_cryptonote_account_spend_pubkey;
-};
-
-class carrot_hierarchy_address_device_ram_borrowed: public carrot_hierarchy_address_device
-{
-public:
-    carrot_hierarchy_address_device_ram_borrowed(
-        const crypto::public_key &account_spend_pubkey,
-        const crypto::public_key &account_view_pubkey,
-        const crypto::public_key &main_address_view_pubkey,
-        const crypto::secret_key &s_generate_address);
-
-    void make_index_extension_generator(const std::uint32_t major_index,
-        const std::uint32_t minor_index,
-        crypto::secret_key &address_generator_out) const override;
-
-    crypto::public_key get_carrot_account_spend_pubkey() const override;
-
-    crypto::public_key get_carrot_account_view_pubkey() const override;
-
-    crypto::public_key get_carrot_main_address_view_pubkey() const override;
-
-protected:
-    const crypto::public_key &m_account_spend_pubkey;
-    const crypto::public_key &m_account_view_pubkey;
-    const crypto::public_key &m_main_address_view_pubkey;
-    const crypto::secret_key &m_s_generate_address;
-};
-
-class hybrid_hierarchy_address_device_composed: public hybrid_hierarchy_address_device
-{
-public:
-    hybrid_hierarchy_address_device_composed(const cryptonote_hierarchy_address_device *cn_addr_dev,
-        const carrot_hierarchy_address_device *carrot_addr_dev);
-
-    bool supports_address_derivation_type(AddressDeriveType derive_type) const override;
-
-    const cryptonote_hierarchy_address_device &access_cryptonote_hierarchy_device() const override;
-
-    const carrot_hierarchy_address_device &access_carrot_hierarchy_device() const override;
-
-protected:
-    const cryptonote_hierarchy_address_device *m_cn_addr_dev;
-    const carrot_hierarchy_address_device *m_carrot_addr_dev;
 };
 } //namespace carrot

--- a/src/carrot_impl/address_utils.h
+++ b/src/carrot_impl/address_utils.h
@@ -40,8 +40,7 @@
 //forward declarations
 namespace carrot
 {
-struct cryptonote_hierarchy_address_device;
-struct hybrid_hierarchy_address_device;
+struct address_device;
 }
 
 namespace carrot
@@ -59,48 +58,15 @@ void make_legacy_subaddress_extension(const crypto::secret_key &k_view,
     const std::uint32_t minor_index,
     crypto::secret_key &legacy_subaddress_extension_out);
 /**
- * brief: make_legacy_subaddress_spend_pubkey - K^j_s
- *   K^j_s = K_s + k^j_subext G
- * param: legacy_subaddress_extension_out - k^j_subext
- * param: account_spend_pubkey - K_s
- * param: addr_dev -
- * param: major_index - j_major
- * param: minor_index - j_minor
- * outparam: legacy_subaddress_spend_pubkey_out - K^j_s
- */
-void make_legacy_subaddress_spend_pubkey(const crypto::secret_key &legacy_subaddress_extension,
-    const crypto::public_key &account_spend_pubkey,
-    crypto::public_key &legacy_subaddress_spend_pubkey_out);
-void make_legacy_subaddress_spend_pubkey(const cryptonote_hierarchy_address_device &addr_dev,
-    const std::uint32_t major_index,
-    const std::uint32_t minor_index,
-    crypto::public_key &legacy_subaddress_spend_pubkey_out);
-/**
- * brief: derive Cryptonote (K^j_s, K^j_v) given address device and j
- *   K^j_s = K_s + k^j_subext G
- *   K^j_v = k_v (G if j=0, else K^j_s)
- * param: addr_dev
- * param: major_index - j_major
- * param: minor_index - j_minor
- * param: account_spend_pubkey - K_s
- * outparam: legacy_subaddress_spend_pubkey_out - K^j_s
- * outparam: legacy_subaddress_view_pubkey_out - K^j_v
- */
-void make_legacy_subaddress_pubkeys(const cryptonote_hierarchy_address_device &addr_dev,
-    const std::uint32_t major_index,
-    const std::uint32_t minor_index,
-    crypto::public_key &legacy_subaddress_spend_pubkey_out,
-    crypto::public_key &legacy_subaddress_view_pubkey_out);
-/**
  * brief: get all supported main address spend pubkeys K_s from a hybrid address device
  * param: addr_dev -
  * outparam: main_address_spend_pubkeys_out -
  * return: number of supported pubkeys or span to supported main_address_spend_pubkeys_out
  */
 std::size_t get_all_main_address_spend_pubkeys(
-    const hybrid_hierarchy_address_device &addr_dev,
+    const address_device &addr_dev,
     crypto::public_key main_address_spend_pubkeys_out[2]);
 epee::span<const crypto::public_key> get_all_main_address_spend_pubkeys_span(
-    const hybrid_hierarchy_address_device &addr_dev,
+    const address_device &addr_dev,
     crypto::public_key main_address_spend_pubkeys_out[2]);
 } //namespace carrot

--- a/src/carrot_impl/key_image_device_composed.h
+++ b/src/carrot_impl/key_image_device_composed.h
@@ -35,6 +35,7 @@
 //third party headers
 
 //standard headers
+#include <memory>
 
 //forward declarations
 
@@ -43,10 +44,18 @@ namespace carrot
 class key_image_device_composed: public key_image_device
 {
 public:
-    key_image_device_composed(const generate_image_key_device &k_generate_image_dev,
-        const hybrid_hierarchy_address_device &addr_dev,
-        const view_balance_secret_device *s_view_balance_dev,
-        const view_incoming_key_device *k_view_incoming_dev);
+    /// @brief single-type derivation device
+    key_image_device_composed(std::shared_ptr<generate_image_key_device> k_generate_image_dev,
+        std::shared_ptr<address_device> addr_dev,
+        std::shared_ptr<view_balance_secret_device> s_view_balance_dev,
+        std::shared_ptr<view_incoming_key_device> k_view_incoming_dev);
+
+    /// @brief hybrid-type derivation device
+    key_image_device_composed(std::shared_ptr<generate_image_key_device> legacy_k_generate_image_dev,
+        std::shared_ptr<generate_image_key_device> carrot_k_generate_image_dev,
+        std::shared_ptr<address_device> addr_dev,
+        std::shared_ptr<view_balance_secret_device> s_view_balance_dev,
+        std::shared_ptr<view_incoming_key_device> k_view_incoming_dev);
 
     crypto::key_image derive_key_image(const OutputOpeningHintVariant &opening_hint) const override;
 
@@ -55,9 +64,10 @@ public:
         const subaddress_index_extended &subaddr_index) const override;
 
 protected:
-    const generate_image_key_device &m_k_generate_image_dev;
-    const hybrid_hierarchy_address_device &m_addr_dev;
-    const view_balance_secret_device *m_s_view_balance_dev;
-    const view_incoming_key_device *m_k_view_incoming_dev;
+    std::shared_ptr<generate_image_key_device> m_legacy_k_generate_image_dev;
+    std::shared_ptr<generate_image_key_device> m_carrot_k_generate_image_dev;
+    std::shared_ptr<address_device> m_addr_dev;
+    std::shared_ptr<view_balance_secret_device> m_s_view_balance_dev;
+    std::shared_ptr<view_incoming_key_device> m_k_view_incoming_dev;
 };
 } //namespace carrot

--- a/src/carrot_impl/spend_device.h
+++ b/src/carrot_impl/spend_device.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+#include "key_image_device.h"
+#include "tx_proposal.h"
+
+//third party headers
+
+//standard headers
+#include <map>
+
+//forward declarations
+
+namespace carrot
+{
+struct spend_device: public key_image_device
+{
+    // maps KI -> (OTA, SA/L) in consensus ordering
+    using signed_input_set_t = std::map<crypto::key_image,
+        std::pair<crypto::public_key, fcmp_pp::FcmpPpSalProof>,
+        std::greater<crypto::key_image>>;
+
+    virtual bool try_sign_carrot_transaction_proposal_v1(const CarrotTransactionProposalV1 &tx_proposal,
+        const std::unordered_map<crypto::public_key, FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
+        crypto::hash &signable_tx_hash_out,
+        signed_input_set_t &signed_inputs_out
+    ) const = 0;
+};
+} //namespace carrot

--- a/src/carrot_impl/spend_device_ram_borrowed.cpp
+++ b/src/carrot_impl/spend_device_ram_borrowed.cpp
@@ -1,0 +1,152 @@
+// Copyright (c) 2025, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//paired header
+#include "spend_device_ram_borrowed.h"
+
+//local headers
+#include "address_device_ram_borrowed.h"
+#include "carrot_core/device_ram_borrowed.h"
+#include "carrot_core/exceptions.h"
+#include "key_image_device_composed.h"
+#include "misc_log_ex.h"
+#include "tx_builder_inputs.h"
+#include "tx_builder_outputs.h"
+
+//third party headers
+
+//standard headers
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "carrot_impl"
+
+#define DEFINE_SUB_DEVICES()                                                                           \
+    /* K_s = k_s G*/                                                                                   \
+    crypto::public_key primary_spend_pubkey;                                                           \
+    crypto::secret_key_to_public_key(m_k_spend, primary_spend_pubkey);                                 \
+    /* devices */                                                                                      \
+    carrot::cryptonote_hierarchy_address_device_ram_borrowed addr_dev(primary_spend_pubkey, m_k_view); \
+    carrot::generate_image_key_ram_borrowed_device k_generate_image_dev(m_k_spend);                    \
+    carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);              \
+    carrot::key_image_device_composed key_image_dev(k_generate_image_dev, hybrid_addr_dev, nullptr, &addr_dev);
+
+namespace carrot
+{
+//-------------------------------------------------------------------------------------------------------------------
+spend_device_ram_borrowed_legacy::spend_device_ram_borrowed_legacy(
+    const crypto::secret_key &k_view,
+    const crypto::secret_key &k_spend)
+:
+    m_k_view(k_view),
+    m_k_spend(k_spend)
+{}
+//-------------------------------------------------------------------------------------------------------------------
+bool spend_device_ram_borrowed_legacy::try_sign_carrot_transaction_proposal_v1(
+    const CarrotTransactionProposalV1 &tx_proposal,
+    const std::unordered_map<crypto::public_key, FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
+    crypto::hash &signable_tx_hash_out,
+    signed_input_set_t &signed_inputs_out) const
+{
+    signable_tx_hash_out = crypto::null_hash;
+    signed_inputs_out.clear();
+
+    DEFINE_SUB_DEVICES()
+
+    // get sorted tx key images and insert into `signed_inputs_out`
+    std::vector<crypto::key_image> sorted_input_key_images;
+    std::vector<std::size_t> key_image_order;
+    carrot::get_sorted_input_key_images_from_proposal_v1(tx_proposal,
+        key_image_dev,
+        sorted_input_key_images,
+        &key_image_order);
+    for (std::size_t tx_input_idx = 0; tx_input_idx < sorted_input_key_images.size(); ++tx_input_idx)
+    {
+        const std::size_t input_proposal_idx = key_image_order.at(tx_input_idx);
+        const crypto::public_key ota = onetime_address_ref(tx_proposal.input_proposals.at(input_proposal_idx));
+        const crypto::key_image &ki = sorted_input_key_images.at(tx_input_idx);
+        signed_inputs_out[ki].first = ota;
+    }
+
+    // calculate signable tx hash
+    make_signable_tx_hash_from_proposal_v1(tx_proposal,
+        /*s_view_balance_dev=*/nullptr,
+        &addr_dev,
+        sorted_input_key_images,
+        signable_tx_hash_out);
+
+    // prove SA/L
+    for (auto &p : signed_inputs_out)
+    {
+        const crypto::public_key &onetime_address = p.second.first;
+
+        const auto input_proposal_it = std::find_if(tx_proposal.input_proposals.cbegin(),
+            tx_proposal.input_proposals.cend(),
+            [&onetime_address](const auto &ip) { return onetime_address_ref(ip) == onetime_address; });
+        CARROT_CHECK_AND_THROW(input_proposal_it != tx_proposal.input_proposals.cend(),
+            carrot::component_out_of_order,
+            "could not find input proposal for given one-time address");
+
+        const auto rerandomized_output_it = rerandomized_outputs.find(onetime_address);
+        CARROT_CHECK_AND_THROW(rerandomized_output_it != rerandomized_outputs.cend(),
+            carrot::component_out_of_order,
+            "could not find rerandomized output for given one-time address");
+
+        crypto::key_image ki;
+        carrot::make_sal_proof_any_to_legacy_v1(signable_tx_hash_out,
+            rerandomized_output_it->second,
+            *input_proposal_it,
+            m_k_spend,
+            addr_dev,
+            p.second.second,
+            ki);
+
+        CARROT_CHECK_AND_THROW(ki == p.first,
+            carrot::component_out_of_order, "key image mismatch during SA/L proving")
+    }
+
+    return true;
+}
+//-------------------------------------------------------------------------------------------------------------------
+crypto::key_image spend_device_ram_borrowed_legacy::derive_key_image(const OutputOpeningHintVariant &opening_hint) const
+{
+    DEFINE_SUB_DEVICES()
+
+    return key_image_dev.derive_key_image(opening_hint);
+}
+//-------------------------------------------------------------------------------------------------------------------
+crypto::key_image spend_device_ram_borrowed_legacy::derive_key_image_prescanned(
+    const crypto::secret_key &sender_extension_g,
+    const crypto::public_key &onetime_address,
+    const subaddress_index_extended &subaddr_index) const
+{
+    DEFINE_SUB_DEVICES()
+
+    return key_image_dev.derive_key_image_prescanned(sender_extension_g, onetime_address, subaddr_index);
+}
+//-------------------------------------------------------------------------------------------------------------------
+} //namespace carrot

--- a/src/carrot_impl/spend_device_ram_borrowed.h
+++ b/src/carrot_impl/spend_device_ram_borrowed.h
@@ -29,6 +29,7 @@
 #pragma once
 
 //local headers
+#include "address_device.h"
 #include "crypto/crypto.h"
 #include "spend_device.h"
 
@@ -40,11 +41,18 @@
 
 namespace carrot
 {
-class spend_device_ram_borrowed_legacy: public spend_device
+class spend_device_ram_borrowed: public spend_device
 {
 public:
-    spend_device_ram_borrowed_legacy(const crypto::secret_key &k_view,
-        const crypto::secret_key &k_spend);
+    /// @brief device composed (except k_s, k_ps, k_gi)
+    spend_device_ram_borrowed(std::shared_ptr<view_incoming_key_device> k_view_incoming_dev,
+        std::shared_ptr<view_balance_secret_device> s_view_balance_dev,
+        std::shared_ptr<address_device> address_dev,
+        const crypto::secret_key &privkey_g,
+        const crypto::secret_key &privkey_t);
+
+    /// @brief cryptonote-derived & ram borrowed from k_s, k_v
+    spend_device_ram_borrowed(const crypto::secret_key &k_spend, const crypto::secret_key &k_view);
 
     bool try_sign_carrot_transaction_proposal_v1(const CarrotTransactionProposalV1 &tx_proposal,
         const std::unordered_map<crypto::public_key, FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
@@ -58,8 +66,11 @@ public:
         const crypto::public_key &onetime_address,
         const subaddress_index_extended &subaddr_index) const;
 
-private:
-    const crypto::secret_key &m_k_view;
-    const crypto::secret_key &m_k_spend;
+protected:
+    std::shared_ptr<view_incoming_key_device> m_k_view_incoming_dev;
+    std::shared_ptr<view_balance_secret_device> m_s_view_balance_dev;
+    std::shared_ptr<address_device> m_address_dev;
+    const crypto::secret_key &m_privkey_g;
+    const crypto::secret_key &m_privkey_t;
 };
 } //namespace carrot

--- a/src/carrot_impl/spend_device_ram_borrowed.h
+++ b/src/carrot_impl/spend_device_ram_borrowed.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+#include "crypto/crypto.h"
+#include "spend_device.h"
+
+//third party headers
+
+//standard headers
+
+//forward declarations
+
+namespace carrot
+{
+class spend_device_ram_borrowed_legacy: public spend_device
+{
+public:
+    spend_device_ram_borrowed_legacy(const crypto::secret_key &k_view,
+        const crypto::secret_key &k_spend);
+
+    bool try_sign_carrot_transaction_proposal_v1(const CarrotTransactionProposalV1 &tx_proposal,
+        const std::unordered_map<crypto::public_key, FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
+        crypto::hash &signable_tx_hash_out,
+        signed_input_set_t &signed_inputs_out
+    ) const override;
+
+    crypto::key_image derive_key_image(const OutputOpeningHintVariant &opening_hint) const override;
+
+    crypto::key_image derive_key_image_prescanned(const crypto::secret_key &sender_extension_g,
+        const crypto::public_key &onetime_address,
+        const subaddress_index_extended &subaddr_index) const;
+
+private:
+    const crypto::secret_key &m_k_view;
+    const crypto::secret_key &m_k_spend;
+};
+} //namespace carrot

--- a/src/carrot_impl/subaddress_index.h
+++ b/src/carrot_impl/subaddress_index.h
@@ -29,6 +29,7 @@
 #pragma once
 
 //local headers
+#include "common/hash_combine.h"
 
 //third party headers
 
@@ -87,3 +88,39 @@ static inline bool operator!=(const subaddress_index_extended &a, const subaddre
     return !(a == b);
 }
 } //namespace carrot
+
+namespace std
+{
+template<>
+struct hash<carrot::subaddress_index>
+{
+    std::size_t operator()(const carrot::subaddress_index &i) const
+    {
+        std::size_t h = 0;
+        tools::hash_combine(h, i.major);
+        tools::hash_combine(h, i.minor);
+        return h;
+    }
+};
+
+template<>
+struct hash<carrot::AddressDeriveType>
+{
+    std::size_t operator()(const carrot::AddressDeriveType &a) const
+    {
+        return static_cast<std::size_t>(a);
+    }
+};
+
+template<>
+struct hash<carrot::subaddress_index_extended>
+{
+    std::size_t operator()(const carrot::subaddress_index_extended &i) const
+    {
+        std::size_t h = 0;
+        tools::hash_combine(h, i.index);
+        tools::hash_combine(h, i.derive_type);
+        return h;
+    }
+}; 
+}

--- a/src/carrot_impl/subaddress_map.h
+++ b/src/carrot_impl/subaddress_map.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+#include "crypto/crypto.h"
+#include "subaddress_index.h"
+
+//third party headers
+
+//standard headers
+#include <optional>
+
+//forward declarations
+
+namespace carrot
+{
+struct subaddress_map
+{
+    /**
+     * brief: Get the index and derivation type of an address given its spend pubkey
+     * param: address_spend_pubkey - K^j_s
+     * return: j for K^j_s, std::nullopt if unable
+     */
+    virtual std::optional<subaddress_index_extended> get_index_for_address_spend_pubkey(
+        const crypto::public_key &address_spend_pubkey) const = 0;
+
+    /**
+     * brief: Get the spend pubkey of an address given index and derivation type
+     * param: subaddr_index - j
+     * return: K^j_s for j, std::nullopt if unable
+     */
+    virtual std::optional<crypto::public_key> get_address_spend_pubkey_for_index(
+        const subaddress_index_extended &subaddr_index) const = 0;
+
+    virtual ~subaddress_map() = default;
+};
+} //namespace carrot

--- a/src/carrot_impl/subaddress_map_legacy.cpp
+++ b/src/carrot_impl/subaddress_map_legacy.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2025, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//paired header
+#include "subaddress_map_legacy.h"
+
+//local headers
+
+//third party headers
+
+//standard headers
+#include <algorithm>
+
+#undef MONERO_DEFAULT_LOG_CATEGORY
+#define MONERO_DEFAULT_LOG_CATEGORY "carrot_impl"
+
+namespace carrot
+{
+//-------------------------------------------------------------------------------------------------------------------
+subaddress_map_legacy::subaddress_map_legacy(
+    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map_legacy)
+:
+    m_subaddress_map_legacy(subaddress_map_legacy)
+{}
+//-------------------------------------------------------------------------------------------------------------------
+std::optional<subaddress_index_extended> subaddress_map_legacy::get_index_for_address_spend_pubkey(
+    const crypto::public_key &address_spend_pubkey) const
+{
+    const auto it = m_subaddress_map_legacy.find(address_spend_pubkey);
+    if (it == m_subaddress_map_legacy.cend())
+        return std::nullopt;
+    const cryptonote::subaddress_index &subaddr_index = it->second;
+    return subaddress_index_extended{
+        .index = subaddress_index{
+            .major = subaddr_index.major,
+            .minor = subaddr_index.minor
+        },
+        .derive_type = AddressDeriveType::PreCarrot
+    };
+}
+//-------------------------------------------------------------------------------------------------------------------
+std::optional<crypto::public_key> subaddress_map_legacy::get_address_spend_pubkey_for_index(
+    const subaddress_index_extended &subaddr_index) const
+{
+    if (subaddr_index.derive_type != AddressDeriveType::PreCarrot)
+        return std::nullopt;
+    const auto it = std::find_if(m_subaddress_map_legacy.cbegin(), m_subaddress_map_legacy.cend(),
+        [&subaddr_index](const std::pair<const crypto::public_key, cryptonote::subaddress_index> &e) {
+            return e.second.major == subaddr_index.index.major && e.second.minor == subaddr_index.index.minor;
+        }
+    );
+    if (it == m_subaddress_map_legacy.cend())
+        return std::nullopt;
+    return it->first;
+}
+//-------------------------------------------------------------------------------------------------------------------
+} //namespace carrot

--- a/src/carrot_impl/subaddress_map_legacy.h
+++ b/src/carrot_impl/subaddress_map_legacy.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2025, The Monero Project
+//
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+#include "cryptonote_basic/subaddress_index.h"
+#include "subaddress_map.h"
+
+//third party headers
+
+//standard headers
+#include <unordered_map>
+
+//forward declarations
+
+namespace carrot
+{
+class subaddress_map_legacy: public subaddress_map
+{
+public:
+    subaddress_map_legacy(
+        const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map_legacy);
+
+    std::optional<subaddress_index_extended> get_index_for_address_spend_pubkey(
+        const crypto::public_key &address_spend_pubkey) const override;
+
+    std::optional<crypto::public_key> get_address_spend_pubkey_for_index(
+        const subaddress_index_extended &subaddr_index) const override;
+
+private:
+    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &m_subaddress_map_legacy;
+};
+} //namespace carrot

--- a/src/carrot_impl/tx_builder_inputs.cpp
+++ b/src/carrot_impl/tx_builder_inputs.cpp
@@ -204,7 +204,7 @@ void make_sal_proof_any_to_legacy_v1(const crypto::hash &signable_tx_hash,
         crypto::null_skey,
         opening_hint,
         {&main_address_spend_pubkey, 1},
-        &addr_dev.get_view_incoming_key_device(),
+        &addr_dev,
         /*s_view_balance_dev=*/nullptr,
         sal_proof_out,
         key_image_out);

--- a/src/carrot_impl/tx_builder_inputs.cpp
+++ b/src/carrot_impl/tx_builder_inputs.cpp
@@ -35,6 +35,7 @@
 #include "carrot_core/config.h"
 #include "carrot_core/enote_utils.h"
 #include "carrot_core/scan.h"
+#include "carrot_impl/address_utils.h"
 #include "crypto/generators.h"
 #include "fcmp_pp/prove.h"
 #include "misc_log_ex.h"
@@ -185,13 +186,14 @@ void make_sal_proof_any_to_legacy_v1(const crypto::hash &signable_tx_hash,
     crypto::key_image &key_image_out)
 {
     // get K_s
-    const crypto::public_key main_address_spend_pubkey = addr_dev.get_cryptonote_account_spend_pubkey();
+    crypto::public_key main_address_spend_pubkey;
+    addr_dev.get_address_spend_pubkey({}, main_address_spend_pubkey);
 
     // k^j_subext = ScalarDeriveLegacy("SubAddr" || IntToBytes8(0) || k_v || IntToBytes32(j_major) || IntToBytes32(j_minor))
     const subaddress_index_extended subaddr_index = subaddress_index_ref(opening_hint);
     crypto::secret_key address_privkey_g;
-    addr_dev.make_legacy_subaddress_extension(subaddr_index.index.major,
-        subaddr_index.index.minor, address_privkey_g);
+    crypto::secret_key dummy_subaddress_scalar;
+    addr_dev.get_address_openings(subaddr_index, address_privkey_g, dummy_subaddress_scalar);
 
     // k^j_g = k^j_subext + k_s
     sc_add(to_bytes(address_privkey_g), to_bytes(address_privkey_g), to_bytes(k_spend));
@@ -202,7 +204,7 @@ void make_sal_proof_any_to_legacy_v1(const crypto::hash &signable_tx_hash,
         crypto::null_skey,
         opening_hint,
         {&main_address_spend_pubkey, 1},
-        &addr_dev,
+        &addr_dev.get_view_incoming_key_device(),
         /*s_view_balance_dev=*/nullptr,
         sal_proof_out,
         key_image_out);
@@ -266,6 +268,43 @@ void make_sal_proof_any_to_carrot_v1(const crypto::hash &signable_tx_hash,
         {&main_address_spend_pubkey, 1},
         &k_view_incoming_dev,
         &s_view_balance_dev,
+        sal_proof_out,
+        key_image_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+void make_sal_proof_any_to_hybrid_v1(const crypto::hash &signable_tx_hash,
+    const FcmpRerandomizedOutputCompressed &rerandomized_output,
+    const OutputOpeningHintVariant &opening_hint,
+    const crypto::secret_key &k_privkey_g,
+    const crypto::secret_key &k_privkey_t,
+    const view_balance_secret_device *s_view_balance_dev,
+    const view_incoming_key_device &k_view_incoming_dev,
+    const address_device &addr_dev,
+    fcmp_pp::FcmpPpSalProof &sal_proof_out,
+    crypto::key_image &key_image_out)
+{
+    crypto::secret_key subaddress_extention_g;
+    crypto::secret_key subaddress_scalar;
+    addr_dev.get_address_openings(subaddress_index_ref(opening_hint), subaddress_extention_g, subaddress_scalar);
+
+    // k^j_g = k_g * k^j_subscal + k^j_subext
+    crypto::secret_key address_privkey_g;
+    sc_muladd(to_bytes(address_privkey_g), to_bytes(k_privkey_g),
+        to_bytes(subaddress_scalar), to_bytes(subaddress_extention_g));
+
+    // k^j_t = k_t * k^j_subscal
+    crypto::secret_key address_privkey_t;
+    sc_mul(to_bytes(address_privkey_t), to_bytes(k_privkey_t), to_bytes(subaddress_scalar));
+
+    crypto::public_key main_address_spend_pubkeys[2];
+    make_sal_proof_nominal_address(signable_tx_hash,
+        rerandomized_output,
+        address_privkey_g,
+        address_privkey_t,
+        opening_hint,
+        get_all_main_address_spend_pubkeys_span(addr_dev, main_address_spend_pubkeys),
+        &k_view_incoming_dev,
+        s_view_balance_dev,
         sal_proof_out,
         key_image_out);
 }

--- a/src/carrot_impl/tx_builder_inputs.h
+++ b/src/carrot_impl/tx_builder_inputs.h
@@ -29,7 +29,7 @@
 #pragma once
 
 //local headers
-#include "address_device.h"
+#include "address_device_hierarchies.h"
 #include "carrot_core/carrot_enote_types.h"
 #include "fcmp_pp/curve_trees.h"
 #include "output_opening_types.h"
@@ -64,7 +64,7 @@ void make_sal_proof_any_to_legacy_v1(const crypto::hash &signable_tx_hash,
     fcmp_pp::FcmpPpSalProof &sal_proof_out,
     crypto::key_image &key_image_out);
 
-// spend any carrot enote addressed to a carrot address
+// spend any enote addressed to a carrot address
 void make_sal_proof_any_to_carrot_v1(const crypto::hash &signable_tx_hash,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
     const OutputOpeningHintVariant &opening_hint,
@@ -73,6 +73,18 @@ void make_sal_proof_any_to_carrot_v1(const crypto::hash &signable_tx_hash,
     const view_balance_secret_device &s_view_balance_dev,
     const view_incoming_key_device &k_view_incoming_dev,
     const generate_address_secret_device &s_generate_address_dev,
+    fcmp_pp::FcmpPpSalProof &sal_proof_out,
+    crypto::key_image &key_image_out);
+
+// spend any enote addressed to a carrot or legacy address
+void make_sal_proof_any_to_hybrid_v1(const crypto::hash &signable_tx_hash,
+    const FcmpRerandomizedOutputCompressed &rerandomized_output,
+    const OutputOpeningHintVariant &opening_hint,
+    const crypto::secret_key &k_privkey_g,
+    const crypto::secret_key &k_privkey_t,
+    const view_balance_secret_device *s_view_balance_dev,
+    const view_incoming_key_device &k_view_incoming_dev,
+    const address_device &addr_dev,
     fcmp_pp::FcmpPpSalProof &sal_proof_out,
     crypto::key_image &key_image_out);
 

--- a/src/common/hash_combine.h
+++ b/src/common/hash_combine.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2025, The Monero Project
+// 
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+//local headers
+
+//third party headers
+
+//standard headers
+#include <functional>
+
+//forward declarations
+
+namespace tools
+{
+template <typename T>
+void hash_combine(std::size_t &seed, T const& v)
+{
+    // see boost::hash_combine()
+    seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+} //namespace tools

--- a/src/wallet/hot_cold.cpp
+++ b/src/wallet/hot_cold.cpp
@@ -129,7 +129,7 @@ exported_carrot_transfer_details export_cold_carrot_output(const wallet2_basic::
     // 4. s_sr = k_v D_e
     const mx25519_pubkey &enote_ephemeral_pubkey = enote_ephemeral_pubkeys.at(ephemeral_pubkey_idx);
     mx25519_pubkey s_sender_receiver_unctx;
-    carrot::make_carrot_uncontextualized_shared_key_receiver(addr_dev.get_view_incoming_key_device(),
+    carrot::make_carrot_uncontextualized_shared_key_receiver(addr_dev,
         enote_ephemeral_pubkey,
         s_sender_receiver_unctx);
 
@@ -165,7 +165,7 @@ exported_carrot_transfer_details export_cold_carrot_output(const wallet2_basic::
         const bool is_special = carrot::verify_carrot_special_janus_protection(etd.tx_first_key_image,
             enote_ephemeral_pubkey,
             onetime_address,
-            addr_dev.get_view_incoming_key_device(),
+            addr_dev,
             etd.janus_anchor);
         if (is_special)
         {
@@ -442,7 +442,7 @@ wallet2_basic::transfer_details import_cold_carrot_output(const exported_carrot_
     //! @TODO: carrot hierarchy
     std::shared_ptr<carrot::cryptonote_view_incoming_key_device> k_view_incoming_dev(
         new carrot::cryptonote_view_incoming_key_ram_borrowed_device(acc_keys.m_view_secret_key));
-    std::shared_ptr<carrot::address_device> addr_dev(
+    std::shared_ptr<carrot::cryptonote_hierarchy_address_device> addr_dev(
         new carrot::cryptonote_hierarchy_address_device(k_view_incoming_dev, acc_keys.m_account_address.m_spend_public_key));
     std::shared_ptr<carrot::generate_image_key_device> legacy_spend_image_dev(
         new carrot::generate_image_key_ram_borrowed_device(acc_keys.m_spend_secret_key));

--- a/src/wallet/hot_cold.cpp
+++ b/src/wallet/hot_cold.cpp
@@ -129,7 +129,7 @@ exported_carrot_transfer_details export_cold_carrot_output(const wallet2_basic::
     // 4. s_sr = k_v D_e
     const mx25519_pubkey &enote_ephemeral_pubkey = enote_ephemeral_pubkeys.at(ephemeral_pubkey_idx);
     mx25519_pubkey s_sender_receiver_unctx;
-    carrot::make_carrot_uncontextualized_shared_key_receiver(addr_dev,
+    carrot::make_carrot_uncontextualized_shared_key_receiver(addr_dev.get_view_incoming_key_device(),
         enote_ephemeral_pubkey,
         s_sender_receiver_unctx);
 
@@ -165,7 +165,7 @@ exported_carrot_transfer_details export_cold_carrot_output(const wallet2_basic::
         const bool is_special = carrot::verify_carrot_special_janus_protection(etd.tx_first_key_image,
             enote_ephemeral_pubkey,
             onetime_address,
-            addr_dev,
+            addr_dev.get_view_incoming_key_device(),
             etd.janus_anchor);
         if (is_special)
         {
@@ -183,8 +183,9 @@ exported_carrot_transfer_details export_cold_carrot_output(const wallet2_basic::
         s_sender_receiver,
         amount_commitment,
         address_spend_pubkey);
-    const bool is_subaddress = address_spend_pubkey != addr_dev.get_cryptonote_account_spend_pubkey();
-    //!@TODO: check nominal subaddress spend pubkey against real one derived from addr_dev
+    crypto::public_key main_address_spend_pubkey;
+    addr_dev.get_address_spend_pubkey({}, main_address_spend_pubkey);
+    const bool is_subaddress = address_spend_pubkey != main_address_spend_pubkey; //! @TODO: Carrot/hybrid
 
     // 12. calc k_a assuming enote_type="change": k_a' = H_n(s^ctx_sr, a, K^j_s, "change")
     crypto::secret_key change_amount_blinding_factor;
@@ -439,15 +440,16 @@ wallet2_basic::transfer_details import_cold_carrot_output(const exported_carrot_
 
     // Now all that's left to do is calculate the key image.
     //! @TODO: carrot hierarchy
-    const carrot::cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        acc_keys.m_account_address.m_spend_public_key,
-        acc_keys.m_view_secret_key);
-    const carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);
-    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(acc_keys.m_spend_secret_key);
-    const carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
-        hybrid_addr_dev,
-        nullptr,
-        &addr_dev);
+    std::shared_ptr<carrot::cryptonote_view_incoming_key_device> k_view_incoming_dev(
+        new carrot::cryptonote_view_incoming_key_ram_borrowed_device(acc_keys.m_view_secret_key));
+    std::shared_ptr<carrot::address_device> addr_dev(
+        new carrot::cryptonote_hierarchy_address_device(k_view_incoming_dev, acc_keys.m_account_address.m_spend_public_key));
+    std::shared_ptr<carrot::generate_image_key_device> legacy_spend_image_dev(
+        new carrot::generate_image_key_ram_borrowed_device(acc_keys.m_spend_secret_key));
+    carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
+        addr_dev,
+        /*s_view_balance_dev=*/{},
+        k_view_incoming_dev);
     td.m_key_image = key_image_dev.derive_key_image(opening_hint);
 
     return td;

--- a/src/wallet/hot_cold.h
+++ b/src/wallet/hot_cold.h
@@ -29,7 +29,7 @@
 #pragma once
 
 //local headers
-#include "carrot_impl/address_device.h"
+#include "carrot_impl/address_device_hierarchies.h"
 #include "carrot_impl/subaddress_index.h"
 #include "span.h"
 #include "tx_builder.h"

--- a/src/wallet/scanning_tools.cpp
+++ b/src/wallet/scanning_tools.cpp
@@ -285,7 +285,8 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_pre_car
 static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_carrot_coinbase_enote(
     const carrot::CarrotCoinbaseEnoteV1 &enote,
     const mx25519_pubkey &s_sender_receiver_unctx,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys)
+    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const carrot::subaddress_map &subaddress_map)
 {
     enote_view_incoming_scan_info_t res;
 
@@ -298,7 +299,7 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_carrot_
         return std::nullopt;
 
     res.payment_id = crypto::null_hash;
-    res.subaddr_index = carrot::subaddress_index_extended{{0, 0}};
+    res.subaddr_index = subaddress_map.get_index_for_address_spend_pubkey(res.address_spend_pubkey);
     res.amount = enote.amount;
     res.amount_blinding_factor = rct::I;
     res.main_tx_pubkey_index = 0;
@@ -524,7 +525,8 @@ std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_enote(
                 s_sender_receiver_unctx,
                 scan_as_sender
                     ? epee::span<const crypto::public_key>(&address.m_spend_public_key, 1)
-                    : main_address_spend_pubkeys);
+                    : main_address_spend_pubkeys,
+                subaddress_map);
         }
 
         std::optional<enote_view_incoming_scan_info_t> operator()(const carrot::CarrotEnoteV1 &enote) const
@@ -789,7 +791,7 @@ void view_incoming_scan_transaction(
 std::vector<std::optional<enote_view_incoming_scan_info_t>> view_incoming_scan_transaction(
     const cryptonote::transaction &tx,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
-    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::address_device &addr_dev,
     const carrot::subaddress_map &subaddress_map)
 {
     crypto::public_key main_address_spend_pubkeys[2];

--- a/src/wallet/scanning_tools.cpp
+++ b/src/wallet/scanning_tools.cpp
@@ -40,7 +40,6 @@
 #include "crypto/generators.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "ringct/rctOps.h"
-#include "ringct/rctSigs.h"
 
 //third party headers
 

--- a/src/wallet/scanning_tools.cpp
+++ b/src/wallet/scanning_tools.cpp
@@ -37,6 +37,7 @@
 #include "carrot_core/scan.h"
 #include "carrot_impl/address_utils.h"
 #include "carrot_impl/format_utils.h"
+#include "carrot_impl/subaddress_map_legacy.h"
 #include "crypto/generators.h"
 #include "cryptonote_basic/cryptonote_format_utils.h"
 #include "ringct/rctOps.h"
@@ -133,27 +134,67 @@ static bool try_load_pre_carrot_enote(const bool is_coinbase,
 }
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
+static std::optional<std::pair<carrot::subaddress_index_extended, crypto::key_derivation>> is_out_to_acc_precomp_sm(
+    const carrot::subaddress_map &subaddresses,
+    const crypto::public_key &out_key,
+    const crypto::key_derivation &derivation,
+    const epee::span<const crypto::key_derivation> additional_derivations,
+    size_t output_index,
+    const boost::optional<crypto::view_tag>& view_tag_opt)
+{
+    static hw::device &hwdev = hw::get_device("default");
+
+    // try the shared tx pubkey
+    crypto::public_key subaddress_spendkey;
+    if (cryptonote::out_can_be_to_acc(view_tag_opt, derivation, output_index, &hwdev))
+    {
+        CHECK_AND_ASSERT_MES(hwdev.derive_subaddress_public_key(out_key, derivation, output_index, subaddress_spendkey),
+            std::nullopt, "Failed to derive subaddress public key");
+        const auto subaddr_it = subaddresses.get_index_for_address_spend_pubkey(subaddress_spendkey);
+        if (subaddr_it)
+            return std::pair{ *subaddr_it, derivation };
+    }
+
+    // try additional tx pubkeys if available
+    if (!additional_derivations.empty())
+    {
+        CHECK_AND_ASSERT_MES(output_index < additional_derivations.size(),
+        std::nullopt, "wrong number of additional derivations");
+        if (cryptonote::out_can_be_to_acc(view_tag_opt, additional_derivations[output_index], output_index, &hwdev))
+        {
+            const crypto::key_derivation &deriv = additional_derivations[output_index];
+            CHECK_AND_ASSERT_MES(hwdev.derive_subaddress_public_key(out_key, deriv, output_index, subaddress_spendkey),
+                std::nullopt, "Failed to derive subaddress public key");
+            const auto subaddr_it = subaddresses.get_index_for_address_spend_pubkey(subaddress_spendkey);
+            if (subaddr_it)
+                return std::pair{ *subaddr_it, additional_derivations[output_index] };
+        }
+    }
+
+    return std::nullopt;
+}
+//-------------------------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------------------------
 static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_pre_carrot_enote(
     const PreCarrotEnote &enote,
     const std::optional<carrot::encrypted_payment_id_t> &encrypted_payment_id,
     const epee::span<const crypto::key_derivation> main_derivations,
     const epee::span<const crypto::key_derivation> additional_derivations,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map)
+    const carrot::subaddress_map &subaddress_map)
 {
     static hw::device &hwdev = hw::get_device("default");
 
-    boost::optional<cryptonote::subaddress_receive_info> receive_info;
+    std::optional<std::pair<carrot::subaddress_index_extended, crypto::key_derivation>> receive_info;
     size_t main_deriv_idx;
     for (main_deriv_idx = 0; main_deriv_idx < std::max<size_t>(1, main_derivations.size()); ++main_deriv_idx)
     {
         const crypto::key_derivation kd = main_deriv_idx < main_derivations.size()
             ? main_derivations[main_deriv_idx] : crypto::key_derivation{};
-        receive_info = cryptonote::is_out_to_acc_precomp(subaddress_map,
+        receive_info = is_out_to_acc_precomp_sm(subaddress_map,
             enote.onetime_address,
             kd,
             main_deriv_idx ? epee::span<const crypto::key_derivation>{} : additional_derivations,
             enote.local_output_index,
-            hwdev,
             enote.view_tag);
         if (receive_info)
             break;
@@ -162,8 +203,9 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_pre_car
     if (!receive_info)
         return std::nullopt;
 
+    const crypto::key_derivation &used_derivation = receive_info->second;
     crypto::ec_scalar amount_key;
-    if (!hwdev.derivation_to_scalar(receive_info->derivation,
+    if (!hwdev.derivation_to_scalar(used_derivation,
             enote.local_output_index,
             amount_key))
         return std::nullopt;
@@ -203,7 +245,7 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_pre_car
 
     // derive k^g_o
     crypto::secret_key sender_extension_g;
-    if (!hwdev.derivation_to_scalar(receive_info->derivation,
+    if (!hwdev.derivation_to_scalar(used_derivation,
             enote.local_output_index,
             sender_extension_g))
         return std::nullopt;
@@ -211,7 +253,7 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_pre_car
     // K^j_s'
     crypto::public_key address_spend_pubkey;
     if (!hwdev.derive_subaddress_public_key(enote.onetime_address,
-            receive_info->derivation,
+            used_derivation,
             enote.local_output_index,
             address_spend_pubkey))
         return std::nullopt;
@@ -221,24 +263,18 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_pre_car
     if (encrypted_payment_id)
     {
         const crypto::secret_key inv_8 = rct::rct2sk(rct::INV_EIGHT);
-        const crypto::public_key fake_pubkey = carrot::raw_byte_convert<crypto::public_key>(receive_info->derivation);
+        const crypto::public_key fake_pubkey = carrot::raw_byte_convert<crypto::public_key>(used_derivation);
         crypto::hash8 pid_hash8 = carrot::raw_byte_convert<crypto::hash8>(*encrypted_payment_id);
         if (hwdev.decrypt_payment_id(pid_hash8, fake_pubkey, inv_8))
             memcpy(&payment_id, &pid_hash8, sizeof(pid_hash8));
     }
-
-    //j
-    const carrot::subaddress_index_extended subaddr_index{
-        .index = {receive_info->index.major, receive_info->index.minor},
-        .derive_type = carrot::AddressDeriveType::PreCarrot
-    };
 
     return enote_view_incoming_scan_info_t{
         .sender_extension_g = sender_extension_g,
         .sender_extension_t = crypto::null_skey,
         .address_spend_pubkey = address_spend_pubkey,
         .payment_id = payment_id,
-        .subaddr_index = subaddr_index,
+        .subaddr_index = receive_info->first,
         .amount = amount,
         .amount_blinding_factor = amount_blinding_factor,
         .main_tx_pubkey_index = main_deriv_idx
@@ -320,7 +356,7 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_carrot_
     const mx25519_pubkey &s_sender_receiver_unctx,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map)
+    const carrot::subaddress_map &subaddress_map)
 {
     enote_view_incoming_scan_info_t res;
 
@@ -341,18 +377,16 @@ static std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_carrot_
             dummy_enote_type))
         return std::nullopt;
 
-    const auto subaddr_it = subaddress_map.find(res.address_spend_pubkey);
-    CHECK_AND_ASSERT_MES(subaddr_it != subaddress_map.cend(),
+    const auto subaddr_it = subaddress_map.get_index_for_address_spend_pubkey(res.address_spend_pubkey);
+    CHECK_AND_ASSERT_MES(subaddr_it,
         std::nullopt,
         "carrot enote scanned successfully, "
         "but the recovered address spend pubkey was not found in the subaddress map");
 
-    const carrot::subaddress_index_extended subaddr_index = {{subaddr_it->second.major, subaddr_it->second.minor}};
-
     memset(&res.payment_id, 0, sizeof(res.payment_id));
     memcpy(&res.payment_id, &payment_id, sizeof(carrot::payment_id_t));
 
-    res.subaddr_index = subaddr_index;
+    res.subaddr_index = *subaddr_it;
     res.amount_blinding_factor = rct::sk2rct(amount_blinding_factor_sk);
     res.main_tx_pubkey_index = 0;
 
@@ -443,7 +477,7 @@ std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_enote(
     const cryptonote::account_public_address &address,
     const carrot::view_incoming_key_device *k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map)
+    const carrot::subaddress_map &subaddress_map)
 {
     CHECK_AND_ASSERT_MES(!main_derivations.empty() || !additional_derivations.empty(),
         std::nullopt,
@@ -527,7 +561,7 @@ std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_enote(
         const cryptonote::account_public_address &address;
         const carrot::view_incoming_key_device *k_view_incoming_dev;
         const epee::span<const crypto::public_key> main_address_spend_pubkeys;
-        const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map;
+        const carrot::subaddress_map &subaddress_map;
     };
 
     return std::visit(
@@ -555,7 +589,7 @@ std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_enote(
     const cryptonote::account_public_address &address,
     const carrot::view_incoming_key_device *k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map)
+    const carrot::subaddress_map &subaddress_map)
 {
     MoneroEnoteVariant enote;
     const bool is_coinbase = cryptonote::is_coinbase(tx);
@@ -622,7 +656,7 @@ std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_enote_from_pre
     const std::size_t local_output_index,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map)
+    const carrot::subaddress_map &subaddress_map)
 {
     const bool is_carrot = carrot::is_carrot_transaction_v1(tx_prefix);
     CHECK_AND_ASSERT_MES(!is_carrot,
@@ -683,7 +717,7 @@ void view_incoming_scan_transaction(
     const epee::span<const crypto::key_derivation> additional_derivations,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
+    const carrot::subaddress_map &subaddress_map,
     const epee::span<std::optional<enote_view_incoming_scan_info_t>> enote_scan_infos_out)
 {
     const size_t n_outputs = tx.vout.size();
@@ -712,7 +746,7 @@ void view_incoming_scan_transaction(
     const cryptonote::transaction &tx,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
+    const carrot::subaddress_map &subaddress_map,
     const epee::span<std::optional<enote_view_incoming_scan_info_t>> enote_scan_infos_out)
 {
     // 1. parse tx extra
@@ -756,7 +790,7 @@ std::vector<std::optional<enote_view_incoming_scan_info_t>> view_incoming_scan_t
     const cryptonote::transaction &tx,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::hybrid_hierarchy_address_device &addr_dev,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map)
+    const carrot::subaddress_map &subaddress_map)
 {
     crypto::public_key main_address_spend_pubkeys[2];
     std::vector<std::optional<enote_view_incoming_scan_info_t>> res(tx.vout.size());
@@ -802,7 +836,7 @@ std::vector<std::optional<enote_view_incoming_scan_info_t>> view_incoming_scan_t
             address,
             /*k_view_incoming_dev=*/nullptr,
             /*main_address_spend_pubkeys=*/{},
-            {{address.m_spend_public_key, {}}});
+            carrot::subaddress_map_legacy{{{address.m_spend_public_key, {}}}});
     }
 
     return res;

--- a/src/wallet/scanning_tools.h
+++ b/src/wallet/scanning_tools.h
@@ -149,7 +149,7 @@ void view_incoming_scan_transaction(
 std::vector<std::optional<enote_view_incoming_scan_info_t>> view_incoming_scan_transaction(
     const cryptonote::transaction &tx,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
-    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::address_device &addr_dev,
     const carrot::subaddress_map &subaddress_map);
 
 /**

--- a/src/wallet/scanning_tools.h
+++ b/src/wallet/scanning_tools.h
@@ -34,6 +34,7 @@
 #include "carrot_impl/address_device.h"
 #include "carrot_impl/key_image_device.h"
 #include "carrot_impl/subaddress_index.h"
+#include "carrot_impl/subaddress_map.h"
 #include "crypto/crypto.h"
 #include "cryptonote_basic/blobdatatype.h"
 #include "cryptonote_basic/cryptonote_basic.h"
@@ -113,7 +114,7 @@ std::optional<enote_view_incoming_scan_info_t> view_incoming_scan_enote_from_pre
     const std::size_t local_output_index,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map);
+    const carrot::subaddress_map &subaddress_map);
 
 /**
  * brief: do a view-incoming scan as receiver on all enotes in a full tx
@@ -137,19 +138,19 @@ void view_incoming_scan_transaction(
     const epee::span<const crypto::key_derivation> additional_derivations,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
+    const carrot::subaddress_map &subaddress_map,
     const epee::span<std::optional<enote_view_incoming_scan_info_t>> enote_scan_infos_out);
 void view_incoming_scan_transaction(
     const cryptonote::transaction &tx,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
+    const carrot::subaddress_map &subaddress_map,
     const epee::span<std::optional<enote_view_incoming_scan_info_t>> enote_scan_infos_out);
 std::vector<std::optional<enote_view_incoming_scan_info_t>> view_incoming_scan_transaction(
     const cryptonote::transaction &tx,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::hybrid_hierarchy_address_device &addr_dev,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map);
+    const carrot::subaddress_map &subaddress_map);
 
 /**
  * brief: do a view-incoming scan as sender on all enotes in a full tx

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -123,7 +123,7 @@ static bool build_payment_proposals(std::vector<carrot::CarrotPaymentProposalV1>
     const carrot::subaddress_map &subaddress_map)
 {
     const auto subaddr_it = subaddress_map.get_index_for_address_spend_pubkey(tx_dest_entry.addr.m_spend_public_key);
-
+ 
     // Make N destinations
     if (subaddr_it)
     {
@@ -1254,7 +1254,7 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::address_device &addr_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,
     const carrot::spend_device &spend_dev)
@@ -1382,7 +1382,7 @@ pending_tx finalize_all_fcmp_pp_proofs_as_pending_tx(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::address_device &addr_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,
     const carrot::spend_device &spend_dev)

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -35,9 +35,8 @@
 #include "carrot_core/exceptions.h"
 #include "carrot_core/output_set_finalization.h"
 #include "carrot_core/scan.h"
-#include "carrot_impl/address_device_ram_borrowed.h"
+#include "carrot_impl/address_utils.h"
 #include "carrot_impl/format_utils.h"
-#include "carrot_impl/key_image_device_composed.h"
 #include "carrot_impl/multi_tx_proposal_utils.h"
 #include "carrot_impl/tx_builder_inputs.h"
 #include "carrot_impl/tx_builder_outputs.h"
@@ -850,50 +849,6 @@ std::vector<std::size_t> collect_selected_transfer_indices(const tx_reconstruct_
     return selected_transfer_indices;
 }
 //-------------------------------------------------------------------------------------------------------------------
-std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_transaction_proposal(
-    const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
-    const carrot::cryptonote_hierarchy_address_device &addr_dev,
-    const crypto::secret_key &k_spend)
-{
-    const size_t n_inputs = tx_proposal.input_proposals.size();
-    CHECK_AND_ASSERT_THROW_MES(rerandomized_outputs.size() == n_inputs,
-        "wrong size for rerandomized_outputs");
-
-    //! @TODO: carrot hierarchy
-    const carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);
-    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(k_spend);
-    const carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
-        hybrid_addr_dev,
-        nullptr,
-        &addr_dev);
-
-    crypto::hash signable_tx_hash;
-    carrot::make_signable_tx_hash_from_proposal_v1(tx_proposal,
-        /*s_view_balance_dev=*/nullptr,
-        &addr_dev,
-        key_image_dev,
-        signable_tx_hash);
-
-    std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sal_proofs_by_ki;
-    for (size_t input_idx = 0; input_idx < n_inputs; ++input_idx)
-    {
-        //! @TODO: spend device
-        fcmp_pp::FcmpPpSalProof sal_proof;
-        crypto::key_image actual_key_image;
-        carrot::make_sal_proof_any_to_legacy_v1(signable_tx_hash,
-            rerandomized_outputs.at(input_idx),
-            tx_proposal.input_proposals.at(input_idx),
-            k_spend,
-            addr_dev,
-            sal_proof,
-            actual_key_image);
-        sal_proofs_by_ki.emplace(actual_key_image, std::move(sal_proof));
-    }
-
-    return sal_proofs_by_ki;
-}
-//-------------------------------------------------------------------------------------------------------------------
 cryptonote::transaction finalize_fcmps_and_range_proofs(
     const std::vector<crypto::key_image> &sorted_input_key_images,
     const std::vector<FcmpRerandomizedOutputCompressed> &sorted_rerandomized_outputs,
@@ -1184,7 +1139,10 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const cryptonote::account_keys &acc_keys)
+    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const carrot::view_incoming_key_device &k_view_incoming_dev,
+    const carrot::view_balance_secret_device *s_view_balance_dev,
+    const carrot::spend_device &spend_dev)
 {
     const size_t n_inputs = tx_proposal.input_proposals.size();
     const size_t n_outputs = tx_proposal.normal_payment_proposals.size()
@@ -1197,23 +1155,11 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
         << tx_proposal.selfsend_payment_proposals.size() << " self-send payment proposals, and a fee of "
         << tx_proposal.fee << " pXMR");
 
-    //! @TODO: carrot hierarchy / HW device
-    const carrot::cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        acc_keys.m_account_address.m_spend_public_key,
-        acc_keys.m_view_secret_key);
-    const carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);
-    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(acc_keys.m_spend_secret_key);
-    const carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
-        hybrid_addr_dev,
-        nullptr,
-        &addr_dev);
-    const crypto::public_key main_address_spend_pubkey = addr_dev.get_cryptonote_account_spend_pubkey();
-
     // finalize key images
     std::vector<crypto::key_image> sorted_input_key_images;
     std::vector<std::size_t> key_image_order;
     carrot::get_sorted_input_key_images_from_proposal_v1(tx_proposal,
-        key_image_dev,
+        spend_dev,
         sorted_input_key_images,
         &key_image_order);
 
@@ -1230,8 +1176,8 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     carrot::get_output_enote_proposals(tx_proposal.normal_payment_proposals,
         selfsend_payment_proposal_cores,
         tx_proposal.dummy_encrypted_payment_id,
-        /*s_view_balance_dev=*/nullptr, //! @TODO: internal
-        &addr_dev,
+        s_view_balance_dev,
+        &k_view_incoming_dev,
         sorted_input_key_images.at(0),
         output_enote_proposals,
         encrypted_payment_id);
@@ -1252,9 +1198,9 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
 
         rct::xmr_amount amount;
         carrot::try_scan_opening_hint_amount(input_proposal,
-            {&main_address_spend_pubkey, 1},
-            &addr_dev,
-            nullptr,
+            main_address_spend_pubkeys,
+            &k_view_incoming_dev,
+            s_view_balance_dev,
             amount,
             input_amount_blinding_factors.emplace_back());
     }
@@ -1265,46 +1211,63 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     for (const carrot::RCTOutputEnoteProposal &output_enote_proposal : output_enote_proposals)
         output_amount_blinding_factors.push_back(rct::sk2rct(output_enote_proposal.amount_blinding_factor));
 
-    // make rerandomized outputs
+    // make rerandomized outputs and collect by OTA
     std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs;
     carrot::make_carrot_rerandomized_outputs_nonrefundable(input_onetime_addresses,
         input_amount_commitments,
         input_amount_blinding_factors,
         output_amount_blinding_factors,
         rerandomized_outputs);
-
-    // do SA/L proofs for each input
-    std::vector<fcmp_pp::FcmpPpSalProof> sal_proofs;
-    sal_proofs.reserve(n_inputs);
+    std::unordered_map<crypto::public_key, FcmpRerandomizedOutputCompressed> rerandomized_outputs_by_ota;
+    for (std::size_t input_idx = 0; input_idx < rerandomized_outputs.size(); ++input_idx)
     {
-        PERF_TIMER(sign_carrot_transaction_proposal);
-        std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sal_proofs_by_ki =
-            sign_carrot_transaction_proposal(
-                tx_proposal, rerandomized_outputs, addr_dev, acc_keys.m_spend_secret_key);
-
-        for (const crypto::key_image &ki : sorted_input_key_images)
-        {
-            const auto sal_it = sal_proofs_by_ki.find(ki);
-            CHECK_AND_ASSERT_THROW_MES(sal_it != sal_proofs_by_ki.end(),
-                "missing SA/L proof");
-            CHECK_AND_ASSERT_THROW_MES(sal_it->second.size() == FCMP_PP_SAL_PROOF_SIZE_V1,
-                "unexpected SA/L proof size");
-            sal_proofs.push_back(std::move(sal_it->second));
-            sal_proofs_by_ki.erase(sal_it);
-        }
+        const crypto::public_key onetime_address = onetime_address_ref(tx_proposal.input_proposals.at(input_idx));
+        rerandomized_outputs_by_ota[onetime_address] = rerandomized_outputs.at(input_idx);
     }
 
-    // sort rerandomized outputs in key image order
+    // call spend device to do SA/L proofs for each input
+    crypto::hash signable_tx_hash;
+    carrot::spend_device::signed_input_set_t signed_inputs;
+    const bool sign_success = spend_dev.try_sign_carrot_transaction_proposal_v1(tx_proposal,
+        rerandomized_outputs_by_ota,
+        signable_tx_hash,
+        signed_inputs);
+    CHECK_AND_ASSERT_THROW_MES(sign_success, "Device declined to sign inputs");
+
+    // sort and collect input infos in key image order
     tools::apply_permutation(key_image_order, rerandomized_outputs);
+    std::vector<fcmp_pp::FcmpPpSalProof> sorted_sal_proofs;
+    sorted_sal_proofs.reserve(signed_inputs.size());
+    for (const auto &signed_input : signed_inputs)
+        sorted_sal_proofs.push_back(signed_input.second.second);
 
     return finalize_fcmps_and_range_proofs(sorted_input_key_images,
         rerandomized_outputs,
-        sal_proofs,
+        sorted_sal_proofs,
         output_enote_proposals,
         encrypted_payment_id,
         tx_proposal.fee,
         tree_cache,
         curve_trees);
+}
+//-------------------------------------------------------------------------------------------------------------------
+cryptonote::transaction finalize_all_fcmp_pp_proofs(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
+    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::view_incoming_key_device &k_view_incoming_dev,
+    const carrot::view_balance_secret_device *s_view_balance_dev,
+    const carrot::spend_device &spend_dev)
+{
+    crypto::public_key main_address_spend_pubkeys[2];
+    return finalize_all_fcmp_pp_proofs(tx_proposal,
+        tree_cache,
+        curve_trees,
+        carrot::get_all_main_address_spend_pubkeys_span(addr_dev, main_address_spend_pubkeys),
+        k_view_incoming_dev,
+        s_view_balance_dev,
+        spend_dev);
 }
 //-------------------------------------------------------------------------------------------------------------------
 pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_proposal,
@@ -1337,7 +1300,7 @@ pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_
         && tx_proposal.normal_payment_proposals.size() == 1
         && tx_proposal.normal_payment_proposals.at(0).amount == 0;
     CHECK_AND_ASSERT_THROW_MES(!tx_proposal.selfsend_payment_proposals.empty(),
-        "make_pending_carrot_tx: carrot tx proposal missing a self-send proposal");
+        "carrot tx proposal missing a self-send proposal");
 
     // collect destinations
     //! @TODO: payment proofs for special self-send, perhaps generate d_e deterministically
@@ -1391,7 +1354,7 @@ pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_
         const std::uint32_t other_subaddr_account = subaddress_index_ref(input_proposal).index.major;
         if (other_subaddr_account != subaddr_account)
         {
-            MWARNING("make_pending_carrot_tx: conflicting account indices: " << subaddr_account << " vs "
+            MWARNING("Conflicting account indices in pending : " << subaddr_account << " vs "
                 << other_subaddr_account);
         }
         subaddr_indices.insert(subaddress_index_ref(input_proposal).index.minor);
@@ -1420,32 +1383,27 @@ pending_tx finalize_all_fcmp_pp_proofs_as_pending_tx(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const cryptonote::account_keys &acc_keys)
+    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::view_incoming_key_device &k_view_incoming_dev,
+    const carrot::view_balance_secret_device *s_view_balance_dev,
+    const carrot::spend_device &spend_dev)
 {
-    //! @TODO: carrot hierarchy
-    const carrot::cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        acc_keys.m_account_address.m_spend_public_key,
-        acc_keys.m_view_secret_key);
-    const carrot::hybrid_hierarchy_address_device_composed hybrid_addr_dev(&addr_dev, nullptr);
-    const carrot::generate_image_key_ram_borrowed_device legacy_spend_image_dev(acc_keys.m_spend_secret_key);
-    const carrot::key_image_device_composed key_image_dev(legacy_spend_image_dev,
-        hybrid_addr_dev,
-        nullptr,
-        &addr_dev);
-
     std::vector<crypto::key_image> sorted_input_key_images;
     carrot::get_sorted_input_key_images_from_proposal_v1(tx_proposal,
-        key_image_dev,
+        spend_dev,
         sorted_input_key_images);
 
     pending_tx ptx = make_pending_carrot_tx(tx_proposal,
         sorted_input_key_images,
-        addr_dev);
+        k_view_incoming_dev);
 
     ptx.tx = finalize_all_fcmp_pp_proofs(tx_proposal,
         tree_cache,
         curve_trees,
-        acc_keys);
+        addr_dev,
+        k_view_incoming_dev,
+        s_view_balance_dev,
+        spend_dev);
 
     return ptx;
 }

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -30,6 +30,7 @@
 
 //local headers
 #include "carrot_impl/address_device.h"
+#include "carrot_impl/spend_device.h"
 #include "carrot_impl/input_selection.h"
 #include "fee_priority.h"
 #include "fcmp_pp/tree_cache.h"
@@ -267,19 +268,6 @@ carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(con
 std::vector<std::size_t> collect_selected_transfer_indices(const tx_reconstruct_variant_t &tx_construction_data,
     const wallet2_basic::transfer_container &transfers);
 /**
- * brief: sign all Carrot transaction proposal inputs given rerandomized outputs
- * param: tx_proposal -
- * param: rerandomized_outputs - rerandomized outputs in order of input proposals in `tx_proposal`
- * param: addr_dev -
- * param: k_spend - k_s
- * return: valid SA/L proofs by key image
- */
-std::unordered_map<crypto::key_image, fcmp_pp::FcmpPpSalProof> sign_carrot_transaction_proposal(
-    const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const std::vector<FcmpRerandomizedOutputCompressed> &rerandomized_outputs,
-    const carrot::cryptonote_hierarchy_address_device &addr_dev,
-    const crypto::secret_key &k_spend);
-/**
  * brief: finalize FCMPs and BP+ range proofs for output amounts for Carrot/FCMP++ txs
  * param: sorted_input_key_images - key images in input order
  * param: sorted_rerandomized_outputs - rerandomized outputs in key image order
@@ -303,14 +291,29 @@ cryptonote::transaction finalize_fcmps_and_range_proofs(
  * param: tx_proposal -
  * param: tree_cache - FCMP tree cache to draw enote paths from
  * param: curve_trees -
- * param: acc_keys -
+ * param: main_address_spend_pubkeys - all K_s
+ * param: addr_dev -
+ * param: k_view_incoming_dev -
+ * param: s_view_balance_dev -
+ * param: spend_dev -
  * return: a fully proved FCMP++ transaction corresponding to the transaction proposal
  */
 cryptonote::transaction finalize_all_fcmp_pp_proofs(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const cryptonote::account_keys &acc_keys);
+    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const carrot::view_incoming_key_device &k_view_incoming_dev,
+    const carrot::view_balance_secret_device *s_view_balance_dev,
+    const carrot::spend_device &spend_dev);
+cryptonote::transaction finalize_all_fcmp_pp_proofs(
+    const carrot::CarrotTransactionProposalV1 &tx_proposal,
+    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
+    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
+    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::view_incoming_key_device &k_view_incoming_dev,
+    const carrot::view_balance_secret_device *s_view_balance_dev,
+    const carrot::spend_device &spend_dev);
 /**
  * brief: fill out a `pending_tx` from a Carrot transaction proposal, excluding the transaction itself
  * param: tx_proposal -
@@ -333,7 +336,10 @@ pending_tx finalize_all_fcmp_pp_proofs_as_pending_tx(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const cryptonote::account_keys &acc_keys);
+    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::view_incoming_key_device &k_view_incoming_dev,
+    const carrot::view_balance_secret_device *s_view_balance_dev,
+    const carrot::spend_device &spend_dev);
 
 } //namespace wallet
 } //namespace tools

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -30,8 +30,9 @@
 
 //local headers
 #include "carrot_impl/address_device.h"
-#include "carrot_impl/spend_device.h"
 #include "carrot_impl/input_selection.h"
+#include "carrot_impl/spend_device.h"
+#include "carrot_impl/subaddress_map.h"
 #include "fee_priority.h"
 #include "fcmp_pp/tree_cache.h"
 #include "wallet2_basic/wallet2_types.h"
@@ -181,7 +182,7 @@ std::vector<carrot::InputCandidate> collect_carrot_input_candidate_list(
  */
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_transfer(
     const wallet2_basic::transfer_container &transfers,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
+    const carrot::subaddress_map &subaddress_map,
     const std::vector<cryptonote::tx_destination_entry> &dsts,
     const rct::xmr_amount fee_per_weight,
     std::vector<uint8_t> extra,
@@ -208,7 +209,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
  */
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep(
     const wallet2_basic::transfer_container &transfers,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
+    const carrot::subaddress_map &subaddress_map,
     const std::vector<crypto::key_image> &input_key_images,
     const cryptonote::account_public_address &address,
     const bool is_subaddress,
@@ -235,7 +236,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
  */
 std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposals_wallet2_sweep_all(
     const wallet2_basic::transfer_container &transfers,
-    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> &subaddress_map,
+    const carrot::subaddress_map &subaddress_map,
     const rct::xmr_amount only_below,
     const cryptonote::account_public_address &address,
     const bool is_subaddress,

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -311,7 +311,7 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::address_device &addr_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,
     const carrot::spend_device &spend_dev);
@@ -337,7 +337,7 @@ pending_tx finalize_all_fcmp_pp_proofs_as_pending_tx(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const carrot::hybrid_hierarchy_address_device &addr_dev,
+    const carrot::address_device &addr_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,
     const carrot::spend_device &spend_dev);

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -101,6 +101,7 @@ using namespace epee;
 #include "carrot_impl/format_utils.h"
 #include "carrot_impl/key_image_device_composed.h"
 #include "carrot_impl/spend_device_ram_borrowed.h"
+#include "carrot_impl/subaddress_map_legacy.h"
 #include "tx_builder.h"
 #include "tx_builder_serialization.h"
 #include "hot_cold_serialization.h" //! @TODO: remove line after #52 is merged
@@ -10658,7 +10659,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
   if (do_carrot_tx_construction)
   {
     const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(::get_transfers(*this),
-      m_subaddresses,
+      carrot::subaddress_map_legacy(m_subaddresses),
       dsts,
       get_fee_per_weight_from_priority(priority, *this),
       extra,
@@ -11444,7 +11445,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_all(uint64_t below
   if (do_carrot_tx_construction)
   {
     const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep_all(::get_transfers(*this),
-      m_subaddresses,
+      carrot::subaddress_map_legacy(m_subaddresses),
       below,
       address,
       is_subaddress,
@@ -11540,7 +11541,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_single(const crypt
   if (do_carrot_tx_construction)
   {
     const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(::get_transfers(*this),
-        m_subaddresses,
+        carrot::subaddress_map_legacy(m_subaddresses),
         {ki},
         address,
         is_subaddress,
@@ -11588,7 +11589,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_from(const crypton
       input_key_images.push_back(m_transfers.at(transfer_idx).m_key_image);
 
     const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(::get_transfers(*this),
-        m_subaddresses,
+        carrot::subaddress_map_legacy(m_subaddresses),
         input_key_images,
         address,
         is_subaddress,

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -2449,7 +2449,7 @@ void wallet2::process_new_transaction(
     wallet::view_incoming_scan_transaction(tx,
       *this->get_view_incoming_key_device(),
       *this->get_hybrid_address_device(),
-      this->m_subaddresses);
+      carrot::subaddress_map_legacy{this->m_subaddresses});
 
   // if view-incoming scan was successful, try deriving the key image
   bool password_failure = false;
@@ -3672,7 +3672,7 @@ void wallet2::process_parsed_blocks(const uint64_t start_height, const uint64_t 
     wallet::view_incoming_scan_transaction(tx,
       *k_view_incoming_dev,
       {&m_account.get_keys().m_account_address.m_spend_public_key, 1}, //! @TODO: Carrot/hybrid
-      this->m_subaddresses,
+      carrot::subaddress_map_legacy{this->m_subaddresses},
       {&enote_scan_infos[0] + tx_output_idx, tx.vout.size()});
 
     // if view-incoming scan was successful, try deriving the key image
@@ -13521,7 +13521,7 @@ crypto::public_key wallet2::get_tx_pub_key_from_received_outs(const tools::walle
     td.m_internal_output_index,
     *k_view_incoming_dev,
     {&m_account.get_keys().m_account_address.m_spend_public_key, 1}, //! @TODO: Carrot/hybrid
-    m_subaddresses);
+    carrot::subaddress_map_legacy{m_subaddresses});
 
   const size_t main_tx_pubkey_index = enote_scan_info ? enote_scan_info->main_tx_pubkey_index : 0;
 
@@ -13847,7 +13847,7 @@ uint64_t wallet2::import_key_images(const std::vector<std::pair<crypto::key_imag
       const auto enote_scan_infos = wallet::view_incoming_scan_transaction(spent_tx,
         *k_view_incoming_dev,
         *hybrid_addr_dev,
-        m_subaddresses);
+        carrot::subaddress_map_legacy{m_subaddresses});
       for (const auto &enote_scan_info : enote_scan_infos)
         if (enote_scan_info && enote_scan_info->subaddr_index)
           tx_money_got_in_outs += enote_scan_info->amount; //! @TODO: check overflow

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -656,9 +656,11 @@ private:
     hw::device::device_type get_device_type() const { return m_key_device_type; }
     bool reconnect_device();
 
+    std::unique_ptr<carrot::view_balance_secret_device> get_view_balance_secret_device() const;
     std::unique_ptr<carrot::view_incoming_key_device> get_view_incoming_key_device() const;
     std::unique_ptr<carrot::hybrid_hierarchy_address_device> get_hybrid_address_device() const;
     std::unique_ptr<carrot::key_image_device> get_key_image_device() const;
+    std::unique_ptr<carrot::spend_device> get_spend_device() const;
 
     // locked & unlocked balance of given or current subaddress account
     uint64_t balance(uint32_t subaddr_index_major, bool strict) const;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -656,11 +656,14 @@ private:
     hw::device::device_type get_device_type() const { return m_key_device_type; }
     bool reconnect_device();
 
-    std::unique_ptr<carrot::view_balance_secret_device> get_view_balance_secret_device() const;
-    std::unique_ptr<carrot::view_incoming_key_device> get_view_incoming_key_device() const;
-    std::unique_ptr<carrot::hybrid_hierarchy_address_device> get_hybrid_address_device() const;
-    std::unique_ptr<carrot::key_image_device> get_key_image_device() const;
-    std::unique_ptr<carrot::spend_device> get_spend_device() const;
+    std::shared_ptr<carrot::view_balance_secret_device> get_view_balance_secret_device() const;
+    std::shared_ptr<carrot::cryptonote_view_incoming_key_device> get_view_incoming_key_device() const;
+    std::shared_ptr<carrot::generate_image_key_device> get_generate_image_key_device() const;
+    std::shared_ptr<carrot::cryptonote_hierarchy_address_device> get_cryptonote_address_device() const;
+    std::shared_ptr<carrot::carrot_hierarchy_address_device> get_carrot_address_device() const;
+    std::shared_ptr<carrot::address_device> get_address_device() const;
+    std::shared_ptr<carrot::key_image_device> get_key_image_device() const;
+    std::shared_ptr<carrot::spend_device> get_spend_device() const;
 
     // locked & unlocked balance of given or current subaddress account
     uint64_t balance(uint32_t subaddr_index_major, bool strict) const;

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -33,6 +33,7 @@
 #include "carrot_core/device_ram_borrowed.h"
 #include "carrot_impl/address_device_ram_borrowed.h"
 #include "carrot_impl/spend_device_ram_borrowed.h"
+#include "carrot_impl/subaddress_map_legacy.h"
 #include "ringct/rctSigs.h"
 #include "ringct/bulletproofs_plus.h"
 #include "chaingen.h"
@@ -398,7 +399,7 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
 
   const auto tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(
       {wallet2_td},
-      subaddrs,
+      carrot::subaddress_map_legacy{subaddrs},
       destinations,
       /*fee_per_weight=*/10000000, // This is just a mock value to pass the test
       /*extra=*/{},

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -414,14 +414,15 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
   const crypto::secret_key &k_s = miner_account.get_keys().m_spend_secret_key;
   const crypto::secret_key &k_v = miner_account.get_keys().m_view_secret_key;
   const crypto::public_key &K_s = miner_account.get_keys().m_account_address.m_spend_public_key;
-  const carrot::cryptonote_hierarchy_address_device_ram_borrowed cn_addr_dev(K_s, k_v);
+  const auto k_view_incoming_dev = std::make_shared<carrot::cryptonote_view_incoming_key_ram_borrowed_device>(k_v);
+  const carrot::cryptonote_hierarchy_address_device cn_addr_dev(k_view_incoming_dev, K_s);
   rct_txes.back() = tools::wallet::finalize_all_fcmp_pp_proofs(tx_proposals.front(),
       tree_cache,
       *fcmp_pp::curve_trees::curve_trees_v1(),
-      carrot::hybrid_hierarchy_address_device_composed(&cn_addr_dev, nullptr),
-      carrot::view_incoming_key_ram_borrowed_device(k_v),
+      cn_addr_dev,
+      *k_view_incoming_dev,
       /*s_view_balance_dev=*/nullptr,
-      carrot::spend_device_ram_borrowed_legacy(k_v, k_s));
+      carrot::spend_device_ram_borrowed(k_s, k_v));
 
   if (post_tx && !post_tx(rct_txes.back(), 0))
   {

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -272,12 +272,12 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
                 scan_results);
             ASSERT_EQ(1, scan_results.size());
             const mock::mock_scan_result_t &scan_result = scan_results.front();
-            const auto subaddr_it = alice.subaddress_map.find(scan_result.address_spend_pubkey);
-            ASSERT_NE(alice.subaddress_map.cend(), subaddr_it);
+            const auto subaddr_it = alice.subaddress_map.get_index_for_address_spend_pubkey(scan_result.address_spend_pubkey);
+            ASSERT_TRUE(subaddr_it);
             opening_hint = CarrotOutputOpeningHintV1{
                 .source_enote = enote,
                 .encrypted_payment_id = encrypted_payment_id,
-                .subaddr_index = subaddr_it->second
+                .subaddr_index = *subaddr_it
             };
         }
         else // is coinbase
@@ -375,7 +375,7 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
     // derive input key images
     std::vector<crypto::key_image> sorted_input_key_images;
     carrot::get_sorted_input_key_images_from_proposal_v1(tx_proposal,
-        alice.carrot_key_image_dev,
+        *alice.key_image_dev,
         sorted_input_key_images);
 
     // derive output enote set

--- a/tests/unit_tests/carrot_tx_builder.cpp
+++ b/tests/unit_tests/carrot_tx_builder.cpp
@@ -41,12 +41,12 @@ TEST(carrot_tx_builder, make_sal_proof_legacy_to_legacy_v1_mainaddr)
     mock::mock_carrot_and_legacy_keys keys;
     keys.generate(AddressDeriveType::PreCarrot);
 
-    const cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key,
-        keys.legacy_acb.get_keys().m_view_secret_key);
-
     // (K^0_s, K^0_v)
     const CarrotDestinationV1 addr = keys.cryptonote_address();
+
+    const cryptonote_hierarchy_address_device cn_addr_dev(
+        std::make_shared<cryptonote_view_incoming_key_ram_borrowed_device>(keys.k_view_incoming_dev),
+        addr.address_spend_pubkey);
 
     const crypto::hash signable_tx_hash = crypto::rand<crypto::hash>();
 
@@ -81,7 +81,7 @@ TEST(carrot_tx_builder, make_sal_proof_legacy_to_legacy_v1_mainaddr)
         .local_output_index = local_output_index
     };
 
-    const crypto::key_image expected_key_image = keys.legacy_key_image_dev.derive_key_image(opening_hint);
+    const crypto::key_image expected_key_image = keys.key_image_dev->derive_key_image(opening_hint);
 
     // fake output amount blinding factor in a hypothetical tx where we spent the aforementioned output
     const rct::key output_amount_blinding_factor = rct::skGen();
@@ -103,7 +103,7 @@ TEST(carrot_tx_builder, make_sal_proof_legacy_to_legacy_v1_mainaddr)
         rerandomized_outputs.front(),
         opening_hint,
         keys.legacy_acb.get_keys().m_spend_secret_key,
-        addr_dev,
+        cn_addr_dev,
         sal_proof,
         actual_key_image);
 
@@ -121,12 +121,12 @@ TEST(carrot_tx_builder, make_sal_proof_legacy_to_legacy_v1_subaddr)
     mock::mock_carrot_and_legacy_keys keys;
     keys.generate(AddressDeriveType::PreCarrot);
 
-    const cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key,
-        keys.legacy_acb.get_keys().m_view_secret_key);
+    const cryptonote_hierarchy_address_device cn_addr_dev(
+        std::make_shared<cryptonote_view_incoming_key_ram_borrowed_device>(keys.k_view_incoming_dev),
+        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key);
 
     // j
-    const subaddress_index_extended subaddress_index = mock::gen_subaddress_index_extended();
+    const subaddress_index_extended subaddress_index = mock::gen_subaddress_index_extended(keys.default_derive_type);
     
     // (K^j_s, K^j_v)
     const CarrotDestinationV1 addr = keys.subaddress(subaddress_index);
@@ -168,7 +168,7 @@ TEST(carrot_tx_builder, make_sal_proof_legacy_to_legacy_v1_subaddr)
         .local_output_index = local_output_index
     };
 
-    const crypto::key_image expected_key_image = keys.legacy_key_image_dev.derive_key_image(opening_hint);
+    const crypto::key_image expected_key_image = keys.key_image_dev->derive_key_image(opening_hint);
 
     // fake output amount blinding factor in a hypothetical tx where we spent the aforementioned output
     const rct::key output_amount_blinding_factor = rct::skGen();
@@ -190,7 +190,7 @@ TEST(carrot_tx_builder, make_sal_proof_legacy_to_legacy_v1_subaddr)
         rerandomized_outputs.front(),
         opening_hint,
         keys.legacy_acb.get_keys().m_spend_secret_key,
-        addr_dev,
+        cn_addr_dev,
         sal_proof,
         actual_key_image);
 
@@ -208,9 +208,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_mainaddr_normal)
     mock::mock_carrot_and_legacy_keys keys;
     keys.generate(AddressDeriveType::PreCarrot);
 
-    const cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key,
-        keys.legacy_acb.get_keys().m_view_secret_key);
+    const cryptonote_hierarchy_address_device cn_addr_dev(
+        std::make_shared<cryptonote_view_incoming_key_ram_borrowed_device>(keys.k_view_incoming_dev),
+        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key);
 
     // (K^0_s, K^0_v)
     const CarrotDestinationV1 addr = keys.cryptonote_address();
@@ -277,7 +277,7 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_mainaddr_normal)
         rerandomized_outputs.front(),
         opening_hint,
         keys.legacy_acb.get_keys().m_spend_secret_key,
-        addr_dev,
+        cn_addr_dev,
         sal_proof,
         actual_key_image);
 
@@ -295,9 +295,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_subaddr_normal)
     mock::mock_carrot_and_legacy_keys keys;
     keys.generate(AddressDeriveType::PreCarrot);
 
-    const cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key,
-        keys.legacy_acb.get_keys().m_view_secret_key);
+    const cryptonote_hierarchy_address_device cn_addr_dev(
+        std::make_shared<cryptonote_view_incoming_key_ram_borrowed_device>(keys.k_view_incoming_dev),
+        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key);
 
     // j
     const subaddress_index subaddr_index = mock::gen_subaddress_index();
@@ -367,7 +367,7 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_subaddr_normal)
         rerandomized_outputs.front(),
         opening_hint,
         keys.legacy_acb.get_keys().m_spend_secret_key,
-        addr_dev,
+        cn_addr_dev,
         sal_proof,
         actual_key_image);
 
@@ -385,9 +385,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_subaddr_special)
     mock::mock_carrot_and_legacy_keys keys;
     keys.generate(AddressDeriveType::PreCarrot);
 
-    const cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key,
-        keys.legacy_acb.get_keys().m_view_secret_key);
+    const cryptonote_hierarchy_address_device cn_addr_dev(
+        std::make_shared<cryptonote_view_incoming_key_ram_borrowed_device>(keys.k_view_incoming_dev),
+        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key);
 
     // j
     const subaddress_index subaddr_index = mock::gen_subaddress_index();
@@ -457,7 +457,7 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_subaddr_special)
         rerandomized_outputs.front(),
         opening_hint,
         keys.legacy_acb.get_keys().m_spend_secret_key,
-        addr_dev,
+        cn_addr_dev,
         sal_proof,
         actual_key_image);
 
@@ -475,9 +475,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_mainaddr_special)
     mock::mock_carrot_and_legacy_keys keys;
     keys.generate(AddressDeriveType::PreCarrot);
 
-    const cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key,
-        keys.legacy_acb.get_keys().m_view_secret_key);
+    const cryptonote_hierarchy_address_device cn_addr_dev(
+        std::make_shared<cryptonote_view_incoming_key_ram_borrowed_device>(keys.k_view_incoming_dev),
+        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key);
 
     // (K^0_s, K^0_v)
     const CarrotDestinationV1 addr = keys.cryptonote_address();
@@ -544,7 +544,7 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_legacy_v1_mainaddr_special)
         rerandomized_outputs.front(),
         opening_hint,
         keys.legacy_acb.get_keys().m_spend_secret_key,
-        addr_dev,
+        cn_addr_dev,
         sal_proof,
         actual_key_image);
 
@@ -1087,9 +1087,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_coinbase_to_legacy_v1)
     mock::mock_carrot_and_legacy_keys keys;
     keys.generate(AddressDeriveType::PreCarrot);
 
-    const cryptonote_hierarchy_address_device_ram_borrowed addr_dev(
-        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key,
-        keys.legacy_acb.get_keys().m_view_secret_key);
+    const cryptonote_hierarchy_address_device cn_addr_dev(
+        std::make_shared<cryptonote_view_incoming_key_ram_borrowed_device>(keys.k_view_incoming_dev),
+        keys.legacy_acb.get_keys().m_account_address.m_spend_public_key);
 
     // (K^0_s, K^0_v)
     const CarrotDestinationV1 addr = keys.cryptonote_address();
@@ -1149,7 +1149,7 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_coinbase_to_legacy_v1)
         rerandomized_outputs.front(),
         opening_hint,
         keys.legacy_acb.get_keys().m_spend_secret_key,
-        addr_dev,
+        cn_addr_dev,
         sal_proof,
         actual_key_image);
 

--- a/tests/unit_tests/tx_construction_helpers.h
+++ b/tests/unit_tests/tx_construction_helpers.h
@@ -115,6 +115,13 @@ static constexpr rct::xmr_amount fake_fee_per_weight = 2023;
 cryptonote::transaction construct_carrot_pruned_transaction_fake_inputs(
     const std::vector<carrot::CarrotPaymentProposalV1> &normal_payment_proposals,
     const std::vector<carrot::CarrotPaymentProposalVerifiableSelfSendV1> &selfsend_payment_proposals,
+    const crypto::public_key &change_address_spend_pubkey,
+    const carrot::subaddress_index_extended &change_subaddr_index,
+    const carrot::view_balance_secret_device *s_view_balance_dev,
+    const carrot::view_incoming_key_device &k_view_incoming_dev);
+cryptonote::transaction construct_carrot_pruned_transaction_fake_inputs(
+    const std::vector<carrot::CarrotPaymentProposalV1> &normal_payment_proposals,
+    const std::vector<carrot::CarrotPaymentProposalVerifiableSelfSendV1> &selfsend_payment_proposals,
     const cryptonote::account_keys &acc_keys);
 //----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------

--- a/tests/unit_tests/wallet_hot_cold.cpp
+++ b/tests/unit_tests/wallet_hot_cold.cpp
@@ -46,7 +46,7 @@ static std::vector<wallet2_basic::transfer_details> hot_scan_into_transfer_detai
 {
     const auto enote_scan_infos = tools::wallet::view_incoming_scan_transaction(tx,
         bob.legacy_acb.get_keys(),
-        bob.subaddress_map_cn());
+        bob.subaddress_map);
     std::vector<wallet2_basic::transfer_details> res;
     for (std::size_t local_output_index = 0; local_output_index < enote_scan_infos.size(); ++local_output_index)
     {

--- a/tests/unit_tests/wallet_scanning.cpp
+++ b/tests/unit_tests/wallet_scanning.cpp
@@ -29,6 +29,7 @@
 #include "gtest/gtest.h"
 
 #include "carrot_impl/address_device_ram_borrowed.h"
+#include "carrot_impl/subaddress_map_legacy.h"
 #include "carrot_impl/tx_builder_inputs.h"
 #include "carrot_mock_helpers.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
@@ -166,7 +167,7 @@ TEST(wallet_scanning, view_scan_long_payment_id)
             tools::wallet::view_incoming_scan_transaction(tx,
                 bob_addr_dev,
                 bob_hybrid_addr_dev,
-                {{bob_main_spend_pubkey, {}}}); // use a fake subaddress map with just the provided address in it
+                carrot::subaddress_map_legacy{{{bob_main_spend_pubkey, {}}}}); // use a fake subaddress map with just the provided address in it
 
         bool matched = false;
         for (const auto &enote_scan_info : enote_scan_infos)
@@ -246,7 +247,7 @@ TEST(wallet_scanning, view_scan_short_payment_id)
             tools::wallet::view_incoming_scan_transaction(tx,
                 bob_addr_dev,
                 bob_hybrid_addr_dev,
-                {{bob_main_spend_pubkey, {}}}); // use a fake subaddress map with just the provided address in it
+                carrot::subaddress_map_legacy{{{bob_main_spend_pubkey, {}}}}); // use a fake subaddress map with just the provided address in it
 
         bool matched = false;
         for (const auto &enote_scan_info : enote_scan_infos)

--- a/tests/unit_tests/wallet_scanning.cpp
+++ b/tests/unit_tests/wallet_scanning.cpp
@@ -165,7 +165,7 @@ TEST(wallet_scanning, view_scan_long_payment_id)
         // just with the proper ECDH
         std::vector<std::optional<tools::wallet::enote_view_incoming_scan_info_t>> enote_scan_infos = 
             tools::wallet::view_incoming_scan_transaction(tx,
-                bob_addr_dev.get_view_incoming_key_device(),
+                bob_addr_dev,
                 bob_addr_dev,
                 carrot::subaddress_map_legacy{{{bob_main_spend_pubkey, {}}}}); // use a fake subaddress map with just the provided address in it
 
@@ -245,7 +245,7 @@ TEST(wallet_scanning, view_scan_short_payment_id)
         // just with the proper ECDH
         std::vector<std::optional<tools::wallet::enote_view_incoming_scan_info_t>> enote_scan_infos = 
             tools::wallet::view_incoming_scan_transaction(tx,
-                bob_addr_dev.get_view_incoming_key_device(),
+                bob_addr_dev,
                 bob_addr_dev,
                 carrot::subaddress_map_legacy{{{bob_main_spend_pubkey, {}}}}); // use a fake subaddress map with just the provided address in it
 

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -31,6 +31,7 @@
 #include "carrot_core/config.h"
 #include "carrot_core/exceptions.h"
 #include "carrot_impl/format_utils.h"
+#include "carrot_impl/subaddress_map_legacy.h"
 #include "carrot_mock_helpers.h"
 #include "cryptonote_core/blockchain.h"
 #include "cryptonote_core/tx_verification_utils.h"
@@ -101,7 +102,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_1)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         dsts,
         /*fee_per_weight=*/1,
         /*extra=*/{},
@@ -162,7 +163,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_2)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(
         transfers,
-        alice.subaddress_map_cn(),
+        carrot::subaddress_map_legacy(alice.subaddress_map_cn()),
         dsts,
         /*fee_per_weight=*/1,
         /*extra=*/{},
@@ -237,7 +238,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_3)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         dsts,
         /*fee_per_weight=*/1,
         /*extra=*/{},
@@ -291,7 +292,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_4)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         dsts,
         fee_per_weight,
         /*extra=*/{},
@@ -321,7 +322,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_4)
     // Check that non-fee-subtractable fails
     EXPECT_THROW(tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         dsts,
         fee_per_weight,
         /*extra=*/{},
@@ -344,7 +345,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_1)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         {transfers.front().m_key_image},
         bob.get_keys().m_account_address,
         /*is_subaddress=*/false,
@@ -378,7 +379,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_2)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         {transfers.front().m_key_image},
         bob.get_keys().m_account_address,
         /*is_subaddress=*/false,
@@ -420,7 +421,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_3)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         {transfers.front().m_key_image},
         alice.get_keys().m_account_address,
         /*is_subaddress=*/false,
@@ -495,7 +496,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_4)
     // make tx proposals
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         selected_key_images,
         bob.get_keys().m_account_address,
         /*is_subaddress=*/false,
@@ -579,7 +580,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_5)
     // make tx proposals
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         selected_key_images,
         alice.get_keys().m_account_address,
         /*is_subaddress=*/false,
@@ -666,7 +667,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_sweep_6)
     // make tx proposals
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_sweep(
         transfers,
-        {{alice.get_keys().m_account_address.m_spend_public_key, {}}},
+        carrot::subaddress_map_legacy{{{alice.get_keys().m_account_address.m_spend_public_key, {}}}},
         selected_key_images,
         alice.get_keys().m_account_address,
         /*is_subaddress=*/false,
@@ -775,7 +776,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = 
         tools::wallet::make_carrot_transaction_proposals_wallet2_transfer( // stupidly long function name ;(
             alice.m_transfers,
-            alice.m_subaddresses,
+            carrot::subaddress_map_legacy(alice.m_subaddresses),
             {cryptonote::tx_destination_entry(out_amount, bob_main_addr, false)},
             /*fee_per_weight=*/1,
             /*extra=*/{},

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -733,7 +733,6 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
     bob.set_offline(true);
     alice.generate("", "");
     bob.generate("", "");
-    const cryptonote::account_keys &alice_keys = alice.get_account().get_keys();
     const cryptonote::account_public_address alice_main_addr = alice.get_account().get_keys().m_account_address;
     const cryptonote::account_public_address bob_main_addr = bob.get_account().get_keys().m_account_address;
     bc.init_wallet_for_starting_block(alice);
@@ -795,7 +794,10 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
     tx = tools::wallet::finalize_all_fcmp_pp_proofs(tx_proposal,
         alice.m_tree_cache,
         *alice.m_curve_trees,
-        alice_keys);
+        *alice.get_hybrid_address_device(),
+        *alice.get_view_incoming_key_device(),
+        alice.get_view_balance_secret_device().get(),
+        *alice.get_spend_device());
 
     // 8.
     LOG_PRINT_L2("Hello, Mr. Blobby");

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -163,7 +163,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_2)
 
     const std::vector<carrot::CarrotTransactionProposalV1> tx_proposals = tools::wallet::make_carrot_transaction_proposals_wallet2_transfer(
         transfers,
-        carrot::subaddress_map_legacy(alice.subaddress_map_cn()),
+        alice.subaddress_map,
         dsts,
         /*fee_per_weight=*/1,
         /*extra=*/{},
@@ -208,7 +208,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_2)
     EXPECT_NE(normal_payment_proposal.randomness, carrot::janus_anchor_t{});
     EXPECT_EQ(spending_subaddr_account, selfsend_payment_proposal.subaddr_index.index.major);
     EXPECT_EQ(0, selfsend_payment_proposal.subaddr_index.index.minor);
-    EXPECT_EQ(alice.subaddress({{spending_subaddr_account, 0}, carrot::AddressDeriveType::PreCarrot}).address_spend_pubkey,
+    EXPECT_EQ(alice.subaddress({{spending_subaddr_account, 0}, carrot::AddressDeriveType::Carrot}).address_spend_pubkey,
         selfsend_payment_proposal.proposal.destination_address_spend_pubkey);
     EXPECT_EQ(carrot::CarrotEnoteType::CHANGE, selfsend_payment_proposal.proposal.enote_type);
     EXPECT_FALSE(selfsend_payment_proposal.proposal.internal_message);
@@ -795,7 +795,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
     tx = tools::wallet::finalize_all_fcmp_pp_proofs(tx_proposal,
         alice.m_tree_cache,
         *alice.m_curve_trees,
-        *alice.get_hybrid_address_device(),
+        *alice.get_address_device(),
         *alice.get_view_incoming_key_device(),
         alice.get_view_balance_secret_device().get(),
         *alice.get_spend_device());


### PR DESCRIPTION
Adds a Carrot/FCMP++ spend device interface and integrates it into `tx_builder`. Overhauls the address device interface suite, unifying Cryptonote/Carrot/hybrid address device interfaces. Adds subaddress map interface. Integrates these new interfaces into wallet tooling. Changes composed devices to use shared pointers instead of references. Adds a test for view-incoming scanning to hybrid sender/receiver key hierarchies using `scanning_tools.h`.

This gets us closer to HW device and hybrid hierarchy support.

Depends on #214 