### PR TITLE
blockchain: re-align Beta stressnet off-by-1 window

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1553,7 +1553,7 @@ void Blockchain::get_last_n_blocks_weights(std::vector<uint64_t>& weights, size_
   weights = m_db->get_block_weights(start_offset, count);
 }
 //------------------------------------------------------------------
-uint64_t Blockchain::get_long_term_block_weight_median(uint64_t start_height, size_t count) const
+uint64_t Blockchain::get_long_term_block_weight_median(uint64_t start_height, size_t count, bool yin_yang) const
 {
   LOG_PRINT_L3("Blockchain::" << __func__);
   CRITICAL_REGION_LOCAL(m_blockchain_lock);
@@ -1586,6 +1586,7 @@ uint64_t Blockchain::get_long_term_block_weight_median(uint64_t start_height, si
   if (tip_height > 0 && tip_height < blockchain_height)
   {
    const size_t rmsize = m_long_term_block_weights_cache_rolling_median.size();
+   // VVVVVVVVVVVVVVVV qi state transition: median cache capacity exceeds shorter stressnet LTM window size
    if (count == rmsize || (count == rmsize + 1 && rmsize < CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE))
    {
     crypto::hash old_tip_hash = m_db->get_block_hash_from_height(tip_height - 1);
@@ -1600,7 +1601,10 @@ uint64_t Blockchain::get_long_term_block_weight_median(uint64_t start_height, si
   }
 
   MTRACE("requesting " << count << " from " << start_height << ", uncached");
-  std::vector<uint64_t> weights = m_db->get_long_term_block_weights(start_height, count);
+  const bool and_one = yin_yang
+    && count == CRYPTONOTE_STRESSNET_BLOCK_WEIGHT_WINDOW_SIZE
+    && m_long_term_block_weights_cache_rolling_median.size() != CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE;
+  std::vector<uint64_t> weights = m_db->get_long_term_block_weights(start_height - and_one, count + and_one);
   m_long_term_block_weights_cache_tip_hash = tip_hash;
   m_long_term_block_weights_cache_rolling_median.clear();
   for (uint64_t w: weights)
@@ -5021,7 +5025,7 @@ uint64_t Blockchain::get_next_long_term_block_weight(uint64_t block_weight) cons
   if (hf_version < HF_VERSION_LONG_TERM_BLOCK_WEIGHT)
     return block_weight;
 
-  const uint64_t long_term_median = get_long_term_block_weight_median(db_height - nblocks, nblocks);
+  const uint64_t long_term_median = get_long_term_block_weight_median(db_height - nblocks, nblocks, /*yin_yang=*/false);
   const uint64_t long_term_effective_median_block_weight = std::max<uint64_t>(get_min_block_weight(hf_version), long_term_median);
 
   uint64_t short_term_constraint{};
@@ -5080,7 +5084,7 @@ bool Blockchain::update_next_cumulative_weight_limit(uint64_t *long_term_effecti
   else
   {
     const uint64_t nblocks = std::min<uint64_t>(m_long_term_block_weights_window, db_height);
-    const uint64_t long_term_median = get_long_term_block_weight_median(db_height - nblocks, nblocks);
+    const uint64_t long_term_median = get_long_term_block_weight_median(db_height - nblocks, nblocks, /*yin_yang=*/true);
 
     m_long_term_effective_median_block_weight = std::max<uint64_t>(full_reward_zone, long_term_median);
 

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -1582,10 +1582,11 @@ namespace cryptonote
      *
      * @param start_height the block height of the first block to query
      * @param count the number of blocks to get weights for
+     * @param yin_yang false for yin, true for yang
      *
      * @return the long term median block weight
      */
-    uint64_t get_long_term_block_weight_median(uint64_t start_height, size_t count) const;
+    uint64_t get_long_term_block_weight_median(uint64_t start_height, size_t count, bool yin_yang) const;
 
     /**
      * @brief checks if a transaction is unlocked (its outputs spendable)

--- a/tests/unit_tests/long_term_block_weight.cpp
+++ b/tests/unit_tests/long_term_block_weight.cpp
@@ -429,7 +429,7 @@ TEST(long_term_block_weight, cache_matches_true_value)
   uint64_t weight_limit = bc->get_current_cumulative_block_weight_limit();
   // refresh the cache
   bc->m_long_term_block_weights_cache_rolling_median.clear();
-  bc->get_long_term_block_weight_median(bc->get_db().height() - TEST_LONG_TERM_BLOCK_WEIGHT_WINDOW, TEST_LONG_TERM_BLOCK_WEIGHT_WINDOW);
+  bc->get_long_term_block_weight_median(bc->get_db().height() - TEST_LONG_TERM_BLOCK_WEIGHT_WINDOW, TEST_LONG_TERM_BLOCK_WEIGHT_WINDOW, /*yin_yang=*/false);
   bc->update_next_cumulative_weight_limit();
 
   // make sure the weight limit is the same


### PR DESCRIPTION
This line:

https://github.com/seraphis-migration/monero/blob/d1adfbba21cdde7cec4b732ae4682ac44ee79167/src/cryptonote_core/blockchain.cpp#L1589

and this line:

https://github.com/seraphis-migration/monero/blob/d1adfbba21cdde7cec4b732ae4682ac44ee79167/src/cryptonote_core/blockchain.cpp#L1596

Introduce a sneaky consensus bug with the small stressnet-specific long-term block median (LTM) window. `Blockchain::m_long_term_block_weights_cache_rolling_median` is a ring buffer with capacity `CRYPTONOTE_LONG_TERM_BLOCK_WEIGHT_WINDOW_SIZE`:

https://github.com/seraphis-migration/monero/blob/d1adfbba21cdde7cec4b732ae4682ac44ee79167/src/cryptonote_core/blockchain.cpp#L129

However, when the stressnet fork activates, we shrink the LTM median:

https://github.com/seraphis-migration/monero/blob/d1adfbba21cdde7cec4b732ae4682ac44ee79167/src/cryptonote_core/blockchain.cpp#L5070

Unfortunately, this didn't update the capacity of `m_long_term_block_weights_cache_rolling_median`. So depending on the 2-arity of the number of times that `Blockchain::get_long_term_block_weight_median()` is called, there is either a cache hit (`count == rmsize`), or a cache miss (i.e. `count == rmsize - 1`). When the cache is hit, it makes the cache one element too big, and will cause a miss next call. When the cache is missed, it would trigger an invalidation and set the size "correctly", triggering a hit next call. Thus, if this 2-arity of `get_long_term_block_weight_median()` got out of sync of your peer, then the LTM value would be different, and thus the block reward would be different, and thus miner transaction validation failed, as was seen in #390. The main way this desync can be triggered is by restarting the node.

This PR acts as if the cache was already populated with one too many elements at startup on the first call. This is technically a netsplit from the original code, but it aligns with the currently highest PoW chain, and allows desynced peers to re-align without having to redo the whole beta stressnet fork.

Resolves #390

TODO:
 - [x] Test de-synced peer
 - [ ] Test sync from scratch
 - [ ] Test cache alignment after block popping and/or reorgs

Later todo: Don't require a cache miss for `Blockchain::get_long_term_block_weight_median()` every single block added to the chain :/