### PR TITLE
cryptonote_basic: have out_to_carrot_v1 replace out_to_scripthash instead

### DIFF
--- a/src/cryptonote_basic/cryptonote_basic.h
+++ b/src/cryptonote_basic/cryptonote_basic.h
@@ -60,6 +60,17 @@ namespace cryptonote
 
   /* outputs */
 
+  struct txout_to_script
+  {
+    std::vector<crypto::public_key> keys;
+    std::vector<uint8_t> script;
+
+    BEGIN_SERIALIZE_OBJECT()
+      FIELD(keys)
+      FIELD(script)
+    END_SERIALIZE()
+  };
+
   struct txout_to_carrot_v1
   {
     crypto::public_key key;                                  // K_o
@@ -74,11 +85,6 @@ namespace cryptonote
       FIELD(view_tag)
       FIELD(encrypted_janus_anchor)
     END_SERIALIZE()
-  };
-
-  struct txout_to_scripthash
-  {
-    crypto::hash hash;
   };
 
   // outputs <= HF_VERSION_VIEW_TAGS
@@ -129,7 +135,16 @@ namespace cryptonote
 
   struct txin_to_scripthash
   {
+    crypto::hash prev;
+    size_t prevout;
+    txout_to_script script;
+    std::vector<uint8_t> sigset;
+
     BEGIN_SERIALIZE_OBJECT()
+      FIELD(prev)
+      VARINT_FIELD(prevout)
+      FIELD(script)
+      FIELD(sigset)
     END_SERIALIZE()
   };
 
@@ -149,7 +164,7 @@ namespace cryptonote
 
   typedef boost::variant<txin_gen, txin_to_script, txin_to_scripthash, txin_to_key> txin_v;
 
-  typedef boost::variant<txout_to_carrot_v1, txout_to_scripthash, txout_to_key, txout_to_tagged_key> txout_target_v;
+  typedef boost::variant<txout_to_script, txout_to_carrot_v1, txout_to_key, txout_to_tagged_key> txout_target_v;
 
   //typedef std::pair<uint64_t, txout> out_t;
   struct tx_out
@@ -169,14 +184,14 @@ namespace cryptonote
   {
     struct tx_out_visitor
     {
+      const crypto::public_key &operator()(const cryptonote::txout_to_script&) const
+      { throw std::runtime_error("Unexpected usage of txout to script"); }
       const crypto::public_key &operator()(const cryptonote::txout_to_carrot_v1 &out) const
       { return out.key; }
       const crypto::public_key &operator()(const cryptonote::txout_to_tagged_key &out) const
       { return out.key; }
       const crypto::public_key &operator()(const cryptonote::txout_to_key &out) const
       { return out.key; }
-      const crypto::public_key &operator()(const cryptonote::txout_to_scripthash&) const
-      { throw std::runtime_error("Unexpected usage of txout to scripthash"); }
     };
     return boost::apply_visitor(tx_out_visitor{}, tx_out);
   }
@@ -670,14 +685,13 @@ namespace std {
 }
 
 BLOB_SERIALIZER(cryptonote::txout_to_key);
-BLOB_SERIALIZER(cryptonote::txout_to_scripthash);
 
 VARIANT_TAG(binary_archive, cryptonote::txin_gen, 0xff);
 VARIANT_TAG(binary_archive, cryptonote::txin_to_script, 0x0);
 VARIANT_TAG(binary_archive, cryptonote::txin_to_scripthash, 0x1);
 VARIANT_TAG(binary_archive, cryptonote::txin_to_key, 0x2);
