### PR TITLE
fix view key corruption

### DIFF
--- a/src/cryptonote_basic/account.cpp
+++ b/src/cryptonote_basic/account.cpp
@@ -84,15 +84,18 @@ DISABLE_VS_WARNINGS(4244 4345)
     return buffer1;
   }
   //-----------------------------------------------------------------
-  void account_keys::xor_with_key_stream(const crypto::chacha_key &key)
+  void account_keys::xor_with_key_stream(const crypto::chacha_key &key, bool skip_viewkey)
   {
     // encrypt a large enough byte stream with chacha20
     epee::wipeable_string key_stream = get_key_stream(key, m_encryption_iv, sizeof(crypto::secret_key) * (2 + m_multisig_keys.size()));
     const char *ptr = key_stream.data();
     for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
       m_spend_secret_key.data[i] ^= *ptr++;
-    for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
-      m_view_secret_key.data[i] ^= *ptr++;
+    if (skip_viewkey)
+      ptr += sizeof(crypto::secret_key);
+    else
+      for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
+        m_view_secret_key.data[i] ^= *ptr++;
     for (crypto::secret_key &k: m_multisig_keys)
     {
       for (size_t i = 0; i < sizeof(crypto::secret_key); ++i)
@@ -124,6 +127,17 @@ DISABLE_VS_WARNINGS(4244 4345)
   void account_keys::decrypt_viewkey(const crypto::chacha_key &key)
   {
     encrypt_viewkey(key);
+  }
+  //-----------------------------------------------------------------
+  void account_keys::encrypt_except_viewkey(const crypto::chacha_key &key)
+  {
+    m_encryption_iv = crypto::rand<crypto::chacha_iv>();
+    xor_with_key_stream(key, /*skip_viewkey=*/true);
+  }
+  //-----------------------------------------------------------------
+  void account_keys::decrypt_except_viewkey(const crypto::chacha_key &key)
+  {
+    xor_with_key_stream(key, /*skip_viewkey=*/true);
   }
   //-----------------------------------------------------------------
   account_base::account_base()

--- a/src/cryptonote_basic/account.h
+++ b/src/cryptonote_basic/account.h
@@ -59,12 +59,14 @@ namespace cryptonote
     void decrypt(const crypto::chacha_key &key);
     void encrypt_viewkey(const crypto::chacha_key &key);
     void decrypt_viewkey(const crypto::chacha_key &key);
+    void encrypt_except_viewkey(const crypto::chacha_key &key);
+    void decrypt_except_viewkey(const crypto::chacha_key &key);
 
     hw::device& get_device()  const ;
     void set_device( hw::device &hwdev) ;
 
   private:
-    void xor_with_key_stream(const crypto::chacha_key &key);
+    void xor_with_key_stream(const crypto::chacha_key &key, bool skip_viewkey = false);
   };
 
   /************************************************************************/
@@ -102,6 +104,8 @@ namespace cryptonote
     void decrypt_keys(const crypto::chacha_key &key) { m_keys.decrypt(key); }
     void encrypt_viewkey(const crypto::chacha_key &key) { m_keys.encrypt_viewkey(key); }
     void decrypt_viewkey(const crypto::chacha_key &key) { m_keys.decrypt_viewkey(key); }
+    void encrypt_keys_except_viewkey(const crypto::chacha_key &key) { m_keys.encrypt_except_viewkey(key); }
+    void decrypt_keys_except_viewkey(const crypto::chacha_key &key) { m_keys.decrypt_except_viewkey(key); }
 
     template <class t_archive>
     inline void serialize(t_archive &a, const unsigned int /*ver*/)

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -4917,8 +4917,8 @@ boost::optional<wallet2::keys_file_data> wallet2::get_keys_file_data(const crypt
 
   if (m_ask_password == AskPasswordToDecrypt && !m_unattended && !m_watch_only)
   {
-    account.encrypt_viewkey(key);
-    account.decrypt_keys(key);
+    // since view key is already decrypted, we exclude it.
+    account.decrypt_keys_except_viewkey(key);
   }
 
   if (watch_only || background_keys_file)
@@ -5147,8 +5147,8 @@ void wallet2::setup_keys(const epee::wipeable_string &password)
   // re-encrypt, but keep viewkey unencrypted
   if (m_ask_password == AskPasswordToDecrypt && !m_unattended && !m_watch_only)
   {
-    m_account.encrypt_keys(key);
-    m_account.decrypt_viewkey(key);
+    // we don't encrypt the view key since its used for scanning.
+    m_account.encrypt_keys_except_viewkey(key);
   }
 
   m_cache_key = derive_cache_key(key, config::HASH_KEY_WALLET_CACHE);
@@ -5789,16 +5789,14 @@ bool wallet2::is_key_encryption_enabled() const
 
 void wallet2::encrypt_keys(const crypto::chacha_key &key)
 {
-  m_account.encrypt_keys(key);
-  m_account.decrypt_viewkey(key);
+  m_account.encrypt_keys_except_viewkey(key);
 }
 
 void wallet2::decrypt_keys(const crypto::chacha_key &key)
 {
   verify_password_with_cached_key(key);
 
-  m_account.encrypt_viewkey(key);
-  m_account.decrypt_keys(key);
+  m_account.decrypt_keys_except_viewkey(key);
 }
 
 void wallet2::encrypt_keys(const epee::wipeable_string &password)


### PR DESCRIPTION
Since the output scanning is done in parallel to key image calculation now,  we sometimes get a scrambled view key due to a race condition where view key gets read by scan job between the time we encrypt view key before decrypting all keys. This PR adds a couple of new functions to `account_keys` that excludes view key encryption/decryption directly instead of encrypting/decrypting it each time.
