### PR TITLE
blockchain_import: update FCMP++ tree after direct block import

### DIFF
--- a/src/blockchain_utilities/blockchain_import.cpp
+++ b/src/blockchain_utilities/blockchain_import.cpp
@@ -488,14 +488,15 @@ int import_from_file(cryptonote::core& core, const std::string& import_file_path
           cumulative_difficulty = bp.cumulative_difficulty;
           coins_generated = bp.coins_generated;
 
+          const uint64_t first_unified_id = core.get_blockchain_storage().get_db().num_outputs();
           std::unordered_map<uint64_t, rct::key> transparent_amount_commitments;
-          cryptonote::collect_transparent_amount_commitments(b.miner_tx, txs, transparent_amount_commitments);
+          const auto tx_refs = cryptonote::collect_transparent_amount_commitments(b.miner_tx, txs, transparent_amount_commitments);
 
           try
           {
             uint64_t long_term_block_weight = core.get_blockchain_storage().get_next_long_term_block_weight(block_weight);
-            core.get_blockchain_storage().get_db().add_block(std::make_pair(b, block_to_blob(b)), block_weight, long_term_block_weight, cumulative_difficulty, coins_generated, txs, transparent_amount_commitments);
-            // FIXME: add locked outputs and advance the tree (call handle_fcmp_tree)
+            const uint64_t new_height = core.get_blockchain_storage().get_db().add_block(std::make_pair(b, block_to_blob(b)), block_weight, long_term_block_weight, cumulative_difficulty, coins_generated, txs, transparent_amount_commitments);
+            cryptonote::handle_fcmp_tree(&core.get_blockchain_storage().get_db(), new_height - 1, first_unified_id, tx_refs, transparent_amount_commitments);
           }
           catch (const std::exception& e)
           {

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2846,7 +2846,7 @@ static bool batch_verify_fcmp_pp_txs(const BlockchainDB *db,
   return true;
 }
 //------------------------------------------------------------------
-static void handle_fcmp_tree(BlockchainDB *db, const uint64_t block_idx, const uint64_t first_unified_id, const std::vector<std::reference_wrapper<const transaction>> &tx_refs, const std::unordered_map<uint64_t, rct::key> &transparent_amount_commitments)
+void cryptonote::handle_fcmp_tree(BlockchainDB *db, const uint64_t block_idx, const uint64_t first_unified_id, const std::vector<std::reference_wrapper<const transaction>> &tx_refs, const std::unordered_map<uint64_t, rct::key> &transparent_amount_commitments)
 {
   // Collect outs by last locked block to add to the db
   OutsByLastLockedBlockMeta new_locked_outs = cryptonote::get_outs_by_last_locked_block(tx_refs, transparent_amount_commitments, first_unified_id, block_idx);

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -72,6 +72,12 @@ namespace cryptonote
   class tx_memory_pool;
   struct test_options;
 
+  void handle_fcmp_tree(BlockchainDB *db,
+      uint64_t block_idx,
+      uint64_t first_unified_id,
+      const std::vector<std::reference_wrapper<const transaction>> &tx_refs,
+      const std::unordered_map<uint64_t, rct::key> &transparent_amount_commitments);
+
   /** Declares ways in which the BlockchainDB backend should be told to sync
    *
    */


### PR DESCRIPTION
Fix `blockchain_import` to update locked outputs and the FCMP++ tree after direct block import.
