### PR TITLE
carrot_impl: fix input selection subroutine, and enable limited inputs

### DIFF
--- a/src/carrot_impl/input_selection.h
+++ b/src/carrot_impl/input_selection.h
@@ -173,8 +173,10 @@ std::vector<std::set<std::size_t>> form_preferred_input_candidate_subsets(
  * Transaction input counts are trivially observable on-chain, so picking a wrong input count when
  * given the chance between multiple choices can have privacy consequences. The purpose of this
  * function is to determine the order in which we should try to select a certain number of inputs.
+ *
+ * param: max_n_inputs - maximum number of inputs to use in selection, set 0 to to use consensus limit
  */
-std::vector<std::size_t> get_input_counts_in_preferred_order();
+std::vector<std::size_t> get_input_counts_in_preferred_order(std::size_t max_n_inputs);
 /**
  * brief: make_single_transfer_input_selector - a customizable input selector for single (i.e. not batched) transfers
  * param: input_candidates -
@@ -198,6 +200,7 @@ select_inputs_func_t make_single_transfer_input_selector(
     const epee::span<const InputCandidate> input_candidates,
     const epee::span<const input_selection_policy_t> policies,
     const std::uint32_t flags,
+    const std::size_t max_n_inputs,
     std::set<size_t> *selected_input_indices_out);
 
 namespace ispolicy

--- a/src/carrot_impl/multi_tx_proposal_utils.cpp
+++ b/src/carrot_impl/multi_tx_proposal_utils.cpp
@@ -55,6 +55,7 @@ void make_multiple_carrot_transaction_proposals_transfer(
     std::vector<InputCandidate> &&input_candidates,
     const epee::span<const input_selection_policy_t> input_selection_policies,
     const std::uint32_t input_selection_flags,
+    const std::size_t max_n_inputs,
     const crypto::public_key &change_address_spend_pubkey,
     const subaddress_index_extended &change_address_index,
     const std::set<std::size_t> &subtractable_normal_payment_proposals,
@@ -104,6 +105,7 @@ void make_multiple_carrot_transaction_proposals_transfer(
             epee::to_span(input_candidates),
             input_selection_policies,
             input_selection_flags,
+            max_n_inputs,
             &selected_transfer_indices);
 
         // make proposal

--- a/src/carrot_impl/multi_tx_proposal_utils.h
+++ b/src/carrot_impl/multi_tx_proposal_utils.h
@@ -73,6 +73,7 @@ void make_multiple_carrot_transaction_proposals_transfer(
     std::vector<InputCandidate> &&input_candidates,
     const epee::span<const input_selection_policy_t> input_selection_policies,
     const std::uint32_t input_selection_flags,
+    const std::size_t max_n_inputs,
     const crypto::public_key &change_address_spend_pubkey,
     const subaddress_index_extended &change_address_index,
     const std::set<std::size_t> &subtractable_normal_payment_proposals,

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -524,6 +524,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const std::set<uint32_t> &subaddr_indices,
     const rct::xmr_amount ignore_above,
     const rct::xmr_amount ignore_below,
+    const std::size_t max_n_inputs,
     std::set<std::uint32_t> subtract_fee_from_outputs,
     const std::uint64_t top_block_index)
 {
@@ -587,6 +588,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
         std::move(input_candidates),
         {&isp, 1},
         input_selection_flags,
+        max_n_inputs,
         change_address_spend_pubkey,
         change_address_index,
         subtractable_normal_payment_proposals,

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -188,6 +188,7 @@ std::vector<carrot::CarrotTransactionProposalV1> make_carrot_transaction_proposa
     const std::set<uint32_t> &subaddr_indices,
     const rct::xmr_amount ignore_above,
     const rct::xmr_amount ignore_below,
+    const std::size_t max_n_inputs,
     std::set<std::uint32_t> subtract_fee_from_outputs,
     const std::uint64_t top_block_index);
 /**

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10629,7 +10629,15 @@ static uint32_t get_count_above(const std::vector<wallet2::transfer_details> &tr
 // This system allows for sending (almost) the entire balance, since it does
 // not generate spurious change in all txes, thus decreasing the instantaneous
 // usable balance.
-std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs)
+std::vector<wallet2::pending_tx> wallet2::create_transactions_2(
+  std::vector<cryptonote::tx_destination_entry> dsts,
+  const size_t fake_outs_count,
+  fee_priority priority,
+  const std::vector<uint8_t>& extra,
+  uint32_t subaddr_account,
+  std::set<uint32_t> subaddr_indices,
+  const unique_index_container& subtract_fee_from_outputs,
+  const std::size_t max_n_inputs)
 {
   boost::lock_guard refresh_lock(m_refresh_mutex);
 
@@ -10650,6 +10658,7 @@ std::vector<wallet2::pending_tx> wallet2::create_transactions_2(std::vector<cryp
       subaddr_indices,
       ignore_outputs_above(),
       ignore_outputs_below(),
+      max_n_inputs,
       subtract_fee_from_outputs,
       get_top_block_index(*this));
     std::vector<pending_tx> ptx_vector;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -710,7 +710,15 @@ private:
      *
      * Transfer-style means that transactions are added until all payment outlays are fulfilled.
      */
-    std::vector<wallet2::pending_tx> create_transactions_2(std::vector<cryptonote::tx_destination_entry> dsts, const size_t fake_outs_count, fee_priority priority, const std::vector<uint8_t>& extra, uint32_t subaddr_account, std::set<uint32_t> subaddr_indices, const unique_index_container& subtract_fee_from_outputs = {});     // pass subaddr_indices by value on purpose
+    std::vector<wallet2::pending_tx> create_transactions_2(
+      std::vector<cryptonote::tx_destination_entry> dsts,
+      const size_t fake_outs_count,
+      fee_priority priority,
+      const std::vector<uint8_t>& extra,
+      uint32_t subaddr_account,
+      std::set<uint32_t> subaddr_indices, // pass subaddr_indices by value on purpose
+      const unique_index_container& subtract_fee_from_outputs = {},
+      const std::size_t max_n_inputs = 0);
     /**
      * brief: create_transactions_all: create "sweep-all" style txs (or tx proposals in hot/cold & multisig wallets)
      * param: below - the money amount below which input selection should pull inputs from; higher amounts are excluded

--- a/tests/core_tests/fcmp_pp.cpp
+++ b/tests/core_tests/fcmp_pp.cpp
@@ -403,6 +403,7 @@ bool gen_fcmp_pp_tx_validation_base::generate_with(std::vector<test_event_entry>
       /*subaddr_indices=*/{},
       /*ignore_above=*/MONEY_SUPPLY,
       /*ignore_below=*/0,
+      /*max_n_inputs=*/0,
       {},
       n_synced_blocks - 1);
   CHECK_AND_ASSERT_MES(tx_proposals.size() == 1, false, "Expected 1 tx proposal");

