### PR TITLE
Fix RPC serialization of UnifiedOutputs

### DIFF
--- a/src/blockchain_db/lmdb/db_lmdb.cpp
+++ b/src/blockchain_db/lmdb/db_lmdb.cpp
@@ -1387,6 +1387,8 @@ void BlockchainLMDB::add_locked_outs(const fcmp_pp::OutsByLastLockedBlock& outs_
     for (const fcmp_pp::UnifiedOutput &locked_output : last_locked_block.second)
     {
       const cryptonote::blobdata output_blob = cryptonote::t_serializable_object_to_blob(locked_output);
+      if (output_blob.size() != SIZEOF_SERIALIZED_UNIFIED_OUTPUT)
+        throw0(DB_ERROR(("Out " + std::to_string(locked_output.unified_id) + " has unexpected blob size" + std::to_string(output_blob.size())).c_str()));
 
       MDB_val_set(k_block_id, last_locked_block_idx);
       MDB_val_sized(v_output, output_blob);
@@ -1872,6 +1874,9 @@ uint64_t BlockchainLMDB::trim_leaves(const uint64_t new_n_leaf_tuples, const uin
     // Re-add the output to the locked output table in order. The output should
     // still be in the outputs tables.
     const cryptonote::blobdata output_blob = cryptonote::t_serializable_object_to_blob(unified_output);
+    if (output_blob.size() != SIZEOF_SERIALIZED_UNIFIED_OUTPUT)
+      throw0(DB_ERROR(("Output " + std::to_string(unified_output.unified_id) + " has unexpected blob size" + std::to_string(output_blob.size())).c_str()));
+
     MDB_val_sized(v_output, output_blob);
     MDEBUG("Re-adding locked unified_id: " << unified_output.unified_id << " , last locked block: " << trim_block_idx);
     int result = mdb_cursor_put(m_cur_locked_outputs, &k_block_id, &v_output, MDB_APPENDDUP);
@@ -2397,9 +2402,11 @@ std::vector<fcmp_pp::UnifiedOutput> BlockchainLMDB::get_outs_at_last_locked_bloc
     const char *range_begin = (const char*)v_output.mv_data;
     const char *range_end = range_begin + v_output.mv_size;
 
-    auto it = range_begin;
-
+    if (v_output.mv_size % SIZEOF_SERIALIZED_UNIFIED_OUTPUT != 0)
+      throw0(DB_ERROR(("Blk id " + std::to_string(blk_id) + " page of outs has unexpected data size" + std::to_string(v_output.mv_size)).c_str()));
     static_assert(SIZEOF_SERIALIZED_UNIFIED_OUTPUT == 73, "Unified output is stored serialized in 73 bytes");
+
+    auto it = range_begin;
 
     // The first MDB_NEXT_MULTIPLE includes the val from MDB_SET, so skip it
     if (outs.size() == 1)

--- a/src/fcmp_pp/curve_trees.cpp
+++ b/src/fcmp_pp/curve_trees.cpp
@@ -1119,8 +1119,9 @@ CurveTrees<Selene, Helios>::Path CurveTrees<Selene, Helios>::path_bytes_to_path(
     typename CurveTrees<Selene, Helios>::Path path;
 
     // Leaves
-    path.leaves.reserve(path_bytes.leaves.size());
-    for (const auto &leaf : path_bytes.leaves)
+    const auto leaves = path_bytes.leaves.to_unified_outputs_vec();
+    path.leaves.reserve(leaves.size());
+    for (const auto &leaf : leaves)
         path.leaves.emplace_back(output_to_tuple(leaf.output_pair));
 
     // Layers
@@ -1157,7 +1158,7 @@ CompressedPath CurveTrees<Selene, Helios>::compress_path(const CurveTrees<Selene
     CompressedPath compressed_path;
 
     // Leaves (leaf tuples don't have enough context, need to know the output's type)
-    compressed_path.leaves = outputs;
+    compressed_path.leaves = fcmp_pp::UnifiedOutputs(outputs);
 
     // Layers
     bool parent_is_c1 = true;
@@ -1497,7 +1498,7 @@ typename CurveTrees<C1, C2>::TreeExtension CurveTrees<C1, C2>::path_to_tree_exte
     typename CurveTrees<C1, C2>::TreeExtension tree_extension;
     tree_extension.leaves = ContiguousLeaves{
             .start_leaf_tuple_idx = path_idxs.leaf_range.first,
-            .tuples               = path_bytes.leaves
+            .tuples               = path_bytes.leaves.to_unified_outputs_vec()
         };
 
     uint8_t layer_idx = 0;

--- a/src/fcmp_pp/fcmp_pp_types.h
+++ b/src/fcmp_pp/fcmp_pp_types.h
@@ -177,6 +177,44 @@ static_assert(std::has_unique_object_representations_v<LegacyOutputPair>);
 static_assert(std::has_unique_object_representations_v<CarrotOutputPairV1>);
 
 using OutputPair = std::variant<LegacyOutputPair, CarrotOutputPairV1>;
+static_assert(std::variant_size_v<OutputPair> == 2, "Added an OutputPairType, make sure to add the enum");
+
+enum OutputPairType : uint8_t
+{
+    Legacy   = 0,
+    CarrotV1 = 1,
+};
+
+inline OutputPairType output_pair_type(const OutputPair &output_pair)
+{
+    struct output_pair_visitor
+    {
+        OutputPairType operator()(const LegacyOutputPair&) const
+        { return OutputPairType::Legacy; }
+        OutputPairType operator()(const CarrotOutputPairV1&) const
+        { return OutputPairType::CarrotV1; }
+    };
+    return std::visit(output_pair_visitor{}, output_pair);
+};
+
+inline OutputPair output_pair_from_type(const OutputPairType type,
+    const crypto::public_key &output_pubkey,
+    const crypto::ec_point &commitment)
+{
+    switch (type)
+    {
+        case OutputPairType::Legacy:
+            return LegacyOutputPair{{output_pubkey, commitment}};
+        case OutputPairType::CarrotV1:
+            return CarrotOutputPairV1{{output_pubkey, commitment}};
+        default:
+        {
+            static_assert(std::variant_size_v<OutputPair> == 2,
+                "Added/Removed a variant type to Output Pair, need to update the switch statement");
+            CHECK_AND_ASSERT_THROW_MES(false, "Unexpected output pair type");
+        }
+    }
+}
 
 const crypto::public_key &output_pubkey_cref(const OutputPair &output_pair);
 const crypto::ec_point &commitment_cref(const OutputPair &output_pair);
@@ -196,14 +234,93 @@ struct UnifiedOutput final
         return unified_id == other.unified_id && output_pair == other.output_pair;
     }
 
-    // TODO: move to fcmp_pp_serialization.h
-    BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE(unified_id)
-        KV_SERIALIZE(output_pair)
-    END_KV_SERIALIZE_MAP()
+    // Warning: Don't KV serialize this struct. Use UnifiedOutputs instead. It saves space and is guaranteed to
+    // work correctly across platforms. See: https://github.com/seraphis-migration/monero/issues/367
 };
 
 #define SIZEOF_SERIALIZED_UNIFIED_OUTPUT 73 // 8+1+32+32
+
+static_assert(std::variant_size_v<OutputPair> <= std::numeric_limits<uint8_t>::max(),
+    "Serialized Output Pair expects 1 byte for variant type");
+static_assert(sizeof(OutputPairType) == 1, "Expect 1 byte for OutputPairType");
+
+// Useful for key-value serialization of multiple unified outputs
+struct UnifiedOutputs final
+{
+    std::vector<uint64_t> unified_ids;
+    std::vector<OutputPairType> output_types;
+    std::vector<crypto::public_key> output_pubkeys;
+    std::vector<crypto::ec_point> commitments;
+
+    UnifiedOutputs() = default;
+
+    bool operator==(const UnifiedOutputs &other) const
+    {
+        return unified_ids == other.unified_ids
+            && output_types == other.output_types
+            && output_pubkeys == other.output_pubkeys
+            && commitments == other.commitments;
+    }
+
+    bool size_check() const
+    {
+        return unified_ids.size() == output_types.size()
+            && unified_ids.size() == output_pubkeys.size()
+            && unified_ids.size() == commitments.size();
+    }
+
+    std::size_t size() const
+    {
+        assert(size_check());
+        return unified_ids.size();
+    };
+
+    std::size_t empty() const
+    {
+        assert(size_check());
+        return unified_ids.empty();
+    };
+
+    UnifiedOutputs(const std::vector<UnifiedOutput> &unified_outputs)
+    {
+        unified_ids.reserve(unified_outputs.size());
+        output_types.reserve(unified_outputs.size());
+        output_pubkeys.reserve(unified_outputs.size());
+        commitments.reserve(unified_outputs.size());
+        for (const auto &oc : unified_outputs)
+        {
+            unified_ids.push_back(oc.unified_id);
+            output_types.emplace_back(output_pair_type(oc.output_pair));
+            output_pubkeys.push_back(output_pubkey_cref(oc.output_pair));
+            commitments.push_back(commitment_cref(oc.output_pair));
+        }
+    }
+
+    std::vector<UnifiedOutput> to_unified_outputs_vec() const
+    {
+        assert(size_check());
+        if (!size_check())
+            return {};
+        std::vector<UnifiedOutput> unified_outputs;
+        unified_outputs.reserve(unified_ids.size());
+        for (std::size_t i = 0; i < unified_ids.size(); ++i)
+        {
+            unified_outputs.emplace_back(UnifiedOutput{
+                .unified_id  = unified_ids.at(i),
+                .output_pair = output_pair_from_type(output_types.at(i), output_pubkeys.at(i), commitments.at(i))
+            });
+        }
+        return unified_outputs;
+    };
+
+    BEGIN_KV_SERIALIZE_MAP()
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(unified_ids)
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(output_types)
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(output_pubkeys)
+        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(commitments)
+        if (!size_check()) return false;
+    END_KV_SERIALIZE_MAP()
+};
 
 using OutsByLastLockedBlock = std::unordered_map<uint64_t, std::vector<UnifiedOutput>>;
 
@@ -251,7 +368,7 @@ struct CompressedChunk final
 // A path in the tree
 struct CompressedPath final
 {
-    std::vector<UnifiedOutput> leaves;
+    UnifiedOutputs leaves;
     std::vector<CompressedChunk> layer_chunks;
 
     bool operator==(const CompressedPath &other) const
@@ -259,7 +376,7 @@ struct CompressedPath final
 
     // TODO: move to fcmp_pp_serialization.h
     BEGIN_KV_SERIALIZE_MAP()
-        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(leaves)
+        KV_SERIALIZE(leaves)
         KV_SERIALIZE(layer_chunks)
     END_KV_SERIALIZE_MAP()
 };

--- a/src/rpc/core_rpc_server_commands_defs.h
+++ b/src/rpc/core_rpc_server_commands_defs.h
@@ -251,7 +251,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
     struct locked_outputs_t
     {
       uint64_t last_locked_block;
-      std::vector<fcmp_pp::UnifiedOutput> outputs;
+      fcmp_pp::UnifiedOutputs outputs;
 
       bool operator==(const locked_outputs_t& other) const
       {
@@ -260,7 +260,7 @@ inline const std::string get_rpc_status(const bool trusted_daemon, const std::st
 
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(last_locked_block)
-        KV_SERIALIZE_CONTAINER_POD_AS_BLOB(outputs)
+        KV_SERIALIZE(outputs)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -3889,7 +3889,7 @@ void wallet2::pull_and_parse_next_blocks(bool check_pool, uint64_t &blocks_start
       // Initialize tree cache
       fcmp_pp::OutsByLastLockedBlock locked_outputs;
       for (auto &lo : init_tree_sync_data->locked_outputs)
-        locked_outputs[lo.last_locked_block] = std::move(lo.outputs);
+        locked_outputs[lo.last_locked_block] = lo.outputs.to_unified_outputs_vec();
 
       m_tree_cache.init(init_block_idx, init_block_hash, init_tree_sync_data->n_leaf_tuples, init_tree_sync_data->last_path, locked_outputs);
 


### PR DESCRIPTION
Confirmed by @redsh4de fixes https://github.com/seraphis-migration/monero/issues/367

Big thank you to @redsh4de for good testing and diagnosing!!

This solution pulls in a large amount of code from #89. That PR introduced this new `UnifiedOutputs` struct to save space in the RPC, and I reused it here to solve the incompatible serialized `std::variant` blobs issue reported in #367.