### PR TITLE
Daemon RPC: include optional KV serialize fields in resp

### DIFF
--- a/contrib/epee/include/serialization/keyvalue_serialization.h
+++ b/contrib/epee/include/serialization/keyvalue_serialization.h
@@ -87,9 +87,9 @@ public: \
   template<typename T> inline void serialize_default(const T &t, T v) { }
   template<typename T> inline void serialize_default(T &t, T v) { t = v; }
 
-#define KV_SERIALIZE_OPT_N(variable, val_name, default_value) \
+#define KV_SERIALIZE_OPT_N(variable, val_name, default_value, exclude_default_on_write) \
   do { \
-    if (is_store && this_ref.variable == default_value) \
+    if (is_store && this_ref.variable == default_value && exclude_default_on_write) \
       break; \
     if (!epee::serialization::selector<is_store>::serialize(this_ref.variable, stg, hparent_section, val_name)) \
       epee::serialize_default(this_ref.variable, default_value); \
@@ -122,7 +122,8 @@ public: \
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_OPT(varialble, def)  KV_SERIALIZE_VAL_POD_AS_BLOB_OPT_N(varialble, #varialble, def)
 #define KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE(varialble)     KV_SERIALIZE_VAL_POD_AS_BLOB_FORCE_N(varialble, #varialble) //skip is_trivially_copyable and is_standard_layout compile time check
 #define KV_SERIALIZE_CONTAINER_POD_AS_BLOB(varialble)     KV_SERIALIZE_CONTAINER_POD_AS_BLOB_N(varialble, #varialble)
-#define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value)
+#define KV_SERIALIZE_OPT(variable,default_value)          KV_SERIALIZE_OPT_N(variable, #variable, default_value, true)
+#define KV_SERIALIZE_INCLUDE_OPT(variable,default_value)  KV_SERIALIZE_OPT_N(variable, #variable, default_value, false)
 
 }
 

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -2276,9 +2276,10 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE_PARENT(rpc_response_base)
         KV_SERIALIZE(version)
         KV_SERIALIZE(release)
-        KV_SERIALIZE_OPT(current_height, (uint64_t)0)
-        KV_SERIALIZE_OPT(target_height, (uint64_t)0)
-        KV_SERIALIZE_OPT(hard_forks, std::vector<hf_entry>())
+        // TODO: These can be made KV_SERIALIZE once the HF_VERSION_FCMP_PLUS_PLUS passes
+        KV_SERIALIZE_INCLUDE_OPT(current_height, (uint64_t)0)
+        KV_SERIALIZE_INCLUDE_OPT(target_height, (uint64_t)0)
+        KV_SERIALIZE_INCLUDE_OPT(hard_forks, std::vector<hf_entry>())
       END_KV_SERIALIZE_MAP()
     };
     typedef epee::misc_utils::struct_init<response_t> response;


### PR DESCRIPTION
As per https://github.com/seraphis-migration/monero/pull/350#discussion_r3175452407