### PR TITLE
carrot_impl: fix swapped K_e opening hints

### DIFF
--- a/src/carrot_impl/carrot_offchain_serialization.h
+++ b/src/carrot_impl/carrot_offchain_serialization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2025-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -130,6 +130,7 @@ END_SERIALIZE()
 BEGIN_SERIALIZE_OBJECT_FN(carrot::LegacyOutputOpeningHintV1)
     FIELD_F(onetime_address)
     FIELD_F(ephemeral_tx_pubkey)
+    FIELD_F(backup_ephemeral_tx_pubkey)
     FIELD_F(subaddr_index)
     VARINT_FIELD_F(amount)
     FIELD_F(amount_blinding_factor)

--- a/src/carrot_impl/format_utils.h
+++ b/src/carrot_impl/format_utils.h
@@ -144,7 +144,7 @@ bool try_load_carrot_enote_from_transaction_v1(const cryptonote::transaction &tx
     CarrotEnoteV1 &enote_out);
 /**
  * @brief Load non-coinbase Carrot info from a cryptonote::transaction
- * @param: tx -
+ * @param tx -
  * @param[out] enotes_out -
  * @param[out] key_images_out -
  * @param[out] fee_out -

--- a/src/carrot_impl/key_image_device_composed.cpp
+++ b/src/carrot_impl/key_image_device_composed.cpp
@@ -88,19 +88,11 @@ key_image_device_composed::key_image_device_composed(
 //-------------------------------------------------------------------------------------------------------------------
 crypto::key_image key_image_device_composed::derive_key_image(const OutputOpeningHintVariant &opening_hint) const
 {
-    const crypto::public_key onetime_address = onetime_address_ref(opening_hint);
-    const subaddress_index_extended subaddr_index = subaddress_index_ref(opening_hint);
-
-    crypto::public_key main_address_spend_pubkeys[2];
-    const std::size_t n_main_addrs = get_all_main_address_spend_pubkeys(*m_addr_dev, main_address_spend_pubkeys);
-    CARROT_CHECK_AND_THROW(n_main_addrs > 0, make_local_device_error(-4, "derive_key_image"),
-        "Address device supports no known address derivation scheme");
-
     // get k^g_o, k^t_o
     crypto::secret_key sender_extension_g;
     crypto::secret_key sender_extension_t;
     if (!try_scan_opening_hint_sender_extensions(opening_hint,
-        {main_address_spend_pubkeys, n_main_addrs},
+        *m_addr_dev,
         m_s_view_balance_dev.get(),
         m_k_view_incoming_dev.get(),
         sender_extension_g,
@@ -110,8 +102,8 @@ crypto::key_image key_image_device_composed::derive_key_image(const OutputOpenin
     }
 
     return this->derive_key_image_prescanned(sender_extension_g,
-        onetime_address,
-        subaddr_index,
+        onetime_address_ref(opening_hint),
+        subaddress_index_ref(opening_hint),
         use_biased_hash_to_point(opening_hint));
 }
 //-------------------------------------------------------------------------------------------------------------------

--- a/src/carrot_impl/output_opening_types.cpp
+++ b/src/carrot_impl/output_opening_types.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2025-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -30,6 +30,7 @@
 #include "output_opening_types.h"
 
 //local headers
+#include "address_utils.h"
 #include "carrot_core/core_types.h"
 #include "carrot_core/enote_utils.h"
 #include "carrot_core/scan.h"
@@ -121,7 +122,7 @@ static bool try_opening_hint_scan_on_carrot_enote(const CarrotEnoteV1 &enote,
 //-------------------------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------------------------
 static bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const view_balance_secret_device *s_view_balance_dev,
     const view_incoming_key_device *k_view_incoming_dev,
     crypto::secret_key &sender_extension_g_out,
@@ -141,17 +142,41 @@ static bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
             if (k_view_incoming_dev == nullptr)
                 return false;
 
-            // 8 k_v K_e
-            crypto::public_key kd_tors;
-            if (!k_view_incoming_dev->view_key_scalar_mult8_ed25519(hint.ephemeral_tx_pubkey, kd_tors))
-                return false;
+            for (int backup_ephem = 0; backup_ephem < 2; ++backup_ephem)
+            {
+                if (backup_ephem && !hint.backup_ephemeral_tx_pubkey)
+                    continue;
 
-            // d = k_o = Hs1(8 k_v K_e, i)
-            crypto::key_derivation derivation;
-            memcpy(&derivation, &kd_tors, sizeof(derivation));
-            crypto::derivation_to_scalar(derivation, hint.local_output_index, sender_extension_g_out);
+                const crypto::public_key &ephemeral_tx_pubkey = backup_ephem
+                    ? hint.backup_ephemeral_tx_pubkey.value()
+                    : hint.ephemeral_tx_pubkey;
 
-            return true;
+                // 8 k_v K_e
+                crypto::public_key kd_tors;
+                if (!k_view_incoming_dev->view_key_scalar_mult8_ed25519(ephemeral_tx_pubkey, kd_tors))
+                    continue;
+
+                // d = k_o = Hs1(8 k_v K_e, i)
+                crypto::key_derivation derivation;
+                memcpy(&derivation, &kd_tors, sizeof(derivation));
+                crypto::derivation_to_scalar(derivation, hint.local_output_index, sender_extension_g_out);
+
+                // K_o ?= K^j_s + k_o G
+                crypto::public_key recovered_address_spend_pubkey;
+                if (!carrot::try_recover_address_spend_pubkey(hint.onetime_address,
+                        sender_extension_g_out, crypto::null_skey, recovered_address_spend_pubkey))
+                    continue;
+                crypto::public_key device_address_spend_pubkey;
+                const subaddress_index_extended legacy_subaddr_index{
+                    .index = hint.subaddr_index,
+                    .derive_type = AddressDeriveType::PreCarrot
+                };
+                addr_dev.get_address_spend_pubkey(legacy_subaddr_index, device_address_spend_pubkey);
+                if (recovered_address_spend_pubkey == device_address_spend_pubkey)
+                    return true;
+            }
+
+            return false;
         }
 
         bool operator()(const CarrotOutputOpeningHintV1 &hint) const
@@ -239,6 +264,7 @@ static bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
             return false;
         }
 
+        const address_device &addr_dev;
         epee::span<const crypto::public_key> main_address_spend_pubkeys;
         const view_balance_secret_device *s_view_balance_dev;
         const view_incoming_key_device *k_view_incoming_dev;
@@ -248,8 +274,11 @@ static bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
         crypto::secret_key &amount_blinding_factor_out;
     };
 
+    crypto::public_key main_address_spend_pubkeys[2];
+
     return std::visit(try_scan_opening_hint_visitor{
-            main_address_spend_pubkeys,
+            addr_dev,
+            get_all_main_address_spend_pubkeys_span(addr_dev, main_address_spend_pubkeys),
             s_view_balance_dev,
             k_view_incoming_dev,
             sender_extension_g_out,
@@ -262,12 +291,13 @@ static bool try_scan_opening_hint(const OutputOpeningHintVariant &opening_hint,
 //-------------------------------------------------------------------------------------------------------------------
 bool operator==(const LegacyOutputOpeningHintV1 &a, const LegacyOutputOpeningHintV1 &b)
 {
-    return a.onetime_address == b.onetime_address
-        && a.ephemeral_tx_pubkey == b.ephemeral_tx_pubkey
-        && a.subaddr_index == b.subaddr_index
-        && a.amount == b.amount
-        && a.amount_blinding_factor == b.amount_blinding_factor
-        && a.local_output_index == b.local_output_index;
+    return a.onetime_address            == b.onetime_address
+        && a.ephemeral_tx_pubkey        == b.ephemeral_tx_pubkey
+        && a.backup_ephemeral_tx_pubkey == b.backup_ephemeral_tx_pubkey
+        && a.subaddr_index              == b.subaddr_index
+        && a.amount                     == b.amount
+        && a.amount_blinding_factor     == b.amount_blinding_factor
+        && a.local_output_index         == b.local_output_index;
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool operator==(const CarrotOutputOpeningHintV1 &a, const CarrotOutputOpeningHintV1 &b)
@@ -387,7 +417,7 @@ fcmp_pp::OutputPair to_output_pair(const OutputOpeningHintVariant &opening_hint)
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &opening_hint,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const view_balance_secret_device *s_view_balance_dev,
     const view_incoming_key_device *k_view_incoming_dev,
     crypto::secret_key &sender_extension_g_out,
@@ -396,7 +426,7 @@ bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &ope
     xmr_amount amount;
     crypto::secret_key amount_blinding_factor;
     return try_scan_opening_hint(opening_hint,
-        main_address_spend_pubkeys,
+        addr_dev,
         s_view_balance_dev,
         k_view_incoming_dev,
         sender_extension_g_out,
@@ -406,7 +436,7 @@ bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &ope
 }
 //-------------------------------------------------------------------------------------------------------------------
 bool try_scan_opening_hint_amount(const OutputOpeningHintVariant &opening_hint,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const view_balance_secret_device *s_view_balance_dev,
     const view_incoming_key_device *k_view_incoming_dev,
     xmr_amount &amount_out,
@@ -414,7 +444,7 @@ bool try_scan_opening_hint_amount(const OutputOpeningHintVariant &opening_hint,
 {
     crypto::secret_key sender_extension_g, sender_extension_t;
     return try_scan_opening_hint(opening_hint,
-        main_address_spend_pubkeys,
+        addr_dev,
         s_view_balance_dev,
         k_view_incoming_dev,
         sender_extension_g,

--- a/src/carrot_impl/output_opening_types.h
+++ b/src/carrot_impl/output_opening_types.h
@@ -33,6 +33,7 @@
 //local headers
 
 //third party headers
+#include "address_device.h"
 #include "carrot_core/carrot_enote_types.h"
 #include "crypto/crypto.h"
 #include "fcmp_pp/fcmp_pp_types.h"
@@ -73,6 +74,9 @@ struct LegacyOutputOpeningHintV1
 
     /// K_e
     crypto::public_key ephemeral_tx_pubkey;
+
+    /// K_e' (needed in edge cases due to weird legacy scanning artifacts)
+    std::optional<crypto::public_key> backup_ephemeral_tx_pubkey;
 
     /// j (legacy only)
     subaddress_index subaddr_index;
@@ -170,6 +174,7 @@ fcmp_pp::OutputPair to_output_pair(const OutputOpeningHintVariant &opening_hint)
 /**
  * @brief Scan sender extensions for given opening hint
  * @param opening_hint -
+ * @param addr_dev -
  * @param s_view_balance_dev device for s_vb (optional)
  * @param k_view_incoming_dev device for k_v (optional)
  * @param[out] sender_extension_g_out k^g_o
@@ -177,7 +182,7 @@ fcmp_pp::OutputPair to_output_pair(const OutputOpeningHintVariant &opening_hint)
  * @return true iff Carrot enote scan was successful, or if nominal legacy derivation-to-scalar didn't fail
  */
 bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &opening_hint,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const view_balance_secret_device *s_view_balance_dev,
     const view_incoming_key_device *k_view_incoming_dev,
     crypto::secret_key &sender_extension_g_out,