-VARIANT_TAG(binary_archive, cryptonote::txout_to_carrot_v1, 0x0);
-VARIANT_TAG(binary_archive, cryptonote::txout_to_scripthash, 0x1);
+VARIANT_TAG(binary_archive, cryptonote::txout_to_script, 0x0);
+VARIANT_TAG(binary_archive, cryptonote::txout_to_carrot_v1, 0x1);
 VARIANT_TAG(binary_archive, cryptonote::txout_to_key, 0x2);
 VARIANT_TAG(binary_archive, cryptonote::txout_to_tagged_key, 0x3);
 VARIANT_TAG(binary_archive, cryptonote::transaction, 0xcc);
@@ -687,8 +701,8 @@ VARIANT_TAG(json_archive, cryptonote::txin_gen, "gen");
 VARIANT_TAG(json_archive, cryptonote::txin_to_script, "script");
 VARIANT_TAG(json_archive, cryptonote::txin_to_scripthash, "scripthash");
 VARIANT_TAG(json_archive, cryptonote::txin_to_key, "key");
+VARIANT_TAG(json_archive, cryptonote::txout_to_script, "script");
 VARIANT_TAG(json_archive, cryptonote::txout_to_carrot_v1, "carrot_v1");
-VARIANT_TAG(json_archive, cryptonote::txout_to_scripthash, "scripthash");
 VARIANT_TAG(json_archive, cryptonote::txout_to_key, "key");
 VARIANT_TAG(json_archive, cryptonote::txout_to_tagged_key, "tagged_key");
 VARIANT_TAG(json_archive, cryptonote::transaction, "tx");
@@ -698,8 +712,8 @@ VARIANT_TAG(debug_archive, cryptonote::txin_gen, "gen");
 VARIANT_TAG(debug_archive, cryptonote::txin_to_script, "script");
 VARIANT_TAG(debug_archive, cryptonote::txin_to_scripthash, "scripthash");
 VARIANT_TAG(debug_archive, cryptonote::txin_to_key, "key");
+VARIANT_TAG(debug_archive, cryptonote::txout_to_script, "script");
 VARIANT_TAG(debug_archive, cryptonote::txout_to_carrot_v1, "carrot_v1");
-VARIANT_TAG(debug_archive, cryptonote::txout_to_scripthash, "scripthash");
 VARIANT_TAG(debug_archive, cryptonote::txout_to_key, "key");
 VARIANT_TAG(debug_archive, cryptonote::txout_to_tagged_key, "tagged_key");
 VARIANT_TAG(debug_archive, cryptonote::transaction, "tx");

--- a/src/cryptonote_basic/cryptonote_boost_serialization.h
+++ b/src/cryptonote_basic/cryptonote_boost_serialization.h
@@ -98,11 +98,10 @@ namespace boost
   }
 
   template <class Archive>
-  inline void serialize(Archive &a, cryptonote::txout_to_carrot_v1 &x, const boost::serialization::version_type ver)
+  inline void serialize(Archive &a, cryptonote::txout_to_script &x, const boost::serialization::version_type ver)
   {
-    a & x.key;
-    a & x.view_tag.bytes;
-    a & x.encrypted_janus_anchor.bytes;
+    a & x.keys;
+    a & x.script;
   }
 
 
@@ -120,9 +119,11 @@ namespace boost
   }
 
   template <class Archive>
-  inline void serialize(Archive &a, cryptonote::txout_to_scripthash &x, const boost::serialization::version_type ver)
+  inline void serialize(Archive &a, cryptonote::txout_to_carrot_v1 &x, const boost::serialization::version_type ver)
   {
-    a & x.hash;
+    a & x.key;
+    a & x.view_tag.bytes;
+    a & x.encrypted_janus_anchor.bytes;
   }
 
   template <class Archive>
@@ -142,6 +143,10 @@ namespace boost
   template <class Archive>
   inline void serialize(Archive &a, cryptonote::txin_to_scripthash &x, const boost::serialization::version_type ver)
   {
+    a & x.prev;
+    a & x.prevout;
+    a & x.script;
+    a & x.sigset;
   }
 
   template <class Archive>

