### PR TITLE
txpool: don't process txs that would push pool over capacity

### DIFF
--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -157,21 +157,12 @@ namespace cryptonote
       return false;
     }
 
-    if (version != nic_verified_hf_version && !cryptonote::ver_non_input_consensus(tx, tvc, version))
-    {
-      LOG_PRINT_L1("transaction " << id << " failed non-input consensus rule checks");
-      tvc.m_verifivation_failed = true; // should already be set, but just in case
-      return false;
-    }
-
-    uint64_t fee;
+    const uint64_t fee = get_tx_fee(tx);
     bool fee_good = false;
     try
     {
-      // get_tx_fee() can throw. It shouldn't throw because we check preconditions in
-      // ver_non_input_consensus(), but let's put it in a try block just in case.
-      fee = get_tx_fee(tx);
-      fee_good = kept_by_block || m_blockchain.check_fee(tx_weight, fee);
+      fee_good = kept_by_block ||
+        (check_max_txpool_weight(id, tx_weight, fee) && m_blockchain.check_fee(tx_weight, fee));
     }
     catch(...) {}
     if (!fee_good) // if fee calculation failed or fee in relayed tx is too low...
@@ -198,6 +189,13 @@ namespace cryptonote
       tvc.m_verifivation_failed = true;
       tvc.m_nonzero_unlock_time = true;
       tvc.m_no_drop_offense = true;
+      return false;
+    }
+
+    if (version != nic_verified_hf_version && !cryptonote::ver_non_input_consensus(tx, tvc, version))
+    {
+      LOG_PRINT_L1("transaction " << id << " failed non-input consensus rule checks");
+      tvc.m_verifivation_failed = true; // should already be set, but just in case
       return false;
     }
 
@@ -381,6 +379,30 @@ namespace cryptonote
   {
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     m_txpool_max_weight = bytes;
+  }
+  //---------------------------------------------------------------------------------
+  bool tx_memory_pool::check_max_txpool_weight(const crypto::hash &id, const size_t weight, const uint64_t fee) const
+  {
+    CRITICAL_REGION_LOCAL(m_transactions_lock);
+
+    const double tx_fee_per_byte = (double) fee / weight;
+    MDEBUG("Checking tx: " << id << ", fee/byte: " << tx_fee_per_byte << ", pool total weight: " << m_txpool_weight);
+
+    if ((weight + m_txpool_weight) < m_txpool_max_weight)
+      return true;
+    if (m_txs_by_fee_and_receive_time.size() <= 1)
+      return true;
+
+    const auto it = --m_txs_by_fee_and_receive_time.end();
+    if (it == m_txs_by_fee_and_receive_time.begin())
+      return true;
+
+    const double lowest_fee_per_byte = it->get_left().first;
+    if (tx_fee_per_byte > lowest_fee_per_byte)
+      return true;
+
+    LOG_PRINT_L1("transaction " << id << " does not pay a high enough fee to enter the pool, pool is at capacity");
+    return false;
   }
   //---------------------------------------------------------------------------------
   void tx_memory_pool::reduce_txpool_weight(size_t weight)

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -162,7 +162,7 @@ namespace cryptonote
     try
     {
       fee_good = kept_by_block ||
-        (check_max_txpool_weight(id, tx_weight, fee) && m_blockchain.check_fee(tx_weight, fee));
+        (check_pool_capacity(id, tx_weight, fee) && m_blockchain.check_fee(tx_weight, fee));
     }
     catch(...) {}
     if (!fee_good) // if fee calculation failed or fee in relayed tx is too low...
@@ -381,27 +381,32 @@ namespace cryptonote
     m_txpool_max_weight = bytes;
   }
   //---------------------------------------------------------------------------------