@@ -185,6 +190,7 @@ bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &ope
 /**
  * @brief Scan amount and blinding factor for given opening hint
  * @param opening_hint -
+ * @param addr_dev -
  * @param s_view_balance_dev device for s_vb (optional)
  * @param k_view_incoming_dev device for k_v (optional)
  * @param[out] amount_out a
@@ -192,7 +198,7 @@ bool try_scan_opening_hint_sender_extensions(const OutputOpeningHintVariant &ope
  * @return true iff Carrot enote scan was successful, or if nominal legacy derivation-to-scalar didn't fail
  */
 bool try_scan_opening_hint_amount(const OutputOpeningHintVariant &opening_hint,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const view_balance_secret_device *s_view_balance_dev,
     const view_incoming_key_device *k_view_incoming_dev,
     xmr_amount &amount_out,

--- a/src/carrot_impl/spend_device_ram_borrowed.cpp
+++ b/src/carrot_impl/spend_device_ram_borrowed.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025, The Monero Project
+// Copyright (c) 2025-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -31,10 +31,8 @@
 
 //local headers
 #include "address_device_ram_borrowed.h"
-#include "carrot_core/account_secrets.h"
 #include "carrot_core/device_ram_borrowed.h"
 #include "carrot_core/exceptions.h"
-#include "crypto/generators.h"
 #include "key_image_device_composed.h"
 #include "misc_log_ex.h"
 #include "tx_builder_inputs.h"

--- a/src/carrot_impl/tx_builder_inputs.cpp
+++ b/src/carrot_impl/tx_builder_inputs.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, The Monero Project
+// Copyright (c) 2024-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -61,10 +61,10 @@ static crypto::secret_key load_sk(const unsigned char s[32])
 //-------------------------------------------------------------------------------------------------------------------
 static void make_sal_proof_nominal_address(const crypto::hash &signable_tx_hash,
     const FcmpRerandomizedOutputCompressed &rerandomized_output,
-    const crypto::secret_key &address_privkey_g,
-    const crypto::secret_key &address_privkey_t,
+    const crypto::secret_key &account_privkey_g,
+    const crypto::secret_key &account_privkey_t,
     const OutputOpeningHintVariant &opening_hint,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const view_balance_secret_device *s_view_balance_dev,
     const view_incoming_key_device *k_view_incoming_dev,
     fcmp_pp::FcmpPpSalProof &sal_proof_out,
@@ -81,24 +81,30 @@ static void make_sal_proof_nominal_address(const crypto::hash &signable_tx_hash,
     crypto::secret_key sender_extension_g;
     crypto::secret_key sender_extension_t;
     CHECK_AND_ASSERT_THROW_MES(try_scan_opening_hint_sender_extensions(opening_hint,
-            main_address_spend_pubkeys,
+            addr_dev,
             s_view_balance_dev,
             k_view_incoming_dev,
             sender_extension_g,
             sender_extension_t),
         "Could not make SA/L proof: failed to scan opening hint");
 
-    // x = k^{j,g}_addr + k^g_o
-    crypto::secret_key x;
-    sc_add(to_bytes(x),
-        to_bytes(address_privkey_g),
-        to_bytes(sender_extension_g));
+    // get address openings
+    crypto::secret_key address_extension_g;
+    crypto::secret_key address_scalar;
+    addr_dev.get_address_openings(subaddress_index_ref(opening_hint),
+        address_extension_g,
+        address_scalar);
 
-    // y = k^{j,t}_addr + k^t_o
+    // x = `account_privkey_g` * k^j_subscal + k^j_{g,addr} + k^g_o
+    crypto::secret_key x;
+    sc_muladd(to_bytes(x), to_bytes(account_privkey_g),
+        to_bytes(address_scalar), to_bytes(sender_extension_g));
+    sc_add(to_bytes(x), to_bytes(x), to_bytes(address_extension_g));
+
+    // y = `account_privkey_t` * k^j_subscal + k^t_o
     crypto::secret_key y;
-    sc_add(to_bytes(y),
-        to_bytes(address_privkey_t),
-        to_bytes(sender_extension_t));
+    sc_muladd(to_bytes(y), to_bytes(account_privkey_t),
+        to_bytes(address_scalar), to_bytes(sender_extension_t));
 
     std::tie(sal_proof_out, key_image_out) = fcmp_pp::prove_sal(signable_tx_hash,
         x,
@@ -109,7 +115,7 @@ static void make_sal_proof_nominal_address(const crypto::hash &signable_tx_hash,
 std::vector<FcmpRerandomizedOutputCompressed> generate_rerandomized_inputs_nonrefundable(
     epee::span<const carrot::RCTOutputEnoteProposal> output_enote_proposals,
     epee::span<const carrot::OutputOpeningHintVariant> input_proposals,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev)
 {
@@ -139,7 +145,7 @@ std::vector<FcmpRerandomizedOutputCompressed> generate_rerandomized_inputs_nonre
 
         carrot::xmr_amount amount;
         const bool scan_success = carrot::try_scan_opening_hint_amount(input_proposal,
-            main_address_spend_pubkeys,
+            addr_dev,
             s_view_balance_dev,
             &k_view_incoming_dev,
             amount,
@@ -190,25 +196,12 @@ void make_sal_proof_any_to_legacy_v1(const crypto::hash &signable_tx_hash,
     fcmp_pp::FcmpPpSalProof &sal_proof_out,
     crypto::key_image &key_image_out)
 {
-    // get K_s
-    crypto::public_key main_address_spend_pubkey;
-    addr_dev.get_address_spend_pubkey({}, main_address_spend_pubkey);
-
-    // k^j_subext = ScalarDeriveLegacy("SubAddr" || IntToBytes8(0) || k_v || IntToBytes32(j_major) || IntToBytes32(j_minor))
-    const subaddress_index_extended subaddr_index = subaddress_index_ref(opening_hint);
-    crypto::secret_key address_privkey_g;
-    crypto::secret_key dummy_subaddress_scalar;
-    addr_dev.get_address_openings(subaddr_index, address_privkey_g, dummy_subaddress_scalar);
-
-    // k^j_g = k^j_subext + k_s
-    sc_add(to_bytes(address_privkey_g), to_bytes(address_privkey_g), to_bytes(k_spend));
-
     make_sal_proof_nominal_address(signable_tx_hash,
         rerandomized_output,
-        address_privkey_g,
+        k_spend,
         crypto::null_skey,
         opening_hint,
-        {&main_address_spend_pubkey, 1},
+        addr_dev,
         /*s_view_balance_dev=*/nullptr,
         &addr_dev,
         sal_proof_out,
@@ -220,63 +213,18 @@ void make_sal_proof_any_to_carrot_v1(const crypto::hash &signable_tx_hash,
     const OutputOpeningHintVariant &opening_hint,
     const crypto::secret_key &k_prove_spend,
     const crypto::secret_key &k_generate_image,
+    const address_device &addr_dev,
     const view_balance_secret_device &s_view_balance_dev,
     const view_incoming_key_device &k_view_incoming_dev,
-    const generate_address_secret_device &s_generate_address_dev,
     fcmp_pp::FcmpPpSalProof &sal_proof_out,
     crypto::key_image &key_image_out)
 {
-    // K_s = k_gi G + k_ps T
-    crypto::public_key main_address_spend_pubkey;
-    carrot::make_carrot_spend_pubkey(k_generate_image, k_prove_spend, main_address_spend_pubkey);
-
-    // K_v = k_v K_s
-    crypto::public_key account_view_pubkey;
-    k_view_incoming_dev.view_key_scalar_mult_ed25519(main_address_spend_pubkey, account_view_pubkey);
-
-    // s^j_ap1 = H_32[s_ga](j_major, j_minor)
-    const subaddress_index_extended subaddr_index = subaddress_index_ref(opening_hint);
-    crypto::secret_key address_index_preimage_1;
-    s_generate_address_dev.make_address_index_preimage_1(subaddr_index.index.major,
-        subaddr_index.index.minor,
-        address_index_preimage_1);
-
-    // s^j_ap2 = H_32[s^j_ap1](j_major, j_minor, K_s, K_v)
-    crypto::secret_key address_index_preimage_2;
-    make_carrot_address_index_preimage_2(address_index_preimage_1,
-        subaddr_index.index.major,
-        subaddr_index.index.minor,
-        main_address_spend_pubkey,
-        account_view_pubkey,
-        address_index_preimage_2);
-
-    // k^j_subscal = H_n[s^j_ap2](K_s)
-    crypto::secret_key subaddress_scalar;
-    if (subaddr_index.index.is_subaddress())
-    {
-        make_carrot_subaddress_scalar(address_index_preimage_2,
-            main_address_spend_pubkey,
-            subaddress_scalar);
-    }
-    else // main address
-    {
-        sc_1(to_bytes(subaddress_scalar));
-    }
-
-    // k^j_g = k_gi * k^j_subscal
-    crypto::secret_key address_privkey_g;
-    sc_mul(to_bytes(address_privkey_g), to_bytes(k_generate_image), to_bytes(subaddress_scalar));
-
-    // k^j_t = k_ps * k^j_subscal
-    crypto::secret_key address_privkey_t;
-    sc_mul(to_bytes(address_privkey_t), to_bytes(k_prove_spend), to_bytes(subaddress_scalar));
-
     make_sal_proof_nominal_address(signable_tx_hash,
         rerandomized_output,
-        address_privkey_g,
-        address_privkey_t,
+        k_generate_image,
+        k_prove_spend,
         opening_hint,
-        {&main_address_spend_pubkey, 1},
+        addr_dev,
         &s_view_balance_dev,
         &k_view_incoming_dev,
         sal_proof_out,
@@ -294,26 +242,12 @@ void make_sal_proof_any_to_hybrid_v1(const crypto::hash &signable_tx_hash,
     fcmp_pp::FcmpPpSalProof &sal_proof_out,
     crypto::key_image &key_image_out)
 {
-    crypto::secret_key subaddress_extention_g;
-    crypto::secret_key subaddress_scalar;
-    addr_dev.get_address_openings(subaddress_index_ref(opening_hint), subaddress_extention_g, subaddress_scalar);
-
-    // k^j_g = k_g * k^j_subscal + k^j_subext
-    crypto::secret_key address_privkey_g;
-    sc_muladd(to_bytes(address_privkey_g), to_bytes(k_privkey_g),
-        to_bytes(subaddress_scalar), to_bytes(subaddress_extention_g));
-
-    // k^j_t = k_t * k^j_subscal
-    crypto::secret_key address_privkey_t;
-    sc_mul(to_bytes(address_privkey_t), to_bytes(k_privkey_t), to_bytes(subaddress_scalar));
-
-    crypto::public_key main_address_spend_pubkeys[2];
     make_sal_proof_nominal_address(signable_tx_hash,
         rerandomized_output,
-        address_privkey_g,
-        address_privkey_t,
+        k_privkey_g,
+        k_privkey_t,
         opening_hint,
-        get_all_main_address_spend_pubkeys_span(addr_dev, main_address_spend_pubkeys),
+        addr_dev,
         s_view_balance_dev,
         &k_view_incoming_dev,
         sal_proof_out,

--- a/src/carrot_impl/tx_builder_inputs.h
+++ b/src/carrot_impl/tx_builder_inputs.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, The Monero Project
+// Copyright (c) 2024-2026, The Monero Project
 //
 // All rights reserved.
 //
@@ -32,7 +32,6 @@
 
 //local headers
 #include "address_device_hierarchies.h"
-#include "carrot_core/core_types.h"
 #include "fcmp_pp/fcmp_pp_types.h"
 #include "output_opening_types.h"
 
@@ -52,7 +51,7 @@ namespace carrot
  * @brief Generate rerandomized outputs (with non-refundable r_o) for given inputs in input proposals
  * @param output_enote_proposals output enotes for spending tx, used to calculate r_c imbalance
  * @param input_proposals inputs for spending tx, used to extract (O, I, C) tuples and calculate r_c imbalance
- * @param main_address_spend_pubkeys all K_s, potentially includes a legacy and a Carrot pubkey
+ * @param addr_dev =
  * @param s_view_balance_dev -
  * @param k_view_incoming_dev -
  * @return Rerandomized inputs in order of `input_proposals`
@@ -60,7 +59,7 @@ namespace carrot
 std::vector<FcmpRerandomizedOutputCompressed> generate_rerandomized_inputs_nonrefundable(
     epee::span<const carrot::RCTOutputEnoteProposal> output_enote_proposals,
     epee::span<const carrot::OutputOpeningHintVariant> input_proposals,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const address_device &addr_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev);
 /**
@@ -99,6 +98,7 @@ void make_sal_proof_any_to_legacy_v1(const crypto::hash &signable_tx_hash,
  * @param opening_hint -
  * @param k_prove_spend k_ps
  * @param k_generate_image k_gi
+ * @param addr_dev address device
  * @param s_view_balance_dev device for s_vb
  * @param k_view_incoming_dev device for k_v
  * @param s_generate_address_dev device for s_ga
@@ -110,9 +110,9 @@ void make_sal_proof_any_to_carrot_v1(const crypto::hash &signable_tx_hash,
     const OutputOpeningHintVariant &opening_hint,
     const crypto::secret_key &k_prove_spend,
     const crypto::secret_key &k_generate_image,
+    const address_device &addr_dev,
     const view_balance_secret_device &s_view_balance_dev,
     const view_incoming_key_device &k_view_incoming_dev,
-    const generate_address_secret_device &s_generate_address_dev,
     fcmp_pp::FcmpPpSalProof &sal_proof_out,
     crypto::key_image &key_image_out);
 /**

--- a/src/wallet/tx_builder.cpp
+++ b/src/wallet/tx_builder.cpp
@@ -32,7 +32,6 @@
 //local headers
 #include "carrot_core/enote_utils.h"
 #include "carrot_core/exceptions.h"
-#include "carrot_core/output_set_finalization.h"
 #include "carrot_core/scan.h"
 #include "carrot_impl/address_utils.h"
 #include "carrot_impl/format_utils.h"
@@ -811,25 +810,25 @@ carrot::OutputOpeningHintVariant make_sal_opening_hint_from_transfer_details(con
     else // !is_carrot
     {
         // choose R
-        const crypto::public_key main_tx_pubkey = cryptonote::get_tx_pub_key_from_extra(td.m_tx, td.m_pk_index);
+        crypto::public_key ephemeral_tx_pubkey = cryptonote::get_tx_pub_key_from_extra(td.m_tx, td.m_pk_index);
         const std::vector<crypto::public_key> additional_tx_pubkeys =
             cryptonote::get_additional_tx_pub_keys_from_extra(td.m_tx);
-        const crypto::public_key &ephemeral_tx_pubkey =
-            (additional_tx_pubkeys.size() > td.m_internal_output_index && !td.m_subaddr_index.is_zero())
-                ? additional_tx_pubkeys.at(td.m_internal_output_index)
-                : main_tx_pubkey;
+        std::optional<crypto::public_key> backup_ephemeral_tx_pubkey =
+            (additional_tx_pubkeys.size() > td.m_internal_output_index)
+            ? additional_tx_pubkeys.at(td.m_internal_output_index)
+            : std::optional<crypto::public_key>{};
+        if (backup_ephemeral_tx_pubkey && !td.m_subaddr_index.is_zero())
+            std::swap(*backup_ephemeral_tx_pubkey, ephemeral_tx_pubkey);
 
         return carrot::LegacyOutputOpeningHintV1{
             .onetime_address = td.get_public_key(),
             .ephemeral_tx_pubkey = ephemeral_tx_pubkey,
+            .backup_ephemeral_tx_pubkey = backup_ephemeral_tx_pubkey,
             .subaddr_index = subaddr_index,
             .amount = td.amount(),
             .amount_blinding_factor = rct::rct2sk(td.m_mask),
             .local_output_index = static_cast<std::size_t>(td.m_internal_output_index)
         };
-
-        ASSERT_MES_AND_THROW("make sal opening hint from transfer details: cannot find subaddress and sender extension "
-            "for given transfer info");
     }
 }
 //-------------------------------------------------------------------------------------------------------------------
@@ -1148,7 +1147,7 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
+    const carrot::address_device &addr_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,
     const carrot::spend_device &spend_dev)
@@ -1195,7 +1194,7 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs = carrot::generate_rerandomized_inputs_nonrefundable(
         epee::to_span(output_enote_proposals),
         epee::to_span(tx_proposal.input_proposals),
-        main_address_spend_pubkeys,
+        addr_dev,
         s_view_balance_dev,
         k_view_incoming_dev);
 
@@ -1232,25 +1231,6 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
         tx_proposal.fee,
         tree_cache,
         curve_trees);
-}
-//-------------------------------------------------------------------------------------------------------------------
-cryptonote::transaction finalize_all_fcmp_pp_proofs(
-    const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
-    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const carrot::address_device &addr_dev,
-    const carrot::view_incoming_key_device &k_view_incoming_dev,
-    const carrot::view_balance_secret_device *s_view_balance_dev,
-    const carrot::spend_device &spend_dev)
-{
-    crypto::public_key main_address_spend_pubkeys[2];
-    return finalize_all_fcmp_pp_proofs(tx_proposal,
-        tree_cache,
-        curve_trees,
-        carrot::get_all_main_address_spend_pubkeys_span(addr_dev, main_address_spend_pubkeys),
-        k_view_incoming_dev,
-        s_view_balance_dev,
-        spend_dev);
 }
 //-------------------------------------------------------------------------------------------------------------------
 pending_tx make_pending_carrot_tx(const carrot::CarrotTransactionProposalV1 &tx_proposal,

--- a/src/wallet/tx_builder.h
+++ b/src/wallet/tx_builder.h
@@ -305,14 +305,6 @@ cryptonote::transaction finalize_all_fcmp_pp_proofs(
     const carrot::CarrotTransactionProposalV1 &tx_proposal,
     const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
     const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
-    const epee::span<const crypto::public_key> main_address_spend_pubkeys,
-    const carrot::view_incoming_key_device &k_view_incoming_dev,
-    const carrot::view_balance_secret_device *s_view_balance_dev,
-    const carrot::spend_device &spend_dev);
-cryptonote::transaction finalize_all_fcmp_pp_proofs(
-    const carrot::CarrotTransactionProposalV1 &tx_proposal,
-    const fcmp_pp::curve_trees::TreeCacheV1 &tree_cache,
-    const fcmp_pp::curve_trees::CurveTreesV1 &curve_trees,
     const carrot::address_device &addr_dev,
     const carrot::view_incoming_key_device &k_view_incoming_dev,
     const carrot::view_balance_secret_device *s_view_balance_dev,

--- a/tests/unit_tests/carrot_fcmp.cpp
+++ b/tests/unit_tests/carrot_fcmp.cpp
@@ -29,7 +29,6 @@
 #include "gtest/gtest.h"
 
 #include "carrot_core/config.h"
-#include "carrot_core/output_set_finalization.h"
 #include "carrot_core/payment_proposal.h"
 #include "carrot_impl/format_utils.h"
 #include "carrot_impl/tx_builder_inputs.h"
@@ -435,7 +434,7 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
     std::vector<FcmpRerandomizedOutputCompressed> rerandomized_outputs = generate_rerandomized_inputs_nonrefundable(
         epee::to_span(output_enote_proposals),
         epee::to_span(sorted_opening_hints),
-        {&alice.carrot_account_spend_pubkey, 1},
+        *alice.addr_dev,
         &alice.s_view_balance_dev,
         alice.k_view_incoming_dev);
     ASSERT_EQ(n_inputs, rerandomized_outputs.size());
@@ -451,9 +450,9 @@ TEST(carrot_fcmp, receive_scan_spend_and_verify_serialized_carrot_tx)
             std::get<2>(input_info_by_ki.at(sorted_input_key_images.at(i))),
             alice.k_prove_spend,
             alice.k_generate_image,
+            *alice.addr_dev,
             alice.s_view_balance_dev,
             alice.k_view_incoming_dev,
-            alice.s_generate_address_dev,
             sal_proofs.emplace_back(),
             actual_key_images.emplace_back());
     }

--- a/tests/unit_tests/carrot_impl.cpp
+++ b/tests/unit_tests/carrot_impl.cpp
@@ -31,7 +31,6 @@
 #include <boost/multiprecision/cpp_int.hpp>
 
 #include "carrot_core/exceptions.h"
-#include "carrot_core/output_set_finalization.h"
 #include "carrot_core/payment_proposal.h"
 #include "carrot_impl/format_utils.h"
 #include "carrot_impl/multi_tx_proposal_utils.h"
@@ -1911,7 +1910,7 @@ TEST(carrot_impl, new_hierarchy_spend_device_ram_1in_2out)
     const std::vector<FcmpRerandomizedOutputCompressed> rerandomized = generate_rerandomized_inputs_nonrefundable(
         epee::to_span(output_enote_proposals),
         epee::to_span(tx_proposal.input_proposals),
-        {&alice.carrot_account_spend_pubkey, 1},
+        *alice.addr_dev,
         &alice.s_view_balance_dev,
         alice.k_view_incoming_dev);
 

--- a/tests/unit_tests/carrot_tx_builder.cpp
+++ b/tests/unit_tests/carrot_tx_builder.cpp
@@ -82,8 +82,6 @@ TEST(carrot_tx_builder, make_sal_proof_legacy_to_legacy_v1_mainaddr)
         .local_output_index = local_output_index
     };
 
-    const bool use_biased_htp = use_biased_hash_to_point(opening_hint);
-
     const crypto::key_image expected_key_image = keys.key_image_dev->derive_key_image(opening_hint);
 
     // fake output amount blinding factor in a hypothetical tx where we spent the aforementioned output
@@ -670,9 +668,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_carrot_v1_mainaddr_normal)
         opening_hint,
         keys.k_prove_spend,
         keys.k_generate_image,
+        *keys.addr_dev,
         keys.s_view_balance_dev,
         keys.k_view_incoming_dev,
-        keys.s_generate_address_dev,
         sal_proof,
         actual_key_image);
 
@@ -764,9 +762,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_carrot_v1_subaddr_normal)
         opening_hint,
         keys.k_prove_spend,
         keys.k_generate_image,
+        *keys.addr_dev,
         keys.s_view_balance_dev,
         keys.k_view_incoming_dev,
-        keys.s_generate_address_dev,
         sal_proof,
         actual_key_image);
 
@@ -857,9 +855,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_carrot_v1_mainaddr_special)
         opening_hint,
         keys.k_prove_spend,
         keys.k_generate_image,
+        *keys.addr_dev,
         keys.s_view_balance_dev,
         keys.k_view_incoming_dev,
-        keys.s_generate_address_dev,
         sal_proof,
         actual_key_image);
 
@@ -953,9 +951,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_carrot_v1_subaddr_special)
         opening_hint,
         keys.k_prove_spend,
         keys.k_generate_image,
+        *keys.addr_dev,
         keys.s_view_balance_dev,
         keys.k_view_incoming_dev,
-        keys.s_generate_address_dev,
         sal_proof,
         actual_key_image);
 
@@ -1046,9 +1044,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_carrot_v1_mainaddr_internal)
         opening_hint,
         keys.k_prove_spend,
         keys.k_generate_image,
+        *keys.addr_dev,
         keys.s_view_balance_dev,
         keys.k_view_incoming_dev,
-        keys.s_generate_address_dev,
         sal_proof,
         actual_key_image);
 
@@ -1142,9 +1140,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_to_carrot_v1_subaddr_internal)
         opening_hint,
         keys.k_prove_spend,
         keys.k_generate_image,
+        *keys.addr_dev,
         keys.s_view_balance_dev,
         keys.k_view_incoming_dev,
-        keys.s_generate_address_dev,
         sal_proof,
         actual_key_image);
 
@@ -1311,9 +1309,9 @@ TEST(carrot_tx_builder, make_sal_proof_carrot_coinbase_to_carrot_v1)
         opening_hint,
         keys.k_prove_spend,
         keys.k_generate_image,
+        *keys.addr_dev,
         keys.s_view_balance_dev,
         keys.k_view_incoming_dev,
-        keys.s_generate_address_dev,
         sal_proof,
         actual_key_image);
 

--- a/tests/unit_tests/wallet_scanning.cpp
+++ b/tests/unit_tests/wallet_scanning.cpp
@@ -32,6 +32,7 @@
 #include "carrot_impl/subaddress_map_legacy.h"
 #include "carrot_impl/tx_builder_inputs.h"
 #include "carrot_mock_helpers.h"
+#include "crypto/generators.h"
 #include "cryptonote_basic/cryptonote_basic_impl.h"
 #include "fake_pruned_blockchain.h"
 #include "fcmp_pp/prove.h"
@@ -40,7 +41,50 @@
 
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "unit_tests.wallet_scanning"
+//----------------------------------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------------------------------
+namespace
+{
+/**
+ * @brief Verify that K_o ?= K^j_s + k^g_o G + k^t_o T, where K^j_s, k^g_o, and k^t_o are given by `enote_scan_info`
+ */
+bool verify_enote_scan_info_sender_extensions(const tools::wallet::enote_view_incoming_scan_info_t &enote_scan_info,
+    const cryptonote::tx_out &tx_out)
+{
+    // k^g_o G
+    ge_p3 tmp1;
+    ge_scalarmult_base(&tmp1, to_bytes(enote_scan_info.sender_extension_g));
+    ge_cached tmp2;
+    ge_p3_to_cached(&tmp2, &tmp1);
 
+    // k^t_o T
+    tmp1 = crypto::get_T_p3();
+    ge_scalarmult_p3(&tmp1, to_bytes(enote_scan_info.sender_extension_t), &tmp1);
+
+    // k^g_o G + k^t_o T
+    ge_p1p1 tmp3;
+    ge_add(&tmp3, &tmp1, &tmp2);
+    ge_p1p1_to_p3(&tmp1, &tmp3);
+    ge_p3_to_cached(&tmp2, &tmp1);
+
+    // K^j_s
+    if (0 != ge_frombytes_vartime(&tmp1, to_bytes(enote_scan_info.address_spend_pubkey)))
+        return false;
+
+    // K^j_s + k^g_o G + k^t_o T
+    crypto::public_key recomputed_onetime_address;
+    ge_add(&tmp3, &tmp1, &tmp2);
+    ge_p1p1_to_p3(&tmp1, &tmp3);
+    ge_p3_tobytes(to_bytes(recomputed_onetime_address), &tmp1);
+
+    // K_o ?= K^j_s + k^g_o G + k^t_o T
+    crypto::public_key onetime_address;
+    if (!cryptonote::get_output_public_key(tx_out, onetime_address))
+        return false;
+    return recomputed_onetime_address == onetime_address;
+}
+} //anonymous namespace
+//----------------------------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------------------------
 TEST(wallet_scanning, view_scan_as_sender_mainaddr)
 {
@@ -826,6 +870,211 @@ TEST(wallet_scanning, scanning_tools_hybrid_view_incoming_scanning)
                 alice_enote_scan_info,
                 *alice.key_image_dev);
             ASSERT_TRUE(alice_key_image);
+        }
+    }
+}
+//----------------------------------------------------------------------------------------------------------------------
+TEST(wallet_scanning, pre_carrot_switched_enote_pubkeys)
+{
+    // Test that non-standard, but previously scannable positions for ephemeral tx pubkeys is still
+    // supported in new scanning code, and that attempting to make opening hints to those enotes
+    // works.
+
+    // Gen Bob
+    cryptonote::account_base bob;
+    bob.generate();
+    const auto bob_k_view_dev = std::make_shared<carrot::cryptonote_view_incoming_key_ram_borrowed_device>(
+        bob.get_keys().m_view_secret_key);
+    const carrot::cryptonote_hierarchy_address_device bob_addr_dev(bob_k_view_dev,
+        bob.get_keys().m_account_address.m_spend_public_key);
+
+    // Bob addresses
+    const cryptonote::account_public_address &bob_main_addr = bob.get_keys().m_account_address;
+    const cryptonote::subaddress_index subaddr_index{0, 1};
+    const cryptonote::account_public_address bob_subaddr = bob.get_device().get_subaddress(bob.get_keys(),
+        subaddr_index);
+    const std::unordered_map<crypto::public_key, cryptonote::subaddress_index> bob_subaddress_map{
+        {bob_main_addr.m_spend_public_key, {}},
+        {bob_subaddr.m_spend_public_key, subaddr_index}
+    };
+
+    // Construct to Bob
+    constexpr carrot::xmr_amount main_amount = COIN;
+    constexpr carrot::xmr_amount subaddr_amount = 2 * COIN;
+    std::vector<cryptonote::tx_destination_entry> dests{
+        cryptonote::tx_destination_entry(main_amount, bob_main_addr, false),
+        cryptonote::tx_destination_entry(subaddr_amount, bob_subaddr, true),
+        carrot::mock::convert_destination_v1(carrot::gen_carrot_main_address_v1(), COIN / 7)
+    };
+    constexpr uint8_t hf_version = HF_VERSION_CLSAG + 1;
+    cryptonote::transaction tx = mock::construct_pre_carrot_tx_with_fake_inputs(dests,
+        COIN / 100, hf_version);
+    ASSERT_EQ(3, tx.vout.size());
+    const crypto::hash og_txid = cryptonote::get_transaction_hash(tx);
+
+    size_t bob_main_local_output_index = tx.vout.size();
+    size_t bob_subaddr_local_output_index = tx.vout.size();
+    for (int swap_K_e = 0; swap_K_e < 2; ++swap_K_e)
+    {
+        LOG_PRINT_L1("pre_carrot_switched_enote_pubkeys: " << (swap_K_e ? "" : "un") << "modified pass");
+
+        if (swap_K_e)
+        {
+            // Replace the main tx pubkey with Bob's subaddress additional publey, and Bob's main
+            // additional pubkey with the original main tx pubkey
+
+            std::vector<cryptonote::tx_extra_field> tx_extra_fields;
+            ASSERT_TRUE(cryptonote::parse_tx_extra(tx.extra, tx_extra_fields));
+            ASSERT_EQ(2, tx_extra_fields.size()); // main & additional pubkeys, no dummy payment ID in >2-out tx
+            cryptonote::tx_extra_pub_key main_tx_pubkey_field;
+            ASSERT_TRUE(cryptonote::find_tx_extra_field_by_type(tx_extra_fields, main_tx_pubkey_field));
+            ASSERT_NE(crypto::null_pkey, main_tx_pubkey_field.pub_key);
+            cryptonote::tx_extra_additional_pub_keys additional_tx_pubkeys_field;
+            ASSERT_TRUE(cryptonote::find_tx_extra_field_by_type(tx_extra_fields, additional_tx_pubkeys_field));
+            ASSERT_EQ(tx.vout.size(), additional_tx_pubkeys_field.data.size());
+
+            std::swap(main_tx_pubkey_field.pub_key, additional_tx_pubkeys_field.data.at(bob_main_local_output_index));
+            std::swap(main_tx_pubkey_field.pub_key, additional_tx_pubkeys_field.data.at(bob_subaddr_local_output_index));
+            tx.extra.clear();
+            ASSERT_TRUE(cryptonote::add_tx_pub_key_to_extra(tx, main_tx_pubkey_field.pub_key));
+            ASSERT_TRUE(cryptonote::add_additional_tx_pub_keys_to_extra(tx.extra, additional_tx_pubkeys_field.data));
+            ASSERT_TRUE(cryptonote::sort_tx_extra(tx.extra, tx.extra));
+            tx.invalidate_hashes();
+            ASSERT_NE(og_txid, cryptonote::get_transaction_hash(tx));
+        }
+
+        // Bob scans
+        const auto enote_scan_infos = tools::wallet::view_incoming_scan_transaction(tx,
+            *bob_k_view_dev,
+            bob_addr_dev,
+            carrot::subaddress_map_legacy(bob_subaddress_map));
+        ASSERT_EQ(tx.vout.size(), enote_scan_infos.size());
+
+        // Bob has 2 scannble outputs, find tx-local output indices for each
+        size_t local_output_index = 0;
+        for (const auto &enote_scan_info : enote_scan_infos)
+        {
+            if (enote_scan_info)
+            {
+                if (enote_scan_info->address_spend_pubkey == bob_main_addr.m_spend_public_key)
+                {
+                    ASSERT_TRUE(bob_main_local_output_index >= tx.vout.size()
+                        || bob_main_local_output_index == local_output_index);
+                    bob_main_local_output_index = local_output_index;
+                }
+                else
+                {
+                    ASSERT_TRUE(bob_subaddr_local_output_index >= tx.vout.size()
+                        || bob_subaddr_local_output_index == local_output_index);
+                    bob_subaddr_local_output_index = local_output_index;
+                }
+            }
+            ++local_output_index;
+        }
+        ASSERT_LT(bob_main_local_output_index, tx.vout.size());
+        ASSERT_LT(bob_subaddr_local_output_index, tx.vout.size());
+        ASSERT_NE(bob_main_local_output_index, bob_subaddr_local_output_index);
+
+        // Check main addr scan results
+        const auto &enote_scan_info_main = enote_scan_infos.at(bob_main_local_output_index);
+        ASSERT_TRUE(enote_scan_info_main->use_biased_hash_to_point);
+        ASSERT_EQ(bob_main_addr.m_spend_public_key, enote_scan_info_main->address_spend_pubkey);
+        ASSERT_EQ(crypto::null_hash, enote_scan_info_main->payment_id);
+        ASSERT_TRUE(enote_scan_info_main->subaddr_index);
+        ASSERT_EQ(carrot::subaddress_index{}, enote_scan_info_main->subaddr_index.value().index);
+        ASSERT_EQ(main_amount, enote_scan_info_main->amount);
+        ASSERT_EQ(0, enote_scan_info_main->main_tx_pubkey_index);
+        ASSERT_TRUE(verify_enote_scan_info_sender_extensions(*enote_scan_info_main,
+            tx.vout.at(bob_main_local_output_index)));
+
+        // Check subaddr scan results
+        const auto &enote_scan_info_sub = enote_scan_infos.at(bob_subaddr_local_output_index);
+        ASSERT_TRUE(enote_scan_info_sub->use_biased_hash_to_point);
+        ASSERT_EQ(bob_subaddr.m_spend_public_key, enote_scan_info_sub->address_spend_pubkey);
+        ASSERT_EQ(crypto::null_hash, enote_scan_info_sub->payment_id);
+        ASSERT_TRUE(enote_scan_info_sub->subaddr_index);
+        ASSERT_EQ(carrot::subaddress_index({subaddr_index.major, subaddr_index.minor}),
+            enote_scan_info_sub->subaddr_index.value().index);
+        ASSERT_EQ(subaddr_amount, enote_scan_info_sub->amount);
+        ASSERT_EQ(0, enote_scan_info_sub->main_tx_pubkey_index);
+        ASSERT_TRUE(verify_enote_scan_info_sender_extensions(*enote_scan_info_sub,
+            tx.vout.at(bob_subaddr_local_output_index)));
+
+        // Create Bob wallet and blockchain instance
+        tools::wallet2 w(cryptonote::MAINNET, /*kdf_rounds=*/1, /*unattended=*/true);
+        w.set_offline(true);
+        w.generate("", "", bob.get_keys().m_spend_secret_key, /*recover=*/true);
+        mock::fake_pruned_blockchain bc;
+        bc.init_wallet_for_starting_block(w);
+
+        // Add block containing tx and refresh wallet
+        const cryptonote::account_public_address random_addr{rct::rct2pk(rct::pkGen()), rct::rct2pk(rct::pkGen())};
+        bc.add_block(hf_version, {tx}, random_addr);
+        bc.refresh_wallet(w);
+    
+        // Check transfer container info
+        wallet2_basic::transfer_container transfers;
+        w.get_transfers(transfers);
+        ASSERT_EQ(2, transfers.size());
+        const auto &main_td = transfers.at(bob_main_local_output_index > bob_subaddr_local_output_index);
+        ASSERT_TRUE(main_td.m_subaddr_index.is_zero());
+        ASSERT_EQ(main_amount, main_td.amount());
+        const auto &subaddr_td = transfers.at(bob_main_local_output_index < bob_subaddr_local_output_index);
+        ASSERT_FALSE(subaddr_td.m_subaddr_index.is_zero());
+        ASSERT_EQ(subaddr_index, subaddr_td.m_subaddr_index);
+        ASSERT_EQ(subaddr_amount, subaddr_td.amount());
+
+        // Make opening hints from transfer details and check info
+        const carrot::OutputOpeningHintVariant main_opening_hint
+            = tools::wallet::make_sal_opening_hint_from_transfer_details(main_td);
+        {
+            crypto::secret_key ohint_k_g_o, ohint_k_t_o;
+            ASSERT_TRUE(carrot::try_scan_opening_hint_sender_extensions(main_opening_hint,
+                bob_addr_dev,
+                nullptr,
+                bob_k_view_dev.get(),
+                ohint_k_g_o,
+                ohint_k_t_o));
+            ASSERT_EQ(enote_scan_info_main->sender_extension_g, ohint_k_g_o);
+            ASSERT_EQ(enote_scan_info_main->sender_extension_t, ohint_k_t_o);
+            ASSERT_EQ(main_td.get_public_key(), onetime_address_ref(main_opening_hint));
+            ASSERT_FALSE(subaddress_index_ref(main_opening_hint).index.is_subaddress());
+            carrot::xmr_amount ohint_amount;
+            crypto::secret_key ohint_k_a;
+            ASSERT_TRUE(carrot::try_scan_opening_hint_amount(main_opening_hint,
+                bob_addr_dev,
+                nullptr,
+                bob_k_view_dev.get(),
+                ohint_amount,
+                ohint_k_a));
+            ASSERT_EQ(main_td.amount(), ohint_amount);
+            ASSERT_EQ(main_td.m_mask, rct::sk2rct(ohint_k_a));
+        }
+        const carrot::OutputOpeningHintVariant subaddr_opening_hint
+            = tools::wallet::make_sal_opening_hint_from_transfer_details(subaddr_td);
+        {
+            crypto::secret_key ohint_k_g_o, ohint_k_t_o;
+            ASSERT_TRUE(carrot::try_scan_opening_hint_sender_extensions(subaddr_opening_hint,
+                bob_addr_dev,
+                nullptr,
+                bob_k_view_dev.get(),
+                ohint_k_g_o,
+                ohint_k_t_o));
+            ASSERT_EQ(enote_scan_info_sub->sender_extension_g, ohint_k_g_o);
+            ASSERT_EQ(enote_scan_info_sub->sender_extension_t, ohint_k_t_o);
+            ASSERT_EQ(subaddr_td.get_public_key(), onetime_address_ref(subaddr_opening_hint));
+            ASSERT_TRUE(subaddress_index_ref(subaddr_opening_hint).index.is_subaddress());
+            ASSERT_EQ(enote_scan_info_sub->subaddr_index->index, subaddress_index_ref(subaddr_opening_hint).index);
+            carrot::xmr_amount ohint_amount;
+            crypto::secret_key ohint_k_a;
+            ASSERT_TRUE(carrot::try_scan_opening_hint_amount(subaddr_opening_hint,
+                bob_addr_dev,
+                nullptr,
+                bob_k_view_dev.get(),
+                ohint_amount,
+                ohint_k_a));
+            ASSERT_EQ(subaddr_td.amount(), ohint_amount);
+            ASSERT_EQ(subaddr_td.m_mask, rct::sk2rct(ohint_k_a));
         }
     }
 }


### PR DESCRIPTION
This PR modifies the opening hint for pre-Carrot enotes to take a backup ephemeral tx pubkey, and does 2 scans against it internally to open sender extensions.

It also adds a unit test which tests whether `wallet2`, when scanning one of these "swapped" $K_e$ txs, produces a usable opening hint.

I also do a bit of cleanup in this PR