### PR TITLE
fcmp++: daemon sets max arenas glibc will use

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -453,6 +453,9 @@ namespace cryptonote
   {
     start_time = std::time(nullptr);
 
+    // Necessary for FCMP++ sync on Linux platforms, especially with limited memory
+    rct::limitMaxMemArenas();
+
     const bool regtest = command_line::get_arg(vm, arg_regtest_on);
     if (test_options != NULL || regtest)
     {

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -44,6 +44,10 @@
 #include "device/device.hpp"
 #include "serialization/crypto.h"
 
+#if defined(__GLIBC__)
+#include <malloc.h>
+#endif
+
 using namespace crypto;
 using namespace std;
 
@@ -1746,5 +1750,27 @@ done:
           return false;
       }
       return true;
+    }
+
+    void limitMaxMemArenas()
+    {
+#ifdef M_ARENA_MAX
+      tools::threadpool &tpool = tools::threadpool::getInstanceForCompute();
+      const std::size_t n_threads = std::max<std::size_t>(1, tpool.get_max_concurrency());
+
+      // See mallopt and M_ARENA_MAX at: https://man7.org/linux/man-pages/man3/mallopt.3.html
+      int r = mallopt(M_ARENA_MAX, n_threads);
+      if (r == 1)
+      {
+        MDEBUG("Set max arenas to " << n_threads);
+        return;
+      }
+
+      MWARNING("Failed to set max arenas, the system may use more memory than expected during sync.");
+#else
+      MDEBUG("System does not have mallopt and M_ARENA_MAX setting. This setting is crucial for some Linux platforms to"
+        << " avoid OOM's when batch verifying FCMP++ txs. If we see OOM's in the future when batch verifying on a non-"
+        << "Linux platform, then check the system allocator behavior and see if it has a setting similar to mallopt");
+#endif
     }
 }

--- a/src/ringct/rctSigs.cpp
+++ b/src/ringct/rctSigs.cpp
@@ -1758,11 +1758,16 @@ done:
       tools::threadpool &tpool = tools::threadpool::getInstanceForCompute();
       const std::size_t n_threads = std::max<std::size_t>(1, tpool.get_max_concurrency());
 
+      // Use at least 2 arenas always to match glibc's default minimum
+      // https://github.com/bminor/glibc/blob/40a751b0044114488e841f0223e630596c527c53/malloc/arena.c#L824-L834
+      // https://github.com/bminor/glibc/blob/40a751b0044114488e841f0223e630596c527c53/malloc/malloc.c#L1974
+      const std::size_t max_arenas = std::max<std::size_t>(2, n_threads);
+
       // See mallopt and M_ARENA_MAX at: https://man7.org/linux/man-pages/man3/mallopt.3.html
-      int r = mallopt(M_ARENA_MAX, n_threads);
+      int r = mallopt(M_ARENA_MAX, max_arenas);
       if (r == 1)
       {
-        MDEBUG("Set max arenas to " << n_threads);
+        MDEBUG("Set max arenas to " << max_arenas);
         return;
       }
 

--- a/src/ringct/rctSigs.h
+++ b/src/ringct/rctSigs.h
@@ -147,6 +147,17 @@ namespace rct {
 
     // Split into batches and verify each batch in parallel
     bool batchVerifyFcmpPpProofs(std::vector<fcmp_pp::FcmpPpVerifyInput> &&fcmp_pp_verify_inputs);
+
+    // The default libc allocator on most Linux systems may cache allocated memory for reuse.
+    // As a result, verifying many large batches of FCMP++ proofs in multithreaded contexts
+    // can end up using a lot of memory that does not get released back to the OS, even
+    // though memory is already freed.
+    // This function uses the mallopt syscall to limit the max number of "arenas" the system
+    // may use, setting it to the number of threads the system has. This way there won't
+    // be more memory allocated and kept around than expected in a potentially unbounded
+    // number of arenas.
+    // More on this here: https://gotplt.org/posts/malloc-per-thread-arenas-in-glibc.html
+    void limitMaxMemArenas();
 }
 #endif  /* RCTSIGS_H */
 


### PR DESCRIPTION
This setting ensures the daemon won't use more memory than expected when batch verifying FCMP++ txs. This is the crucial setting necessary for @SNeedlewoods  to avoid consistent OOM's when syncing as noted [here](https://github.com/seraphis-migration/monero/issues/202#issuecomment-3487818091).

What was happening: @SNeedlewoods' 2 thread machine with 8GB RAM must have been using more than 10 arenas, which would mean the allocator was not releasing over 8GB of memory back to the OS, even though the memory used for batch verifying FCMP++ txs is freed properly.

This PR ensures a 2 thread Linux machine using glibc's allocator would use a max of 2 arenas, ensuring that more memory doesn't get allocated and cached than expected.

Hopefully the comments in the PR / links are also helpful in explaining the underlying reasoning.