-  bool tx_memory_pool::check_max_txpool_weight(const crypto::hash &id, const size_t weight, const uint64_t fee) const
+  bool tx_memory_pool::check_pool_capacity(const crypto::hash &id, const size_t weight, const uint64_t fee) const
   {
+    if (weight == 0)
+      return true;
+
     CRITICAL_REGION_LOCAL(m_transactions_lock);
 
-    const double tx_fee_per_byte = (double) fee / weight;
-    MDEBUG("Checking tx: " << id << ", fee/byte: " << tx_fee_per_byte << ", pool total weight: " << m_txpool_weight);
-
+    // If the tx doesn't push the pool over the capacity limit, it fits! We can immediately return true
     if ((weight + m_txpool_weight) < m_txpool_max_weight)
       return true;
+
+    // If it does, then see if it pays a higher fee than any txs already in the pool
     if (m_txs_by_fee_and_receive_time.size() <= 1)
       return true;
-
     const auto it = --m_txs_by_fee_and_receive_time.end();
     if (it == m_txs_by_fee_and_receive_time.begin())
       return true;
 
+    const double fee_per_byte = (double) fee / weight;
+    MDEBUG("Check pool capacity for tx " << id << ", fee/byte: " << fee_per_byte << ", pool total weight: " << m_txpool_weight);
+
     const double lowest_fee_per_byte = it->get_left().first;
-    if (tx_fee_per_byte > lowest_fee_per_byte)
+    if (fee_per_byte > lowest_fee_per_byte)
       return true;
 
-    LOG_PRINT_L1("transaction " << id << " does not pay a high enough fee to enter the pool, pool is at capacity");
+    LOG_PRINT_L1("Pool is at capacity, and tx " << id << " does not pay a high enough fee to enter");
     return false;
   }
   //---------------------------------------------------------------------------------

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -622,6 +622,17 @@ namespace cryptonote
     void mark_double_spend(const transaction &tx);
 
     /**
+     * @brief don't accept new txs if pool is at capacity and the tx doesn't have a high enough fee
+     *
+     * @param txid the txid of the transaction to check
+     * @param weight the transaction weight
+     * @param fee the tx fee
+     *
+     * @return true if the transaction doesn't push the pool over capacity
+     */
+    bool check_max_txpool_weight(const crypto::hash &id, const size_t weight, const uint64_t fee) const;
+
+    /**
      * @brief prune lowest fee/byte txes till we're not above bytes
      *
      * if bytes is 0, use m_txpool_max_weight

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -622,15 +622,15 @@ namespace cryptonote
     void mark_double_spend(const transaction &tx);
 
     /**
-     * @brief don't accept new txs if pool is at capacity and the tx doesn't have a high enough fee
+     * @brief check if pool has capacity for the given tx
      *
      * @param txid the txid of the transaction to check
      * @param weight the transaction weight
      * @param fee the tx fee
      *
-     * @return true if the transaction doesn't push the pool over capacity
+     * @return true if the pool has capacity for the tx
      */
-    bool check_max_txpool_weight(const crypto::hash &id, const size_t weight, const uint64_t fee) const;
+    bool check_pool_capacity(const crypto::hash &id, const size_t weight, const uint64_t fee) const;
 
     /**
      * @brief prune lowest fee/byte txes till we're not above bytes

--- a/src/cryptonote_core/tx_pool.h
+++ b/src/cryptonote_core/tx_pool.h
@@ -624,7 +624,11 @@ namespace cryptonote
     /**
      * @brief check if pool has capacity for the given tx
      *
-     * @param txid the txid of the transaction to check
+     * If the tx would push the pool above its max weight limit, then the tx
+     * must pay a fee higher than txs in the pool already in order to enter the
+     * pool. Otherwise, the pool does not have capacity for the tx.
+     *
+     * @param txid the txid of the transaction to check, strictly used for logging
      * @param weight the transaction weight
      * @param fee the tx fee
      *


### PR DESCRIPTION
Assume a node's pool is at capacity (the total `m_txpool_weight` is right at `m_txpool_max_weight`).

The node doesn't need to process any further txs if the new tx's fee per byte is less than the smallest existing pool tx.

Without this PR, the node would process and add such txs to the pool, then immediately remove them via `prune`. A node could get stuck processing tons of txs that the node immediately removes after adding. Wasted work.

This PR introduces a simple short-circut when adding a tx: if the node doesn't have the capacity to add a relayed tx to its pool, then it'll short-circuit with `m_fee_too_low=true`, a no-drop-offense. It won't process the tx then remove it.

The stressnet pool is well above the max right now (@nahuhh is also running a node with capacity higher than the default). This PR helps keep a default node syncing smoothly while the network is in this state.

I would upstream this PR too once it's undergone a round of testing in stressnet as well.