### PR TITLE
Txes returned via relay v2 should be in fluff mode

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -1001,6 +1001,7 @@ namespace cryptonote
     {
       NOTIFY_NEW_TRANSACTIONS::request request = {};
       request.txs = std::move(txs);
+      request.dandelionpp_fluff = true; // in relay_category::broadcasted already
       pad_tx_request(request);
       post_notify<NOTIFY_NEW_TRANSACTIONS>(request, context);
     }


### PR DESCRIPTION
I will make a separate PR for `stage` shortly. I will also post on Monero mainline repo.

The new TX Relay V2 code leverages the existing notification system for transactions. Unfortunately it is sending the txes as "stem" when they should be "fluff". You can verify this a few lines above where only "broadcasted" (i.e. not stem) transactions are pulled from the DB. Also, the [D++ code only sends the full tx via stem](https://github.com/seraphis-migration/monero/blob/ab5a53c5b0fbd298dd0f3a29bcb0491062503804/src/cryptonote_protocol/levin_notify.cpp#L575) - the hashes are sent only in the fluff phase. So a V2 response is naturally always in the fluff phase.

