### PR TITLE
Fix fcmp++ block serialiazationin ZMQ

### DIFF
--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -318,6 +318,11 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::b
   INSERT_INTO_JSON_OBJECT(dest, nonce, b.nonce);
   INSERT_INTO_JSON_OBJECT(dest, miner_tx, b.miner_tx);
   INSERT_INTO_JSON_OBJECT(dest, tx_hashes, b.tx_hashes);
+  if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+  {
+    INSERT_INTO_JSON_OBJECT(dest, fcmp_pp_n_tree_layers, b.fcmp_pp_n_tree_layers);
+    INSERT_INTO_JSON_OBJECT(dest, fcmp_pp_tree_root, b.fcmp_pp_tree_root);
+  }
 
   dest.EndObject();
 }
@@ -337,6 +342,12 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::block& b)
   GET_FROM_JSON_OBJECT(val, b.nonce, nonce);
   GET_FROM_JSON_OBJECT(val, b.miner_tx, miner_tx);
   GET_FROM_JSON_OBJECT(val, b.tx_hashes, tx_hashes);
+
+  if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)                             
+  {                                                                             
+    GET_FROM_JSON_OBJECT(val, b.fcmp_pp_n_tree_layers, fcmp_pp_n_tree_layers);
+    GET_FROM_JSON_OBJECT(val, b.fcmp_pp_tree_root, fcmp_pp_tree_root);        
+  }                                                                             
 }
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_v& txin)


### PR DESCRIPTION
This is causing problems for people trying to do fcmp++ testing in `monero-lws`.