### PR TITLE
carrot_impl: fix addr derive type log spam

### DIFF
--- a/src/carrot_impl/address_device.h
+++ b/src/carrot_impl/address_device.h
@@ -63,11 +63,16 @@ struct address_device
         crypto::public_key &address_view_pubkey_out) const = 0;
 
     /**
-     * get (k^j_subext, k^j_subscalar) given j s.t. K^j_s = k^j_subscalar K_s + k^j_subext G
+     * brief: get (k^j_subext, k^j_subscalar) given j s.t. K^j_s = k^j_subscalar K_s + k^j_subext G
      */
     virtual void get_address_openings(const subaddress_index_extended &subaddr_index,
         crypto::secret_key &address_extension_g_out,
         crypto::secret_key &address_scalar_out) const = 0;
+
+    /**
+     * brief: query whether address derivation type is supported by this device
+     */
+    virtual bool supports_address_derive_type(AddressDeriveType derive_type) const = 0;
 
     virtual ~address_device() = default;
 };

--- a/src/carrot_impl/address_device_hierarchies.cpp
+++ b/src/carrot_impl/address_device_hierarchies.cpp
@@ -32,6 +32,7 @@
 //local headers
 #include "carrot_core/address_utils.h"
 #include "carrot_core/exceptions.h"
+#include "carrot_impl/subaddress_index.h"
 #include "crypto/crypto.h"
 #include "crypto/generators.h"
 extern "C"
@@ -150,6 +151,11 @@ void cryptonote_hierarchy_address_device::get_address_openings(const subaddress_
 
     // k^j_subscal = 1
     address_scalar_out = crypto::secret_key{{1}};
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool cryptonote_hierarchy_address_device::supports_address_derive_type(const AddressDeriveType derive_type) const
+{
+    return derive_type == AddressDeriveType::Auto || derive_type == AddressDeriveType::PreCarrot;
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool cryptonote_hierarchy_address_device::view_key_scalar_mult_ed25519(const crypto::public_key &P,
@@ -275,6 +281,11 @@ void carrot_hierarchy_address_device::get_address_openings(const subaddress_inde
     address_scalar_out = this->get_subaddress_scalar(subaddr_index.index);
 }
 //-------------------------------------------------------------------------------------------------------------------
+bool carrot_hierarchy_address_device::supports_address_derive_type(const AddressDeriveType derive_type) const
+{
+    return derive_type == AddressDeriveType::Auto || derive_type == AddressDeriveType::Carrot;
+}
+//-------------------------------------------------------------------------------------------------------------------
 crypto::secret_key carrot_hierarchy_address_device::get_subaddress_scalar(const subaddress_index &subaddr_index) const
 {
     if (subaddr_index.is_subaddress())
@@ -319,7 +330,13 @@ hybrid_hierarchy_address_device::hybrid_hierarchy_address_device(std::shared_ptr
 :
     m_carrot_addr_dev(std::move(carrot_addr_dev)),
     m_cryptonote_addr_dev(std::move(cryptonote_addr_dev))
-{}
+{
+    assert(this->m_carrot_addr_dev || this->m_cryptonote_addr_dev);
+    if (this->m_carrot_addr_dev)
+        assert(this->m_carrot_addr_dev->supports_address_derive_type(AddressDeriveType::Carrot));
+    if (this->m_cryptonote_addr_dev)
+        assert(this->m_cryptonote_addr_dev->supports_address_derive_type(AddressDeriveType::PreCarrot));
+}
 //-------------------------------------------------------------------------------------------------------------------
 void hybrid_hierarchy_address_device::get_address_spend_pubkey(const subaddress_index_extended &subaddr_index,
     crypto::public_key &address_spend_pubkey_out) const
@@ -342,6 +359,13 @@ void hybrid_hierarchy_address_device::get_address_openings(const subaddress_inde
 {
     this->resolve_address_device(subaddr_index.derive_type, "get_address_openings")
         .get_address_openings(subaddr_index, address_extension_g_out, address_scalar_out);
+}
+//-------------------------------------------------------------------------------------------------------------------
+bool hybrid_hierarchy_address_device::supports_address_derive_type(const AddressDeriveType derive_type) const
+{
+    return derive_type == AddressDeriveType::Auto
+        || (derive_type == AddressDeriveType::PreCarrot && this->m_cryptonote_addr_dev)
+        || (derive_type == AddressDeriveType::Carrot && this->m_carrot_addr_dev);
 }
 //-------------------------------------------------------------------------------------------------------------------
 const address_device& hybrid_hierarchy_address_device::resolve_address_device(const AddressDeriveType derive_type,

--- a/src/carrot_impl/address_device_hierarchies.h
+++ b/src/carrot_impl/address_device_hierarchies.h
@@ -78,6 +78,8 @@ public:
         crypto::secret_key &address_extension_g_out,
         crypto::secret_key &address_scalar_out) const override;
 
+    bool supports_address_derive_type(AddressDeriveType derive_type) const override;
+
 //cryptonote_view_incoming_key_device
     bool view_key_scalar_mult_ed25519(const crypto::public_key &P, crypto::public_key &kvP) const override;
 
@@ -129,6 +131,8 @@ public:
         crypto::secret_key &address_extension_g_out,
         crypto::secret_key &address_scalar_out) const override;
 
+    bool supports_address_derive_type(AddressDeriveType derive_type) const override;
+
 protected:
 //member fields
     std::shared_ptr<generate_address_secret_device> m_s_generate_address_dev;
@@ -163,6 +167,8 @@ public:
     void get_address_openings(const subaddress_index_extended &subaddr_index,
         crypto::secret_key &address_extension_g_out,
         crypto::secret_key &address_scalar_out) const override;
+
+    bool supports_address_derive_type(AddressDeriveType derive_type) const override;
 
 protected:
 //member fields

--- a/src/carrot_impl/address_utils.cpp
+++ b/src/carrot_impl/address_utils.cpp
@@ -31,6 +31,7 @@
 
 //local headers
 #include "address_device.h"
+#include "carrot_impl/subaddress_index.h"
 #include "crypto/generators.h"
 #include "cryptonote_config.h"
 #include "int-util.h"
@@ -85,20 +86,18 @@ std::size_t get_all_main_address_spend_pubkeys(const address_device &addr_dev,
     memset(main_address_spend_pubkeys_out, 0, 2*sizeof(main_address_spend_pubkeys_out[0]));
 
     std::size_t n_main_addrs = 0;
-    try
+    if (addr_dev.supports_address_derive_type(AddressDeriveType::PreCarrot))
     {
         addr_dev.get_address_spend_pubkey({{}, AddressDeriveType::PreCarrot},
             main_address_spend_pubkeys_out[n_main_addrs]);
         ++n_main_addrs;
     }
-    catch (...) {}
-    try
+    if (addr_dev.supports_address_derive_type(AddressDeriveType::Carrot))
     {
         addr_dev.get_address_spend_pubkey({{}, AddressDeriveType::Carrot},
             main_address_spend_pubkeys_out[n_main_addrs]);
         ++n_main_addrs;
     }
-    catch (...) {}
 
     return n_main_addrs;
 }


### PR DESCRIPTION
Uses `if`s instead of `try`s for querying address derivation type support 

Resolves #315