### PR TITLE
txpool: don't re-relay invalid FCMP++ txs

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -3897,20 +3897,25 @@ bool Blockchain::check_tx_inputs(transaction& tx,
     sig_index++;
   }
 
-  // enforce min output age
-  if (hf_version >= HF_VERSION_ENFORCE_MIN_AGE)
+  crypto::ec_point ref_tree_root{};
+  if (rct::is_rct_fcmp(tx.rct_signatures.type))
   {
+    if (pmax_used_block_height)
+      *pmax_used_block_height = tx.rct_signatures.p.reference_block;
+
+    // Read the db for the tree root for FCMP tx. Enforces that the ref block is in the chain
+    if (!get_fcmp_tx_tree_root(m_db, tx, ref_tree_root))
+    {
+      // We might not be synced yet and an honest synced peer may have sent us the tx, so we make this a no-drop-offense
+      tvc.m_no_drop_offense = true;
+      return false;
+    }
+  }
+  else if (hf_version >= HF_VERSION_ENFORCE_MIN_AGE)
+  {
+    // enforce min output age on rings
     CHECK_AND_ASSERT_MES(*pmax_used_block_height + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE <= m_db->height(),
         false, "Transaction spends at least one output which is too young");
-  }
-
-  // Read the db for the tree root for FCMP txs
-  crypto::ec_point ref_tree_root{};
-  if (rct::is_rct_fcmp(tx.rct_signatures.type) && !get_fcmp_tx_tree_root(m_db, tx, ref_tree_root))
-  {
-    // We might not be synced yet and an honest synced peer may have sent us the tx, so we make this a no-drop-offense
-    tvc.m_no_drop_offense = true;
-    return false;
   }
 
   const crypto::hash txid = get_transaction_hash(tx);

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -276,7 +276,7 @@ namespace cryptonote
         meta.weight = tx_weight;
         meta.fee = fee;
         meta.max_used_block_id = null_hash;
-        meta.max_used_block_height = rct::is_rct_fcmp(tx.rct_signatures.type) ? max_used_block_height : 0;
+        meta.max_used_block_height = tx.pruned ? 0 : tx.rct_signatures.p.reference_block; // pre FCMP++, this just gets set to 0
         meta.last_failed_height = 0;
         meta.last_failed_id = null_hash;
         meta.receive_time = receive_time;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -118,6 +118,47 @@ namespace cryptonote
       if (candidate < next_check.load(std::memory_order_relaxed))
         next_check = candidate;
     }
+
+    // Quick check if inputs were rendered invalid. If true, this does not mean the inputs are still valid. It only
+    // means we **expect** them to be valid, but they would still need to go through the full validation flow.
+    // But if false, we're sure the inputs are now invalid. This is helpful to avoid re-relaying invalid txs.
+    bool expect_valid_tx_inputs(const crypto::hash &txid, const txpool_tx_meta_t &meta, const Blockchain& m_blockchain, std::unordered_map<uint64_t, crypto::ec_point> &tree_roots_by_block_inout)
+    {
+      if (meta.max_used_block_height < m_blockchain.get_earliest_ideal_height_for_version(HF_VERSION_FCMP_PLUS_PLUS + 1))
+        return true;
+
+      // After the FCMP++ fork, the max_used_block_height == tx's used reference_block. That's expected to be the tip of
+      // the chain when constructing a tx. We can use this value to quickly determine if the tx's proof is still
+      // expected to be valid. We couldn't do this quickly with ring signatures, so we start doing it after FCMP++.
+      const uint64_t reference_block = meta.max_used_block_height;
+
+      // If we don't already know this tree root by block index, get it from the db and cache it
+      if (tree_roots_by_block_inout.find(reference_block) == tree_roots_by_block_inout.end())
+      {
+        crypto::ec_point tree_root;
+        try
+        {
+          m_blockchain.get_db().get_tree_root_at_blk_idx(reference_block, tree_root);
+        }
+        catch (...)
+        {
+          MERROR("Failed to get tree root at block " << reference_block);
+          return false;
+        }
+        tree_roots_by_block_inout[reference_block] = tree_root;
+      }
+
+      const crypto::ec_point &tree_root = tree_roots_by_block_inout[reference_block];
+
+      // Warning: this doesn't guarantee the tx inputs are definitely still valid. Need to check the tx's included
+      // n_tree_layers as well, but we don't want to have to parse the full tx blob in here, so we do this spot check.
+      const auto expected_ver_id = make_input_verification_id(txid, tree_root);
+      if (meta.valid_input_verification_id == expected_ver_id)
+        return true;
+
+      MINFO("Tx " << txid << " no longer has a valid input verification id, not re-relaying");
+      return false;
+    }
   }
   //---------------------------------------------------------------------------------
   //---------------------------------------------------------------------------------
