### PR TITLE
wallet2: fix bootstrap wallet sync

### DIFF
--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3437,23 +3437,23 @@ bool wallet2::bump_refresh_start_height(const uint64_t init_start_height, const 
   // Get the corresponding hash from the daemon
   crypto::hash granularized_init_hash;
   {
-    cryptonote::COMMAND_RPC_GETBLOCKHASH::request req = AUTO_VAL_INIT(req);
-    cryptonote::COMMAND_RPC_GETBLOCKHASH::response res = AUTO_VAL_INIT(res);
+    cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request req = AUTO_VAL_INIT(req);
+    cryptonote::COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response res = AUTO_VAL_INIT(res);
     epee::json_rpc::error error;
     error.code = 0;
-    req.push_back(granularized_init_block_idx);
+    req.height = granularized_init_block_idx;
 
     const boost::lock_guard<boost::recursive_mutex> lock{m_daemon_rpc_mutex};
-    bool r = net_utils::invoke_http_json_rpc("/json_rpc", "on_get_block_hash", req, res, error, *m_http_client, rpc_timeout);
+    bool r = net_utils::invoke_http_json_rpc("/json_rpc", "getblockheaderbyheight", req, res, error, *m_http_client, rpc_timeout);
     if (error.code == CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT) {
       // We don't need to sync if start height is higher than the daemon height
       MWARNING("Refresh start height is higher than the current chain tip, not syncing");
       return false;
     }
-    THROW_WALLET_EXCEPTION_IF(!r || error.code != 0, error::get_block_hash_error, error.message);
-    THROW_WALLET_EXCEPTION_IF(res.size() != 64, error::get_block_hash_error, "Hash is not 32 bytes as expected");
-    r = epee::string_tools::hex_to_pod(res, granularized_init_hash);
-    THROW_WALLET_EXCEPTION_IF(!r, error::get_block_hash_error, "Failed to parse getblockhash hash");
+    THROW_WALLET_EXCEPTION_IF(!r || error.code != 0, error::block_header_by_height_error, error.message);
+    THROW_WALLET_EXCEPTION_IF(res.block_header.hash.size() != 64, error::block_header_by_height_error, "Hash is not 32 bytes as expected");
+    r = epee::string_tools::hex_to_pod(res.block_header.hash, granularized_init_hash);
+    THROW_WALLET_EXCEPTION_IF(!r, error::block_header_by_height_error, "Failed to parse getblockheaderbyheight hash");
   }
 
   MINFO("Starting scanner on top of block " << granularized_init_block_idx << " , hash " << granularized_init_hash);

--- a/src/wallet/wallet_errors.h
+++ b/src/wallet/wallet_errors.h
@@ -72,7 +72,7 @@ namespace tools
     //         get_blocks_error
     //         get_hashes_error
     //         get_out_indexes_error
-    //         get_block_hash_error
+    //         block_header_by_height_error
     //         tx_parse_error
     //         get_tx_pool_error
     //         reorg_depth_error
@@ -146,7 +146,7 @@ namespace tools
       get_hashes_error_message_index,
       get_out_indices_error_message_index,
       get_outs_error_message_index,
-      get_block_hash_error_message_index
+      block_header_by_height_error_message_index
     };
 
     template<typename Base, int msg_index>
@@ -418,7 +418,7 @@ namespace tools
     //----------------------------------------------------------------------------------------------------
     typedef failed_rpc_request<refresh_error, get_out_indices_error_message_index> get_out_indices_error;
     //----------------------------------------------------------------------------------------------------
-    typedef failed_rpc_request<refresh_error, get_block_hash_error_message_index> get_block_hash_error;
+    typedef failed_rpc_request<refresh_error, block_header_by_height_error_message_index> block_header_by_height_error;
     //----------------------------------------------------------------------------------------------------
     struct tx_parse_error : public refresh_error
     {


### PR DESCRIPTION
Syncing via a bootstrap daemon is currently broken because of this

We can't use the `on_get_block_hash` RPC here because it [doesn't support bootstrap daemons](https://github.com/monero-project/monero/blob/c182abb4cbc7774e08e2db62488f2f61c7b459e8/src/rpc/core_rpc_server.cpp#L1850) (the request/response structure isn't compatible)