--- a/tests/unit_tests/carrot_impl.cpp
+++ b/tests/unit_tests/carrot_impl.cpp
@@ -1220,6 +1220,7 @@ TEST(carrot_impl, make_single_transfer_input_selector_not_enough_money_1)
     select_inputs_func_t input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
         epee::to_span(policies),
         flags,
+        0,
         &selected_input_indices);
 
     const boost::multiprecision::uint128_t nominal_output_sum = 369;
@@ -1264,6 +1265,7 @@ TEST(carrot_impl, make_single_transfer_input_selector_not_enough_money_2)
     select_inputs_func_t input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
         epee::to_span(policies),
         flags,
+        0,
         &selected_input_indices);
 
     const boost::multiprecision::uint128_t nominal_output_sum = 369;
@@ -1335,6 +1337,7 @@ TEST(carrot_impl, make_single_transfer_input_selector_not_enough_money_3)
     select_inputs_func_t input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
         epee::to_span(policies),
         flags,
+        0,
         &selected_input_indices);
 
     const size_t num_normal_payment_proposals = 1;
@@ -1378,6 +1381,7 @@ TEST(carrot_impl, make_single_transfer_input_selector_greedy_aging_1)
     select_inputs_func_t input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
         epee::to_span(policies),
         flags,
+        0,
         &selected_input_indices);
 
     const boost::multiprecision::uint128_t nominal_output_sum = 369;
@@ -1437,6 +1441,7 @@ TEST(carrot_impl, make_single_transfer_input_selector_greedy_aging_2)
     select_inputs_func_t input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
         epee::to_span(policies),
         flags,
+        0,
         &selected_input_indices);
 
     const boost::multiprecision::uint128_t nominal_output_sum = 369;
@@ -1524,6 +1529,7 @@ TEST(carrot_impl, make_single_transfer_input_selector_greedy_aging_3)
     select_inputs_func_t input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
         epee::to_span(policies),
         flags,
+        0,
         &selected_input_indices);
 
     const boost::multiprecision::uint128_t nominal_output_sum = 223;
@@ -1558,6 +1564,185 @@ TEST(carrot_impl, make_single_transfer_input_selector_greedy_aging_3)
 
     // this particular set of 4 indices is the indices of the 4 oldest inputs
     ASSERT_EQ(std::set<size_t>({0, 1, 2, 4}), selected_input_indices);
