### PR TITLE
Bump RPC version for expected compatibility

### DIFF
--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -103,7 +103,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
 // Don't go over 32767 for any of these
 // TODO: make sure this matches RPC version expected in wallet2::check_version when FCMP++ is ready
 #define CORE_RPC_VERSION_MAJOR 3
-#define CORE_RPC_VERSION_MINOR 17
+#define CORE_RPC_VERSION_MINOR 100
 #define MAKE_CORE_RPC_VERSION(major,minor) (((major)<<16)|(minor))
 #define CORE_RPC_VERSION MAKE_CORE_RPC_VERSION(CORE_RPC_VERSION_MAJOR, CORE_RPC_VERSION_MINOR)
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -6662,7 +6662,7 @@ bool wallet2::check_version(uint32_t *version, bool *wallet_is_outdated, bool *d
   // check wallet compatibility with daemon's hard fork version
   if (!m_allow_mismatched_daemon_version)
   {
-    if (rpc_version < MAKE_CORE_RPC_VERSION(3, 17))
+    if (rpc_version < MAKE_CORE_RPC_VERSION(3, 100))
     {
       // Wallet cannot init FCMP++ tree while syncing if pointing to an older daemon
       if (daemon_is_outdated)


### PR DESCRIPTION
Tbc, this is unrelated to #344

This is a good version compatibility check to make sure that updated FCMP++ wallets are pointing to FCMP++ compatible daemons (current master daemon is on [minor v17](https://github.com/monero-project/monero/blob/2e0dcb3d954b0c9888ef93e63132fe2cef4e21dc/src/rpc/core_rpc_server_commands_defs.h#L104) already). Note: I bump the minor version so that older non-FCMP++ wallets can still communicate with the updated daemon until the fork.