### PR TITLE
tx relay v2: log missing requested pool tx [beta]

### DIFF
--- a/src/cryptonote_protocol/cryptonote_protocol_handler.inl
+++ b/src/cryptonote_protocol/cryptonote_protocol_handler.inl
@@ -993,7 +993,11 @@ namespace cryptonote
       {
         txs.push_back(std::move(tx_blob));
       }
-      // If tx is not in the pool, then ignore it (do not penalize peer)
+      else
+      {
+        // If tx is not in the pool, then ignore it (do not penalize peer)
+        LOG_DEBUG_CC(context, "Received request for pool tx " << tx_hash << " and it's not in our pool");
+      }
     }
 
     // Send response if any txs found


### PR DESCRIPTION
The going theory for the cause of #373 is described in #378. This log would help confirm that theory. If a node sees this log statement plastered all over its logs, followed shortly by a dropped connection to the same peer included in the log statement, then that would help confirm the theory. With the theory confirmed, I think we would have more than enough evidence to move forward with #378.