### PR TITLE
serialization: revert va_args_commaprefix usage

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -7310,8 +7310,9 @@ void BlockchainLMDB::migrate_5_6()
           };
 
         auto output_context = fcmp_pp::curve_trees::OutputContext{
-            .output_id   = output_id,
-            .output_pair = std::move(output_pair)
+            .output_id       = output_id,
+            .torsion_checked = 0,
+            .output_pair     = std::move(output_pair)
           };
 
         // Get the output's last locked block

--- a/src/carrot_impl/format_utils.cpp
+++ b/src/carrot_impl/format_utils.cpp
@@ -556,6 +556,7 @@ rct::rctSigPrunable store_fcmp_proofs_to_rct_prunable_v1(
         memcpy(pseudoOuts[i].bytes, rerandomized_outputs.at(i).input.C_tilde, sizeof(rct::key));
 
     return rct::rctSigPrunable{
+        .rangeSigs = {},
         .bulletproofs = {},
         .bulletproofs_plus = {bulletproof_plus},
         .MGs = {},

--- a/src/common/va_args.h
+++ b/src/common/va_args.h
@@ -33,13 +33,3 @@
 #define PP_THIRD_ARG(a,b,c,...) c
 #define VA_OPT_SUPPORTED_I(...) PP_THIRD_ARG(__VA_OPT__(,),true,false,)
 #define VA_OPT_SUPPORTED VA_OPT_SUPPORTED_I(?)
-
-// VA_ARGS_COMMAPREFIX(): VA_ARGS_COMMAPREFIX(__VA_ARGS__) expands to __VA_ARGS__ with a comma in
-// front if more than one argument, else nothing.
-// If __VA_OPT__ supported, use that. Else, use GCC's ,## hack
-#if VA_OPT_SUPPORTED
-#    define VA_ARGS_COMMAPREFIX(...) __VA_OPT__(,) __VA_ARGS__
-#else
-#    define VA_ARGS_COMMAPREFIX(...) , ## __VA_ARGS__
-#endif
-

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -191,9 +191,9 @@ inline auto do_serialize(Archive &ar, T &v, Args&&... args)
  * VARINT_FIELD_F(). Otherwise, this macro is similar to
  * BEGIN_SERIALIZE_OBJECT(), as you should list only field serializations.
  */
-#define BEGIN_SERIALIZE_OBJECT_FN(stype, ...)                                           \
-  template <bool W, template <bool> class Archive>                                      \
-  bool do_serialize_object(Archive<W> &ar, stype &v VA_ARGS_COMMAPREFIX(__VA_ARGS__)) {
+#define BEGIN_SERIALIZE_OBJECT_FN(stype)           \
+  template <bool W, template <bool> class Archive> \
+  bool do_serialize_object(Archive<W> &ar, stype &v) {
 
 /*! \macro DECLARE_SERIALIZE_OBJECT
  *
@@ -219,10 +219,10 @@ inline auto do_serialize(Archive &ar, T &v, Args&&... args)
  *
  * \brief serializes a field \a f tagged \a t  
  */
-#define FIELD_N(t, f, ...)                                    \
+#define FIELD_N(t, f)                    \
   do {							\
     ar.tag(t);						\
-    bool r = do_serialize(ar, f VA_ARGS_COMMAPREFIX(__VA_ARGS__)); \
+    bool r = do_serialize(ar, f); \
     if (!r || !ar.good()) return false;			\
   } while(0);
 
@@ -241,7 +241,7 @@ inline auto do_serialize(Archive &ar, T &v, Args&&... args)
  *
  * \brief tags the field with the variable name and then serializes it (for use in a free function)
  */
-#define FIELD_F(f, ...) FIELD_N(#f, v.f VA_ARGS_COMMAPREFIX(__VA_ARGS__))
+#define FIELD_F(f) FIELD_N(#f, v.f)
 
 /*! \macro FIELDS(f)
  *

--- a/src/serialization/serialization.h
+++ b/src/serialization/serialization.h
@@ -191,17 +191,23 @@ inline auto do_serialize(Archive &ar, T &v, Args&&... args)
  * VARINT_FIELD_F(). Otherwise, this macro is similar to
  * BEGIN_SERIALIZE_OBJECT(), as you should list only field serializations.
  */
-#define BEGIN_SERIALIZE_OBJECT_FN(stype)           \
-  template <bool W, template <bool> class Archive> \
-  bool do_serialize_object(Archive<W> &ar, stype &v) {
+#if VA_OPT_SUPPORTED
+  #define BEGIN_SERIALIZE_OBJECT_FN(stype, ...)      \
+    template <bool W, template <bool> class Archive> \
+    bool do_serialize_object(Archive<W> &ar, stype &v __VA_OPT__(,) __VA_ARGS__) {
+#else
+  #define BEGIN_SERIALIZE_OBJECT_FN(stype, ...)      \
+    template <bool W, template <bool> class Archive> \
+    bool do_serialize_object(Archive<W> &ar, stype &v, ## __VA_ARGS__) {
+#endif
 
 /*! \macro DECLARE_SERIALIZE_OBJECT
  *
  * \brief forward declare a BEGIN_SERIALIZE_OBJECT_FN function
 */
-#define DECLARE_SERIALIZE_OBJECT(stype, ...)                                           \
-  template <bool W, template <bool> class Archive>                                     \
-  bool do_serialize_object(Archive<W> &ar, stype &v VA_ARGS_COMMAPREFIX(__VA_ARGS__));
+#define DECLARE_SERIALIZE_OBJECT(stype)            \
+  template <bool W, template <bool> class Archive> \
+  bool do_serialize_object(Archive<W> &ar, stype &v);
 
 /*! \macro PREPARE_CUSTOM_VECTOR_SERIALIZATION
  */


### PR DESCRIPTION
Cherry-picks PR https://github.com/monero-project/monero/pull/10214/ and reworks `BEGIN_SERIALIZE_OBJECT_FN` to use fallback for GCC 7. Also modifies some more aggregate initializations to work on GCC 7.