### PR TITLE
Revert stressnet pool complement handling changes [stressnet]

### DIFF
--- a/src/cryptonote_core/cryptonote_core.cpp
+++ b/src/cryptonote_core/cryptonote_core.cpp
@@ -1170,8 +1170,6 @@ namespace cryptonote
         {
           default:
           case relay_method::none:
-          case relay_method::block:
-          case relay_method::fluff:
             break;
           case relay_method::local:
             private_req.txs.push_back(std::move(std::get<1>(tx)));
@@ -1181,6 +1179,8 @@ namespace cryptonote
             stem_req.txs.push_back(std::move(std::get<1>(tx)));
             stem_tx_hashes.push_back(std::move(std::get<0>(tx)));
             break;
+          case relay_method::block:
+          case relay_method::fluff:
           case relay_method::stem:
             public_req.txs.push_back(std::move(std::get<1>(tx)));
             public_tx_hashes.push_back(std::move(std::get<0>(tx)));

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -829,10 +829,10 @@ namespace cryptonote
             break;
           default:
           case relay_method::none:
-          case relay_method::fluff:
-          case relay_method::block:
             return true;
           case relay_method::local:
+          case relay_method::fluff:
+          case relay_method::block:
             if (now - meta.last_relayed_time <= get_relay_delay(meta.last_relayed_time, meta.receive_time))
               return true; // continue to next tx
             break;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -182,7 +182,6 @@ namespace cryptonote
     bool kick_idle_peers();
     bool check_standby_peers();
     bool update_sync_search();
-    bool check_txpool_complement();
     void send_txs_request(cryptonote_connection_context &context, std::vector<crypto::hash> &&tx_hashes);
     std::mutex m_check_tx_request_queue_mutex;
     bool check_tx_request_queue();
@@ -209,7 +208,6 @@ namespace cryptonote
     epee::math_helper::once_a_time_milliseconds<100> m_standby_checker;
     epee::math_helper::once_a_time_seconds<101> m_sync_search_checker;
     epee::math_helper::once_a_time_seconds<43> m_bad_peer_checker;
-    epee::math_helper::once_a_time_seconds<60> m_txpool_complement_checker;
     epee::math_helper::once_a_time_seconds<5> m_peer_tx_request_checker;
     std::unordered_map<epee::net_utils::zone, unsigned int> m_max_out_peers;
     mutable epee::critical_section m_max_out_peers_lock;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.h
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.h
@@ -209,7 +209,7 @@ namespace cryptonote
     epee::math_helper::once_a_time_milliseconds<100> m_standby_checker;
     epee::math_helper::once_a_time_seconds<101> m_sync_search_checker;
     epee::math_helper::once_a_time_seconds<43> m_bad_peer_checker;
-    epee::math_helper::once_a_time_seconds<300> m_txpool_complement_checker;
+    epee::math_helper::once_a_time_seconds<60> m_txpool_complement_checker;
     epee::math_helper::once_a_time_seconds<5> m_peer_tx_request_checker;
     std::unordered_map<epee::net_utils::zone, unsigned int> m_max_out_peers;
     mutable epee::critical_section m_max_out_peers_lock;

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -2931,12 +2931,6 @@ skip:
   template<class t_core>
   bool t_cryptonote_protocol_handler<t_core>::check_txpool_complement()
   {
-    if (!is_synchronized())
-    {
-      MDEBUG("Not ready for txpool complement");
-      return true;
-    }
-
     m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool
     {
       if(context.m_state < cryptonote_connection_context::state_synchronizing)

--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1846,7 +1846,6 @@ skip:
     m_idle_peer_kicker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::kick_idle_peers, this));
     m_standby_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::check_standby_peers, this));
     m_sync_search_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::update_sync_search, this));
-    m_txpool_complement_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::check_txpool_complement, this));
     m_peer_tx_request_checker.do_call(boost::bind(&t_cryptonote_protocol_handler<t_core>::check_tx_request_queue, this));
     return m_core.on_idle();
   }
@@ -2704,7 +2703,20 @@ skip:
     val_expected = true;
     if (m_ask_for_txpool_complement.compare_exchange_strong(val_expected, false))
     {
-      this->check_txpool_complement();
+      m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool
+      {
+        if(context.m_state < cryptonote_connection_context::state_synchronizing)
+        {
+          MDEBUG(context << "not ready, ignoring");
+          return true;
+        }
+        if (!request_txpool_complement(context))
+        {
+          MERROR(context << "Failed to request txpool complement");
+          return true;
+        }
+        return false;
+      });
     }
 
     return true;
@@ -2926,26 +2938,6 @@ skip:
        DB twice on received transactions - it is difficult to workaround this
        due to the internal design. */
     return m_p2p->send_txs(std::move(arg.txs), std::move(tx_hashes), zone, source, tx_relay) != epee::net_utils::zone::invalid;
-  }
-  //------------------------------------------------------------------------------------------------------------------------
-  template<class t_core>
-  bool t_cryptonote_protocol_handler<t_core>::check_txpool_complement()
-  {
-    m_p2p->for_each_connection([&](cryptonote_connection_context& context, nodetool::peerid_type peer_id, uint32_t support_flags)->bool
-    {
-      if(context.m_state < cryptonote_connection_context::state_synchronizing)
-      {
-        MDEBUG(context << "not ready for txpool complement check");
-        return true;
-      }
-      if (!this->request_txpool_complement(context))
-      {
-        MERROR(context << "Failed to request txpool complement");
-        return true;
-      }
-      return false;
-    });
-    return true;
   }
   //------------------------------------------------------------------------------------------------------------------------
   template<class t_core>


### PR DESCRIPTION
Reverts #177, #188, #209

These PR's were implemented on stressnet only to soften the load on nodes, and help isolate and tackle other issues present. With tx relay v2 merged into the stressnet branch and drastically reducing bandwidth for pool relaying, those PR's are not as useful. Those PR's also don't have support for upstreaming to mainnet (see discussion [here](https://github.com/seraphis-migration/monero/pull/174#issuecomment-3412324552)).