### PR TITLE
Fix infinite loop in cryptonote_hierarchy_address_device

### DIFF
--- a/src/carrot_impl/address_device_hierarchies.cpp
+++ b/src/carrot_impl/address_device_hierarchies.cpp
@@ -163,7 +163,7 @@ bool cryptonote_hierarchy_address_device::view_key_scalar_mult8_ed25519(const cr
 bool cryptonote_hierarchy_address_device::view_key_scalar_mult_x25519(const mx25519_pubkey &D,
     mx25519_pubkey &kvD) const
 {
-    return this->view_key_scalar_mult_x25519(D, kvD);
+    return this->m_k_view_incoming_dev->view_key_scalar_mult_x25519(D, kvD);
 }
 //-------------------------------------------------------------------------------------------------------------------
 void cryptonote_hierarchy_address_device::make_janus_anchor_special(const mx25519_pubkey &enote_ephemeral_pubkey,


### PR DESCRIPTION
The current implementation is an infinite loop, which is clearly undesirable. It looks like this was intended to forward to the view incoming device. My unit tests in LWS pass with this change (indicating that this is likely the intended implementation).