--- a/src/cryptonote_basic/cryptonote_format_utils.cpp
+++ b/src/cryptonote_basic/cryptonote_format_utils.cpp
@@ -2021,8 +2021,8 @@ namespace cryptonote
         { return fcmp_pp::LegacyOutputPair{{O, C}}; }
         fcmp_pp::OutputPair operator()(const cryptonote::txout_to_key&) const
         { return fcmp_pp::LegacyOutputPair{{O, C}}; }
-        fcmp_pp::OutputPair operator()(const cryptonote::txout_to_scripthash&) const
-        { return fcmp_pp::LegacyOutputPair{{O, C}}; }
+        fcmp_pp::OutputPair operator()(const cryptonote::txout_to_script&) const
+        { throw std::logic_error("cannot convert txout to script into an output pair"); }
     };
 
     const crypto::public_key &O = cryptonote::output_pubkey_cref(tx_out);

--- a/src/cryptonote_basic/cryptonote_format_utils.h
+++ b/src/cryptonote_basic/cryptonote_format_utils.h
@@ -310,7 +310,7 @@ namespace cryptonote
       { return false; }
       bool operator()(const cryptonote::txout_to_key&) const
       { return false; }
-      bool operator()(const cryptonote::txout_to_scripthash&) const
+      bool operator()(const cryptonote::txout_to_script&) const
       { return false; }
     };
 

--- a/src/serialization/json_object.cpp
+++ b/src/serialization/json_object.cpp
@@ -343,11 +343,11 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::block& b)
   GET_FROM_JSON_OBJECT(val, b.miner_tx, miner_tx);
   GET_FROM_JSON_OBJECT(val, b.tx_hashes, tx_hashes);
 
-  if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)                             
-  {                                                                             
+  if (b.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+  {
     GET_FROM_JSON_OBJECT(val, b.fcmp_pp_n_tree_layers, fcmp_pp_n_tree_layers);
-    GET_FROM_JSON_OBJECT(val, b.fcmp_pp_tree_root, fcmp_pp_tree_root);        
-  }                                                                             
+    GET_FROM_JSON_OBJECT(val, b.fcmp_pp_tree_root, fcmp_pp_tree_root);
+  }
 }
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_v& txin)
@@ -469,6 +469,12 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_script& txin
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_scripthash& txin)
 {
   dest.StartObject();
+
+  INSERT_INTO_JSON_OBJECT(dest, prev, txin.prev);
+  INSERT_INTO_JSON_OBJECT(dest, prevout, txin.prevout);
+  INSERT_INTO_JSON_OBJECT(dest, script, txin.script);
+  INSERT_INTO_JSON_OBJECT(dest, sigset, txin.sigset);
+
   dest.EndObject();
 }
 
@@ -479,6 +485,11 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_scripthash& 
   {
     throw WRONG_TYPE("json object");
   }
+
+  GET_FROM_JSON_OBJECT(val, txin.prev, prev);
+  GET_FROM_JSON_OBJECT(val, txin.prevout, prevout);
+  GET_FROM_JSON_OBJECT(val, txin.script, script);
+  GET_FROM_JSON_OBJECT(val, txin.sigset, sigset);
 }
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txin_to_key& txin)
@@ -505,6 +516,28 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin)
 }
 
 
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_script& txout)
+{
+  dest.StartObject();
+
+  INSERT_INTO_JSON_OBJECT(dest, keys, txout.keys);
+  INSERT_INTO_JSON_OBJECT(dest, script, txout.script);
+
+  dest.EndObject();
+}
+
+void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_script& txout)
+{
+  if (!val.IsObject())
+  {
+    throw WRONG_TYPE("json object");
+  }
+
+  GET_FROM_JSON_OBJECT(val, txout.keys, keys);
+  GET_FROM_JSON_OBJECT(val, txout.script, script);
+}
+
+
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_carrot_v1& txout)
 {
   dest.StartObject();
@@ -526,26 +559,6 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_carrot_v1& 
   GET_FROM_JSON_OBJECT(val, txout.key, key);
   GET_FROM_JSON_OBJECT(val, txout.view_tag, view_tag);
   GET_FROM_JSON_OBJECT(val, txout.encrypted_janus_anchor, encrypted_janus_anchor);
-}
-
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_scripthash& txout)
-{
-  dest.StartObject();
-
-  INSERT_INTO_JSON_OBJECT(dest, hash, txout.hash);
-
-  dest.EndObject();
-}
-
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_scripthash& txout)
-{
-  if (!val.IsObject())
-  {
-    throw WRONG_TYPE("json object");
-  }
-
-  GET_FROM_JSON_OBJECT(val, txout.hash, hash);
 }
 
 
