### PR TITLE
Revert to compatible req field

### DIFF
--- a/src/rpc/core_rpc_server.cpp
+++ b/src/rpc/core_rpc_server.cpp
@@ -851,7 +851,7 @@ namespace cryptonote
       }
 
       std::vector<std::pair<std::pair<cryptonote::blobdata, crypto::hash>, std::vector<std::pair<crypto::hash, cryptonote::blobdata> > > > bs;
-      if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.top_block_hash, res.start_height, req.prune, !req.no_miner_tx, req.block_ids_exclusive, max_blocks, COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT))
+      if(!m_core.find_blockchain_supplement(req.start_height, req.block_ids, bs, res.current_height, res.top_block_hash, res.start_height, req.prune, !req.no_miner_tx, req.block_ids_skip_common_block, max_blocks, COMMAND_RPC_GET_BLOCKS_FAST_MAX_TX_COUNT))
       {
         res.status = "Failed";
         add_host_fail(ctx);

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -191,7 +191,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
       uint64_t    start_height;
       bool        prune;
       bool        no_miner_tx;
-      bool        block_ids_exclusive;
+      bool        block_ids_skip_common_block;
       uint64_t    pool_info_since;
       uint64_t    max_block_count;
       bool        init_tree_sync;
@@ -202,7 +202,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
         KV_SERIALIZE(start_height)
         KV_SERIALIZE(prune)
         KV_SERIALIZE_OPT(no_miner_tx, false)
-        KV_SERIALIZE_OPT(block_ids_exclusive, false)
+        KV_SERIALIZE_OPT(block_ids_skip_common_block, false)
         KV_SERIALIZE_OPT(pool_info_since, (uint64_t)0)
         KV_SERIALIZE_OPT(max_block_count, (uint64_t)0)
         KV_SERIALIZE_OPT(init_tree_sync, false)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3096,7 +3096,7 @@ void wallet2::pull_blocks(bool check_pool, uint64_t &blocks_start_height, const 
   cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::request req = AUTO_VAL_INIT(req);
   cryptonote::COMMAND_RPC_GET_BLOCKS_FAST::response res = AUTO_VAL_INIT(res);
   req.block_ids = short_chain_history;
-  req.block_ids_exclusive = true; // start with the first new block after highest common block
+  req.block_ids_skip_common_block = true; // start with the first new block after highest common block
   req.prune = true;
   req.no_miner_tx = false; // always need the miner tx so we can grow the tree correctly
   req.init_tree_sync = m_tree_cache.n_synced_blocks() == 0;
@@ -3252,7 +3252,7 @@ static uint64_t check_for_reorg(const uint64_t parsed_blocks_start_idx, const cr
 
   // Note: this section assumes the wallet used its latest short_chain_history in the getblocks.bin request.
   // The daemon response should always include at least 1 block with prev_id included in our local chain
-  // (see block_ids_exclusive param). If there was a reorg, then the daemon resp includes a block w/prev_id in
+  // (see block_ids_skip_common_block param). If there was a reorg, then the daemon resp includes a block w/prev_id in
   // our local chain that is contiguous to the main chain, and also returns contiguous blocks after. It's possible the
   // resp includes multiple blocks we have already synced, since short_chain_history has gaps in it. If
   // parsed_blocks_start_idx-1 is not in our hashchain, however, then the reorg must have occurred earlier than the


### PR DESCRIPTION
v1.0 and v1.1 beta wallets expect the daemon to handle this req field, so reverting back to this field to maintain compatibility to avoid breaking sync for v1.0 and v1.1 wallets