### PR TITLE
fcmp++: use proof_len optimization + decompress in verify [stressnet]

### DIFF
--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -274,7 +274,7 @@ mkdir -p "$LOGDIR_BASE"
 # Download and archive Rust dependencies.
 # Version and Hash need to be updated when src/fcmp_pp/fcmp_pp_rust/Cargo.lock is updated.
 RUST_DEPS_VERSION=0
-RUST_DEPS_HASH="srhvi8sna6qafapa61hq2cbqy4n4z03i"
+RUST_DEPS_HASH="prdgg0zh2isiyi59zx9n6f99c9mccbsk"
 RUST_DEPS_ARCHIVE="rust_deps-${RUST_DEPS_VERSION}.tar.gz"
 RUST_DEPS_STORE_ITEM="/gnu/store/${RUST_DEPS_HASH}-${RUST_DEPS_ARCHIVE}"
 if [ ! -f "${RUST_DEPS_STORE_ITEM}" ]; then

--- a/contrib/guix/rust/config.toml
+++ b/contrib/guix/rust/config.toml
@@ -6,9 +6,9 @@ git = "https://github.com/kayabaNerve/crypto-bigint"
 branch = "c-repr"
 replace-with = "vendored-sources"
 
-[source."git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f"]
-git = "https://github.com/kayabaNerve/monero-oxide"
-rev = "34dab2669d54bf92631fa3a2b0b6764254a2066f"
+[source."git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8"]
+git = "https://github.com/j-berman/monero-oxide"
+rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8"
 replace-with = "vendored-sources"
 
 [source.vendored-sources]