+}
+//----------------------------------------------------------------------------------------------------------------------
+TEST(carrot_impl, make_single_transfer_input_selector_greedy_aging_4)
+{
+    // Give 10 input candidates, greater than 4, less than or equal to 7, are
+    // needed to fund the output amount. Transaction input count should be 8
+    // without limiting input count. After limiting input count to 7,
+    // transaction input count should be less than or equal to 7.
+
+    const std::vector<InputCandidate> input_candidates = {
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 55
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 22
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 11
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 88
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 72
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 52
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 39
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 12
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 71
+        },
+        InputCandidate {
+            .core = CarrotSelectedInput {
+                .amount = 100,
+                .input = gen_output_opening_hint(),
+            },
+            .is_pre_carrot = false,
+            .is_external = false,
+            .block_index = 85
+        }
+    };
+
+    const std::vector<input_selection_policy_t> policies = { &carrot::ispolicy::select_greedy_aging };
+
+    const uint32_t flags = 0;
+
+    std::set<size_t> selected_input_indices;
+    select_inputs_func_t input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
+        epee::to_span(policies),
+        flags,
+        /*max_n_inputs=*/0,
+        &selected_input_indices);
+
+    const boost::multiprecision::uint128_t nominal_output_sum = 577;
+
+    const std::map<size_t, rct::xmr_amount> fee_by_input_count = {
+        { 1, 10},
+        { 2, 20},
+        { 3, 29},
+        { 4, 37},
+        { 5, 44},
+        { 6, 50},
+        { 7, 55},
+        { 8, 59},
+        { 9, 62},
+        {10, 64}
+    };
+
+    const size_t num_normal_payment_proposals = 1;
+    const size_t num_selfsend_payment_proposals = 1;
+
+    std::vector<CarrotSelectedInput> selected_inputs;
+    input_selector(nominal_output_sum,
+        fee_by_input_count,
+        num_normal_payment_proposals,
+        num_selfsend_payment_proposals,
+        selected_inputs);
+
+    std::size_t expected_n_inputs = 8;
+    ASSERT_EQ(expected_n_inputs, selected_input_indices.size()); // discretization yay
+    ASSERT_EQ(expected_n_inputs, selected_inputs.size());
+    std::set<crypto::public_key> selected_otas;
+    for (const CarrotSelectedInput &selected_input : selected_inputs)
+        selected_otas.insert(onetime_address_ref(selected_input.input));
+    ASSERT_EQ(expected_n_inputs, selected_otas.size());
+
+    // this particular set of 8 indices is the indices of the 8 oldest inputs
+    ASSERT_EQ(std::set<size_t>({0, 1, 2, 4, 5, 6, 7, 8}), selected_input_indices);
+
+    //*********
+    // now limited to 7
+
+    static constexpr std::size_t max_n_inputs = 7;
+    static_assert(max_n_inputs <= FCMP_PLUS_PLUS_MAX_INPUTS);
+
+    input_selector = make_single_transfer_input_selector(epee::to_span(input_candidates),
+        epee::to_span(policies),
+        flags,
+        max_n_inputs,
+        &selected_input_indices);
+
+    selected_input_indices.clear();
+    selected_inputs.clear();
+    selected_otas.clear();
+    input_selector(nominal_output_sum,
+        fee_by_input_count,
+        num_normal_payment_proposals,
+        num_selfsend_payment_proposals,
+        selected_inputs);
+
+    expected_n_inputs = 7;
+    ASSERT_EQ(expected_n_inputs, selected_input_indices.size());
+    ASSERT_EQ(expected_n_inputs, selected_inputs.size());
+    for (const CarrotSelectedInput &selected_input : selected_inputs)
+        selected_otas.insert(onetime_address_ref(selected_input.input));
+    ASSERT_EQ(expected_n_inputs, selected_otas.size());
+
+    // this particular set of 7 indices is the indices of the 7 oldest inputs
+    ASSERT_EQ(std::set<size_t>({0, 1, 2, 5, 6, 7, 8}), selected_input_indices);
 }
 //----------------------------------------------------------------------------------------------------------------------
 TEST(carrot_impl, make_multiple_carrot_transaction_proposals_sweep_1)

--- a/tests/unit_tests/wallet_tx_builder.cpp
+++ b/tests/unit_tests/wallet_tx_builder.cpp
@@ -109,6 +109,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_1)
         /*subaddr_indices=*/{},
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
+        /*max_n_inputs=*/0,
         {},
         top_block_index);
 
@@ -170,6 +171,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_2)
         /*subaddr_indices=*/{},
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
+        /*max_n_inputs=*/0,
         {},
         top_block_index);
 
@@ -245,6 +247,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_3)
         /*subaddr_indices=*/{},
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
+        /*max_n_inputs=*/0,
         /*subtract_fee_from_outputs=*/{0},
         top_block_index);
 
@@ -299,6 +302,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_4)
         /*subaddr_indices=*/{},
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
+        /*max_n_inputs=*/0,
         /*subtract_fee_from_outputs=*/{0},
         top_block_index);
 
@@ -329,6 +333,7 @@ TEST(wallet_tx_builder, make_carrot_transaction_proposals_wallet2_transfer_4)
         /*subaddr_indices=*/{},
         /*ignore_above=*/MONEY_SUPPLY,
         /*ignore_below=*/0,
+        /*max_n_inputs=*/0,
         /*subtract_fee_from_outputs=*/{},
         top_block_index), carrot::not_enough_money);
 }
@@ -784,6 +789,7 @@ TEST(wallet_tx_builder, wallet2_scan_propose_sign_prove_member_and_scan_1)
             /*subaddr_indices=*/{},
             /*ignore_above=*/std::numeric_limits<rct::xmr_amount>::max(),
             /*ignore_below=*/0,
+            /*max_n_inputs=*/0,
             {},
             /*top_block_index=*/bc.height()-1);
     


### PR DESCRIPTION
Resolves #200 and also fixes an input selection bug which may have been the cause of the sporadic transaction building failures.

Users of `wallet2` can pass a value for `max_n_inputs` to limit number of inputs used in input selection.