@@ -808,11 +849,13 @@ namespace cryptonote
     uint64_t next_check = clock::to_time_t(clock::from_time_t(time_t(now)) + max_relayable_check);
     std::vector<std::pair<crypto::hash, txpool_tx_meta_t>> change_timestamps;
 
+    std::unordered_map<uint64_t, crypto::ec_point> tree_roots_by_block;
+
     CRITICAL_REGION_LOCAL(m_transactions_lock);
     CRITICAL_REGION_LOCAL1(m_blockchain);
     LockedTXN lock(m_blockchain.get_db());
     txs.reserve(m_blockchain.get_txpool_tx_count());
-    m_blockchain.for_all_txpool_txes([this, now, &txs, &change_timestamps, &next_check](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *){
+    m_blockchain.for_all_txpool_txes([this, now, &txs, &change_timestamps, &next_check, &tree_roots_by_block](const crypto::hash &txid, const txpool_tx_meta_t &meta, const cryptonote::blobdata_ref *){
       // 0 fee transactions are never relayed
       if(!meta.pruned && meta.fee > 0 && !meta.do_not_relay)
       {
@@ -845,6 +888,8 @@ namespace cryptonote
         uint64_t max_age = (tx_relay == relay_method::block) ? CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME : CRYPTONOTE_MEMPOOL_TX_LIVETIME;
         if (now - meta.receive_time <= max_age / 2)
         {
+          if (!expect_valid_tx_inputs(txid, meta, m_blockchain, tree_roots_by_block))
+            return true; // continue to next tx
           try
           {
             txs.emplace_back(txid, m_blockchain.get_txpool_tx_blob(txid, relay_category::all), tx_relay);

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -119,13 +119,13 @@ namespace cryptonote
         next_check = candidate;
     }
 
-    // Quick check if inputs were rendered invalid. If true, this does not mean the inputs are still valid. It only
-    // means we **expect** them to be valid, but they would still need to go through the full validation flow.
-    // But if false, we're sure the inputs are now invalid. This is helpful to avoid re-relaying invalid txs.
-    bool expect_valid_tx_inputs(const crypto::hash &txid, const txpool_tx_meta_t &meta, const Blockchain& m_blockchain, std::unordered_map<uint64_t, crypto::ec_point> &tree_roots_by_block_inout)
+    // Quick check if inputs were rendered invalid. If false, this does not mean the inputs are still valid. The
+    // tx would still need to go through the full validation flow. But if true, we're sure the inputs are now
+    // invalid. This is helpful to avoid re-relaying invalid txs.
+    bool expect_invalid_tx_inputs(const crypto::hash &txid, const txpool_tx_meta_t &meta, const Blockchain& m_blockchain, std::unordered_map<uint64_t, crypto::ec_point> &tree_roots_by_block_inout)
     {
       if (meta.max_used_block_height < m_blockchain.get_earliest_ideal_height_for_version(HF_VERSION_FCMP_PLUS_PLUS + 1))
-        return true;
+        return false;
 
       // After the FCMP++ fork, the max_used_block_height == tx's used reference_block. That's expected to be the tip of
       // the chain when constructing a tx. We can use this value to quickly determine if the tx's proof is still
@@ -143,7 +143,7 @@ namespace cryptonote
         catch (...)
         {
           MERROR("Failed to get tree root at block " << reference_block);
-          return false;
+          return true;
         }
         tree_roots_by_block_inout[reference_block] = tree_root;
       }
@@ -154,10 +154,10 @@ namespace cryptonote
       // n_tree_layers as well, but we don't want to have to parse the full tx blob in here, so we do this spot check.
       const auto expected_ver_id = make_input_verification_id(txid, tree_root);
       if (meta.valid_input_verification_id == expected_ver_id)
-        return true;
+        return false;
 
       MINFO("Tx " << txid << " no longer has a valid input verification id, not re-relaying");
-      return false;
+      return true;
     }
   }
   //---------------------------------------------------------------------------------
@@ -888,7 +888,7 @@ namespace cryptonote
         uint64_t max_age = (tx_relay == relay_method::block) ? CRYPTONOTE_MEMPOOL_TX_FROM_ALT_BLOCK_LIVETIME : CRYPTONOTE_MEMPOOL_TX_LIVETIME;
         if (now - meta.receive_time <= max_age / 2)
         {
-          if (!expect_valid_tx_inputs(txid, meta, m_blockchain, tree_roots_by_block))
+          if (expect_invalid_tx_inputs(txid, meta, m_blockchain, tree_roots_by_block))
             return true; // continue to next tx
           try
           {

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -276,7 +276,7 @@ namespace cryptonote
         meta.weight = tx_weight;
         meta.fee = fee;
         meta.max_used_block_id = null_hash;
-        meta.max_used_block_height = 0;
+        meta.max_used_block_height = rct::is_rct_fcmp(tx.rct_signatures.type) ? max_used_block_height : 0;
         meta.last_failed_height = 0;
         meta.last_failed_id = null_hash;
         meta.receive_time = receive_time;

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -277,6 +277,7 @@ namespace cryptonote
         meta.fee = fee;
         meta.max_used_block_id = null_hash;
         meta.max_used_block_height = (!tx.pruned && rct::is_rct_fcmp(tx.rct_signatures.type)) ? tx.rct_signatures.p.reference_block : 0;
+        meta.last_failed_height = 0;
         meta.last_failed_id = null_hash;
         meta.receive_time = receive_time;
         meta.last_relayed_time = time(NULL);

--- a/src/cryptonote_core/tx_pool.cpp
+++ b/src/cryptonote_core/tx_pool.cpp
@@ -276,8 +276,7 @@ namespace cryptonote
         meta.weight = tx_weight;
         meta.fee = fee;
         meta.max_used_block_id = null_hash;
-        meta.max_used_block_height = tx.pruned ? 0 : tx.rct_signatures.p.reference_block; // pre FCMP++, this just gets set to 0
-        meta.last_failed_height = 0;
+        meta.max_used_block_height = (!tx.pruned && rct::is_rct_fcmp(tx.rct_signatures.type)) ? tx.rct_signatures.p.reference_block : 0;
         meta.last_failed_id = null_hash;
         meta.receive_time = receive_time;
         meta.last_relayed_time = time(NULL);


### PR DESCRIPTION
After a deep reorg, txs can be rendered invalid (if >10 blocks, FCMP++ tx tree roots can change). A node with a now-invalid tx in its pool will still re-relay that now-invalid tx to its peers in a loop via `get_relayable_transactions`. The node's peers will then drop the node for receiving an invalid tx. Noted in #372 as a cause for poor node connectivity after a deep reorg.

This PR addresses this by checking if the tx about to be re-relayed has been rendered invalid, using the `valid_input_verification_id` stored on the tx. If invalid, we don't re-relay.

This PR repurposes `meta.max_used_block_height` for FCMP++, setting it to the `reference_block` used to construct the FCMP++ tx (expected to be the tip of the chain at tx construction time).