### PR TITLE
Use latest round of changes to FCMP++ lib

### DIFF
--- a/src/fcmp_pp/fcmp_pp_rust/Cargo.lock
+++ b/src/fcmp_pp/fcmp_pp_rust/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "ec-divisors"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "crypto-bigint",
  "dalek-ff-group 0.5.0",
@@ -308,7 +308,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "full-chain-membership-proofs"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -332,7 +332,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 [[package]]
 name = "generalized-bulletproofs"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -348,7 +348,7 @@ dependencies = [
 [[package]]
 name = "generalized-bulletproofs-circuit-abstraction"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "ciphersuite",
  "generalized-bulletproofs",
@@ -359,7 +359,7 @@ dependencies = [
 [[package]]
 name = "generalized-bulletproofs-ec-gadgets"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "ciphersuite",
  "generalized-bulletproofs-circuit-abstraction",
@@ -422,7 +422,7 @@ dependencies = [
 [[package]]
 name = "helioselene"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -495,7 +495,7 @@ dependencies = [
 [[package]]
 name = "monero-ed25519"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "blake2",
  "crypto-bigint",
@@ -511,7 +511,7 @@ dependencies = [
 [[package]]
 name = "monero-fcmp-plus-plus"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "blake2",
  "ciphersuite",
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "monero-fcmp-plus-plus-generators"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "ciphersuite",
  "full-chain-membership-proofs",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "monero-io"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "std-shims",
 ]
@@ -559,7 +559,7 @@ dependencies = [
 [[package]]
 name = "monero-primitives"
 version = "0.1.0"
-source = "git+https://github.com/monero-oxide/monero-oxide?rev=0d6f5e840ad1f955e4e4dec00c5165f134815b15#0d6f5e840ad1f955e4e4dec00c5165f134815b15"
+source = "git+https://github.com/monero-oxide/monero-oxide?rev=0e438aed2cce5c0ab8a935916c1a89bb0077f97f#0e438aed2cce5c0ab8a935916c1a89bb0077f97f"
 dependencies = [
  "sha3",
 ]

--- a/src/fcmp_pp/fcmp_pp_rust/Cargo.toml
+++ b/src/fcmp_pp/fcmp_pp_rust/Cargo.toml
@@ -13,16 +13,16 @@ rand_core = { version = "0.6", default-features = false }
 multiexp = "0.4"
 ciphersuite = { version = "0.4.2", features = ["ed25519"] }
 dalek-ff-group = "0.5.0"
-helioselene = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0d6f5e840ad1f955e4e4dec00c5165f134815b15" }
+helioselene = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0e438aed2cce5c0ab8a935916c1a89bb0077f97f" }
 
-generalized-bulletproofs = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0d6f5e840ad1f955e4e4dec00c5165f134815b15" }
-ec-divisors = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0d6f5e840ad1f955e4e4dec00c5165f134815b15", features = ["ed25519"] }
-full-chain-membership-proofs = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0d6f5e840ad1f955e4e4dec00c5165f134815b15" }
+generalized-bulletproofs = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0e438aed2cce5c0ab8a935916c1a89bb0077f97f" }
+ec-divisors = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0e438aed2cce5c0ab8a935916c1a89bb0077f97f", features = ["ed25519"] }
+full-chain-membership-proofs = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0e438aed2cce5c0ab8a935916c1a89bb0077f97f" }
 
-monero-fcmp-plus-plus-generators = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0d6f5e840ad1f955e4e4dec00c5165f134815b15" }
-monero-fcmp-plus-plus = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0d6f5e840ad1f955e4e4dec00c5165f134815b15" }
+monero-fcmp-plus-plus-generators = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0e438aed2cce5c0ab8a935916c1a89bb0077f97f" }
+monero-fcmp-plus-plus = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0e438aed2cce5c0ab8a935916c1a89bb0077f97f" }
 
-monero-ed25519 = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0d6f5e840ad1f955e4e4dec00c5165f134815b15" }
+monero-ed25519 = { git = "https://github.com/monero-oxide/monero-oxide", rev = "0e438aed2cce5c0ab8a935916c1a89bb0077f97f" }
 std-shims = { version = "0.1.5", default-features = false }
 
 [patch.crates-io]


### PR DESCRIPTION
Uses the latest round of FCMP++ lib changes, which includes the latest GBP updated fix here (as well as helioselene changes): https://github.com/monero-oxide/monero-oxide/commit/8ff1f904bf5018e3be22bbf3da4e186ac2d09e41

