### PR TITLE
simplewallet: skip prompt_if_old for FCMP++ txs

### DIFF
--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6340,6 +6340,9 @@ bool simple_wallet::prompt_if_old(const std::vector<tools::wallet2::pending_tx> 
   int max_n_old = 0;
   for (const auto &ptx: ptx_vector)
   {
+    if (ptx.tx.rct_signatures.type >= rct::RCTTypeFcmpPlusPlus)
+      continue;
+
     int n_old = 0;
     for (const auto i: ptx.selected_transfers)
     {

--- a/src/simplewallet/simplewallet.cpp
+++ b/src/simplewallet/simplewallet.cpp
@@ -6340,6 +6340,7 @@ bool simple_wallet::prompt_if_old(const std::vector<tools::wallet2::pending_tx> 
   int max_n_old = 0;
   for (const auto &ptx: ptx_vector)
   {
+    // Old co-spend heuristic doesn't apply after FCMP++
     if (ptx.tx.rct_signatures.type >= rct::RCTTypeFcmpPlusPlus)
       continue;
 


### PR DESCRIPTION
`simple_wallet::prompt_if_old` currently warns when a transaction spends
  multiple very old outputs. Based on the FCMP++ fork behavior, that warning
  no longer seems necessary for FCMP++ transactions.

  This patch skips the `prompt_if_old` old-output warning logic when the
  pending transaction RCT type is `rct::RCTTypeFcmpPlusPlus` or higher, while
  leaving the existing behavior unchanged for non-FCMP++ transactions.

  Testing:
  - rebuilt `simplewallet`
  - tested the `transfer` path on local regtest/private fakechain
  - confirmed the transaction reached the normal confirmation/submission flow
  without showing the old-output warning