### PR TITLE
fix macos errors

### DIFF
--- a/contrib/epee/include/net/http_server_impl_base.h
+++ b/contrib/epee/include/net/http_server_impl_base.h
@@ -109,7 +109,10 @@ namespace epee
     {
       //go to loop
       MINFO("Run net_service loop( " << threads_count << " threads)...");
-      if(!m_net_server.run_server(threads_count, wait))
+      // set stack size
+      boost::thread::attributes attrs;
+      attrs.set_stack_size(THREAD_STACK_SIZE);
+      if(!m_net_server.run_server(threads_count, wait, attrs))
       {
         LOG_ERROR("Failed to run net tcp server!");
       }

--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -1621,7 +1621,7 @@ uint64_t Blockchain::get_long_term_block_weight_median(uint64_t start_height, si
 
   MTRACE("requesting " << count << " from " << start_height << ", uncached");
   const std::vector<uint64_t> weights = m_db->get_long_term_block_weights(start_height, count);
-  assert(weights.size() == std::min(count, blockchain_height - start_height));
+  assert(weights.size() == std::min(static_cast<uint64_t>(count), blockchain_height - start_height));
   m_long_term_block_weights_cache_tip_hash = tip_hash;
   for (const uint64_t w: weights)
     m_long_term_block_weights_cache_rolling_median.insert(w);


### PR DESCRIPTION
This PR fixes 2 problems I encountered on macOS M1 chip.

1- compilation error regarding uint types
2- node panics and crashes with a bus error during transfers due to stack size on macOS.  I have set the stack size to THREAD_STACK_SIZE.
