### PR TITLE
abort batch when fcmp++ tree growth fails

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4954,6 +4954,7 @@ leave:
   catch (const std::exception& e)
   {
     LOG_ERROR("Failed to advance tree at block with hash: " << id << ", what = " << e.what());
+    m_batch_success = false;
     bvc.m_verifivation_failed = true;
     return false;
   }


### PR DESCRIPTION
add missing `m_batch_success = false` if the fcmp tree growth fails. Without this set, `cleanup_handle_incoming_blocks()` still called `batch_stop()` and committed the block without its tree entry. That leaves the tree tip permanently behind the chain tip. That breaks the code in multiple places such as pop_blocks path. 