--- a/src/fcmp_pp/fcmp_pp_rust/Cargo.lock
+++ b/src/fcmp_pp/fcmp_pp_rust/Cargo.lock
@@ -3,18 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,7 +187,7 @@ dependencies = [
 [[package]]
 name = "ec-divisors"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "crypto-bigint",
  "dalek-ff-group",
@@ -255,6 +243,7 @@ dependencies = [
  "helioselene",
  "monero-fcmp-plus-plus",
  "monero-generators",
+ "monero-io",
  "multiexp",
  "rand_core",
 ]
@@ -291,9 +280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "full-chain-membership-proofs"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -317,7 +312,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "generalized-bulletproofs"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -332,7 +327,7 @@ dependencies = [
 [[package]]
 name = "generalized-bulletproofs-circuit-abstraction"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "ciphersuite",
  "generalized-bulletproofs",
@@ -343,7 +338,7 @@ dependencies = [
 [[package]]
 name = "generalized-bulletproofs-ec-gadgets"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "ciphersuite",
  "generalized-bulletproofs-circuit-abstraction",
@@ -395,17 +390,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "ahash",
+ "foldhash",
 ]
 
 [[package]]
 name = "helioselene"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -478,7 +473,7 @@ dependencies = [
 [[package]]
 name = "monero-fcmp-plus-plus"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -492,6 +487,7 @@ dependencies = [
  "generic-array 1.1.1",
  "helioselene",
  "monero-generators",
+ "monero-io",
  "multiexp",
  "rand_chacha",
  "rand_core",
@@ -502,7 +498,7 @@ dependencies = [
 [[package]]
 name = "monero-generators"
 version = "0.4.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -522,10 +518,11 @@ dependencies = [
 [[package]]
 name = "monero-io"
 version = "0.1.0"
-source = "git+https://github.com/kayabaNerve/monero-oxide?rev=34dab2669d54bf92631fa3a2b0b6764254a2066f#34dab2669d54bf92631fa3a2b0b6764254a2066f"
+source = "git+https://github.com/j-berman/monero-oxide?rev=5c15bcc00575b26f9411264e9189d36d3f3edce8#5c15bcc00575b26f9411264e9189d36d3f3edce8"
 dependencies = [
  "curve25519-dalek",
  "std-shims",
+ "zeroize",
 ]
 
 [[package]]
@@ -743,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "std-shims"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbb9ed849fede2765386134c64bc8984081e8c8408bc9201b99c6e3143ec5e7"
+checksum = "227c4f8561598188d0df96dbe749824576174bba278b5b6bb2eacff1066067d0"
 dependencies = [
  "hashbrown",
  "rustversion",

--- a/src/fcmp_pp/fcmp_pp_rust/Cargo.toml
+++ b/src/fcmp_pp/fcmp_pp_rust/Cargo.toml
@@ -13,14 +13,16 @@ rand_core = { version = "0.6", default-features = false }
 multiexp = "0.4"
 ciphersuite = { version = "0.4.2", features = ["ed25519"] }
 dalek-ff-group = "0.4.4"
-helioselene = { git = "https://github.com/kayabaNerve/monero-oxide", rev = "34dab2669d54bf92631fa3a2b0b6764254a2066f" }
+helioselene = { git = "https://github.com/j-berman/monero-oxide", rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8" }
 
-generalized-bulletproofs = { git = "https://github.com/kayabaNerve/monero-oxide", rev = "34dab2669d54bf92631fa3a2b0b6764254a2066f" }
-ec-divisors = { git = "https://github.com/kayabaNerve/monero-oxide", rev = "34dab2669d54bf92631fa3a2b0b6764254a2066f", features = ["ed25519"] }
-full-chain-membership-proofs = { git = "https://github.com/kayabaNerve/monero-oxide", rev = "34dab2669d54bf92631fa3a2b0b6764254a2066f" }
+generalized-bulletproofs = { git = "https://github.com/j-berman/monero-oxide", rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8" }
+ec-divisors = { git = "https://github.com/j-berman/monero-oxide", rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8", features = ["ed25519"] }
+full-chain-membership-proofs = { git = "https://github.com/j-berman/monero-oxide", rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8" }
 
-monero-generators = { git = "https://github.com/kayabaNerve/monero-oxide", rev = "34dab2669d54bf92631fa3a2b0b6764254a2066f" }
-monero-fcmp-plus-plus = { git = "https://github.com/kayabaNerve/monero-oxide", rev = "34dab2669d54bf92631fa3a2b0b6764254a2066f" }
+monero-generators = { git = "https://github.com/j-berman/monero-oxide", rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8" }
+monero-fcmp-plus-plus = { git = "https://github.com/j-berman/monero-oxide", rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8" }
+
+monero-io = { git = "https://github.com/j-berman/monero-oxide", rev = "5c15bcc00575b26f9411264e9189d36d3f3edce8" }
 
 [patch.crates-io]
 crypto-bigint = { git = "https://github.com/kayabaNerve/crypto-bigint", branch = "c-repr" }

--- a/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
+++ b/src/fcmp_pp/fcmp_pp_rust/src/lib.rs
@@ -29,6 +29,7 @@ use monero_fcmp_plus_plus::{
 use monero_generators::{
     FCMP_PLUS_PLUS_U, FCMP_PLUS_PLUS_V, HELIOS_HASH_INIT, SELENE_HASH_INIT, T,
 };
+use monero_io::CompressedPoint;
 
 use std::os::raw::c_int;
 
@@ -134,10 +135,21 @@ fn ed25519_scalar_from_bytes(ed25519_scalar: *const u8) -> std::io::Result<Scala
     <Ed25519>::read_F(&mut ed25519_scalar)
 }
 
-fn hash_array_from_bytes(
-    h: *const u8,
-) -> std::result::Result<[u8; 32], std::array::TryFromSliceError> {
-    unsafe { core::slice::from_raw_parts(h, 32) }.try_into()
+fn to_byte_slice(x: *const u8) -> std::result::Result<[u8; 32], std::array::TryFromSliceError> {
+    unsafe { core::slice::from_raw_parts(x, 32) }.try_into()
+}
+
+fn to_byte_slice_vec(
+    x: &[*const u8],
+) -> std::result::Result<Vec<[u8; 32]>, std::array::TryFromSliceError> {
+    x.iter()
+        .map(
+            |&v| -> std::result::Result<[u8; 32], std::array::TryFromSliceError> {
+                let v = to_byte_slice(v)?;
+                Ok(v)
+            },
+        )
+        .collect::<Result<Vec<_>, _>>()
 }
 
 // @TODO: this is horrible :(, expose direct read/write for Input in the fcmp-plus-plus crate
@@ -861,7 +873,7 @@ pub unsafe extern "C" fn fcmp_pp_prove_sal(
     sal_proof_out: *mut u8,
     key_image_out: *mut u8,
 ) -> c_int {
-    let Ok(signable_tx_hash) = hash_array_from_bytes(signable_tx_hash) else {
+    let Ok(signable_tx_hash) = to_byte_slice(signable_tx_hash) else {
         return -1;
     };
 
@@ -940,7 +952,7 @@ pub struct FcmpPpVerifyInput {
     tree_root: TreeRoot<Selene, Helios>,
     n_tree_layers: usize,
     signable_tx_hash: [u8; 32],
-    key_images: Vec<EdwardsPoint>,
+    key_images: Vec<CompressedPoint>,
 }
 
 /// # Safety
@@ -972,40 +984,30 @@ pub unsafe extern "C" fn fcmp_pp_verify_input_new(
     }
     debug_assert_eq!(proof_len, _slow_fcmp_pp_proof_size(n_inputs, n_tree_layers));
 
-    let Ok(signable_tx_hash) = hash_array_from_bytes(signable_tx_hash) else {
+    let Ok(signable_tx_hash) = to_byte_slice(signable_tx_hash) else {
         return -4;
     };
 
     let mut proof: &[u8] = unsafe { core::slice::from_raw_parts(proof, proof_len) };
 
     // 32 byte pseudo outs
-    let pseudo_outs: &[*const u8] = pseudo_outs.into();
-    let pseudo_outs: Vec<[u8; 32]> = pseudo_outs
-        .iter()
-        .map(|&x| {
-            let x = unsafe { core::slice::from_raw_parts(x, 32) };
-            let mut pseudo_out = [0u8; 32];
-            pseudo_out.copy_from_slice(x);
-            pseudo_out
-        })
-        .collect();
+    let Ok(pseudo_outs) = to_byte_slice_vec(pseudo_outs.into()) else {
+        return -5;
+    };
+    let pseudo_outs = pseudo_outs.iter().map(|&x| CompressedPoint(x)).collect();
 
     // Read the FCMP++ proof
     let Ok(fcmp_plus_plus) = FcmpPlusPlus::read(&pseudo_outs, n_tree_layers, &mut proof) else {
-        return -5;
+        return -6;
     };
 
     let tree_root: TreeRoot<Selene, Helios> = unsafe { *tree_root };
 
-    // Collect de-compressed key images into a Vec
-    let key_images_slice: &[*const u8] = key_images.into();
-    let mut key_images = Vec::with_capacity(key_images_slice.len());
-    for compressed_ki in key_images_slice {
-        let Ok(key_image) = ed25519_point_from_bytes(*compressed_ki) else {
-            return -6;
-        };
-        key_images.push(key_image);
-    }
+    // Collect compressed key images into a Vec
+    let Ok(key_images) = to_byte_slice_vec(key_images.into()) else {
+        return -7;
+    };
+    let key_images = key_images.iter().map(|&x| CompressedPoint(x)).collect();
 
     let fcmp_pp_verify_input = FcmpPpVerifyInput {
         fcmp_pp: fcmp_plus_plus,
@@ -1032,7 +1034,7 @@ pub unsafe extern "C" fn fcmp_pp_verify_sal(
     key_image: *const u8,
     sal_proof: *const u8,
 ) -> bool {
-    let Ok(signable_tx_hash) = hash_array_from_bytes(signable_tx_hash) else {
+    let Ok(signable_tx_hash) = to_byte_slice(signable_tx_hash) else {
         return false;
     };
     let input_bytes = core::slice::from_raw_parts(input_bytes, 4 * 32);
@@ -1051,13 +1053,16 @@ pub unsafe extern "C" fn fcmp_pp_verify_sal(
 
     let mut ed_verifier = multiexp::BatchVerifier::new(/*capacity: */ 1);
 
-    sal_proof.verify(
+    let Ok(_) = sal_proof.verify(
         &mut OsRng,
         &mut ed_verifier,
         signable_tx_hash,
         &input,
         key_image,
-    );
+    )
+    else {
+        return false;
+    };
 
     ed_verifier.verify_vartime()
 }


### PR DESCRIPTION
Some stressnet users complained about poor sync performance that was caused by:

1. Slow calls for the `proof_len` when de-serializing the FCMP++ proof using the Rust lib (https://github.com/monero-oxide/monero-oxide/issues/125).
2. Single threaded point decompressions.

This PR includes changes that address both.

I forked the FCMP++ lib, pulling in @kayabaNerve's solution for (1), and I also implemented a solution for (2) that does decompressions inside `verify` rather than when de-serializing (calls to `verify` from C++ all multithreaded). Unfortunately there have been changes on the mainline `monero-oxide` branch that conflict with my solution for (2), and @kayabaNerve wants to implement it differently on the mainline `monero-oxide` branch. Problem is the mainline branch will fork stressnet since it already includes changes for Helios/Selene, unbiased hash to point etc.

So, I don't think we'll have an alpha stressnet FCMP++ lib upstream anytime soon that addresses both of these issues, hence, why I think we should use my fork to address both while we're still on alpha stressnet.

You can see all the changes to the FCMP++ lib that my fork introduces on top of the commit that the stressnet is currently using here: https://github.com/j-berman/monero-oxide/compare/34dab2669d54bf92631fa3a2b0b6764254a2066f...5c15bcc00575b26f9411264e9189d36d3f3edce8