@@ -608,13 +621,13 @@ void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::t
     {
       INSERT_INTO_JSON_OBJECT(dest, to_tagged_key, output);
     }
+    void operator()(cryptonote::txout_to_script const& output) const
+    {
+      INSERT_INTO_JSON_OBJECT(dest, to_script, output);
+    }
     void operator()(cryptonote::txout_to_carrot_v1 const& output) const
     {
       INSERT_INTO_JSON_OBJECT(dest, to_carrot_v1, output);
-    }
-    void operator()(cryptonote::txout_to_scripthash const& output) const
-    {
-      INSERT_INTO_JSON_OBJECT(dest, to_scripthash, output);
     }
   };
   boost::apply_visitor(add_output{dest}, txout.target);
@@ -652,15 +665,15 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::tx_out& txout)
       fromJsonValue(elem.value, tmpVal);
       txout.target = std::move(tmpVal);
     }
-    else if (elem.name == "to_carrot_v1")
+    else if (elem.name == "to_script")
     {
-      cryptonote::txout_to_carrot_v1 tmpVal;
+      cryptonote::txout_to_script tmpVal;
       fromJsonValue(elem.value, tmpVal);
       txout.target = std::move(tmpVal);
     }
-    else if (elem.name == "to_scripthash")
+    else if (elem.name == "to_carrot_v1")
     {
-      cryptonote::txout_to_scripthash tmpVal;
+      cryptonote::txout_to_carrot_v1 tmpVal;
       fromJsonValue(elem.value, tmpVal);
       txout.target = std::move(tmpVal);
     }

--- a/src/serialization/json_object.h
+++ b/src/serialization/json_object.h
@@ -219,11 +219,11 @@ void fromJsonValue(const rapidjson::Value& val, cryptonote::txin_to_key& txin);
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_target_v& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_target_v& txout);
 
+void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_script& txout);
+void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_script& txout);
+
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_carrot_v1& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_carrot_v1& txout);
-
-void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_scripthash& txout);
-void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_scripthash& txout);
 
 void toJsonValue(rapidjson::Writer<epee::byte_stream>& dest, const cryptonote::txout_to_key& txout);
 void fromJsonValue(const rapidjson::Value& val, cryptonote::txout_to_key& txout);

--- a/tests/core_tests/tx_validation.cpp
+++ b/tests/core_tests/tx_validation.cpp
@@ -733,7 +733,7 @@ bool gen_tx_output_is_not_txout_to_key::generate(std::vector<test_event_entry>& 
 
   builder.m_tx.vout.push_back(tx_out());
   builder.m_tx.vout.back().amount = 1;
-  builder.m_tx.vout.back().target = txout_to_scripthash();
+  builder.m_tx.vout.back().target = txout_to_script();
 
   builder.step4_calc_hash();
   builder.step5_sign(sources);


### PR DESCRIPTION
This will un-break cold wallet cache deserialization, ans shrinks the diff against upstream. Issue identified by @j-berman. Cannot be applied to beta because it would cause a hard fork, and probably a ton of other errors.

https://github.com/seraphis-migration/monero/pull/52#pullrequestreview-4520704975